### PR TITLE
Remove brew tap from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ TUIOS is a terminal-based window manager that provides a modern, efficient inter
 
 **Homebrew (macOS/Linux):**
 ```bash
-brew tap Gaurav-Gosain/tap
 brew install tuios
 ```
 


### PR DESCRIPTION
Looking at the README, I realized I didn't have to do a `brew tap` at all when I installed `tuios` (aka: you got enough stars to be in [the main repo](https://formulae.brew.sh/formula/tuios#default)! 🎉). Thus, we can simplify.