### PR TITLE
Update background refresh rate from 20Hz to 30Hz

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ TUIOS is built on the Bubble Tea v2 framework following the Model-View-Update pa
 **Optimization Strategies:**
 - Smart caching with sequence-based change detection
 - Viewport culling for off-screen windows
-- Adaptive refresh rates (60Hz focused, 20Hz background)
+- Adaptive refresh rates (60Hz focused, 30Hz background)
 - Memory pooling for strings, buffers, and styles
 - LRU style cache (40-60% allocation reduction)
 - Frame skipping when no changes detected


### PR DESCRIPTION
You write further up in the README, that its 60hz and 30hz: This section here described 20hz, and I do think you mean 30 instead.

Also: Theme support is now in master, I already considered updating the README to mention it, while its probably best to wait for the release.