### PR TITLE
Add extra guards in safeColorsEquals to account for rapid scrollback

### DIFF
--- a/internal/app/render_terminal.go
+++ b/internal/app/render_terminal.go
@@ -189,7 +189,12 @@ func (m *OS) renderTerminal(window *terminal.Window, isFocused bool, inTerminalM
 		}
 	}
 
-	safeColorEquals := func(a, b color.Color) bool {
+	safeColorEquals := func(a, b color.Color) (result bool) {
+		defer func() {
+			if recover() != nil {
+				result = false
+			}
+		}()
 		if a == nil && b == nil {
 			return true
 		}


### PR DESCRIPTION
Addresses problems discussed in  #19 . Please see the issue for more detail.  

@Gaurav-Gosain here is the PR for the panic issue. Hopefully the lack of ceremony on the PR format can be forgiven with the context. 