### PR TITLE
fix: paste not working in daemon mode

### DIFF
--- a/internal/vt/csi_mode.go
+++ b/internal/vt/csi_mode.go
@@ -117,3 +117,9 @@ func (e *Emulator) isModeSet(mode ansi.Mode) bool {
 func (e *Emulator) ApplicationCursorKeys() bool {
 	return e.isModeSet(ansi.ModeCursorKeys)
 }
+
+// BracketedPasteEnabled returns true if bracketed paste mode (?2004) is enabled.
+// When enabled, pasted text should be wrapped with escape sequences.
+func (e *Emulator) BracketedPasteEnabled() bool {
+	return e.isModeSet(ansi.ModeBracketedPaste)
+}


### PR DESCRIPTION
## Summary

- Fix paste functionality in daemon mode which was silently failing
- `Terminal.Paste()` was writing to an internal pipe that gets drained by `StartDaemonResponseReader()`
- Changed to use `SendInput()` which routes through `DaemonWriteFunc` in daemon mode
- Added `BracketedPasteEnabled()` method to properly wrap paste content

## Root Cause

In daemon mode, `StartDaemonResponseReader()` drains all data from `Terminal.Read()` to prevent terminal query responses (DA, CPR, etc.) from appearing as visible escape sequences. However, `Terminal.Paste()` also writes to this same pipe, causing paste data to be silently discarded.

## Test plan

- [x] Build and run tests pass
- [x] Tested paste in local mode (was already working)
- [x] Tested paste in daemon mode (`tuios --daemon` + `tuios attach`) - now working
- [x] Verified bracketed paste sequences are correctly applied when shell has `?2004` mode enabled