### PR TITLE
fix: window teardown races, daemon multi-client correctness, and open issue fixes

### DIFF
--- a/cmd/tuios-web/main.go
+++ b/cmd/tuios-web/main.go
@@ -471,22 +471,30 @@ func registerMultiClientHandlers(m *app.OS, client *session.TUIClient) {
 		}
 	})
 
-	// Handle session resize (min of all clients)
+	// Handle session resize (min of all clients). The callback runs on the daemon
+	// read-loop goroutine, so the actual geometry mutation (TileAllWindows,
+	// emulator resizes) must happen in Update; route it through the event channel.
 	client.OnSessionResize(func(width, height, clientCount int) {
 		log.Printf("[WEB] Session resize: %dx%d (clients: %d)", width, height, clientCount)
-		if m.EffectiveWidth != width || m.EffectiveHeight != height {
-			m.EffectiveWidth = width
-			m.EffectiveHeight = height
-			m.MarkAllDirty()
-			if m.AutoTiling {
-				m.TileAllWindows()
+		if m.ClientEventChan != nil {
+			select {
+			case m.ClientEventChan <- app.ClientEvent{Type: "resize", ClientCount: clientCount, Width: width, Height: height}:
+			default:
+				log.Printf("[WEB] Warning: ClientEventChan full, dropping session resize event")
 			}
 		}
 	})
 
-	// Handle force refresh
+	// Handle force refresh (also on the read-loop goroutine; MarkAllDirty must run
+	// on the program goroutine).
 	client.OnForceRefresh(func(reason string) {
 		log.Printf("[WEB] Force refresh requested: %s", reason)
-		m.MarkAllDirty()
+		if m.ClientEventChan != nil {
+			select {
+			case m.ClientEventChan <- app.ClientEvent{Type: "refresh", Reason: reason}:
+			default:
+				log.Printf("[WEB] Warning: ClientEventChan full, dropping force refresh event")
+			}
+		}
 	})
 }

--- a/cmd/tuios-web/main.go
+++ b/cmd/tuios-web/main.go
@@ -312,6 +312,7 @@ func createEphemeralTUIOSInstance(width, height int, graphicsOut *os.File) (tea.
 	// by the browser terminal.
 	tuiosInstance := app.NewOS(app.OSOptions{
 		KeybindRegistry:           keybindRegistry,
+		UserConfig:                userConfig,
 		ShowKeys:                  showKeys,
 		Width:                     width,
 		Height:                    height,
@@ -389,6 +390,7 @@ func createDaemonTUIOSInstance(sessionName string, width, height int, graphicsOu
 	// sequences reach the browser's xterm.js image addon (sip v0.1.12+).
 	tuiosInstance := app.NewOS(app.OSOptions{
 		KeybindRegistry:           keybindRegistry,
+		UserConfig:                userConfig,
 		ShowKeys:                  showKeys,
 		Width:                     width,
 		Height:                    height,

--- a/cmd/tuios/run.go
+++ b/cmd/tuios/run.go
@@ -132,6 +132,11 @@ func runLocal() error {
 		userConfig = config.DefaultConfig()
 	}
 
+	// Apply the config appearance globals as the baseline, then let CLI flags
+	// win. LoadUserConfig no longer applies globals itself, so this must run
+	// before ApplyOverrides (which only overrides the fields its flags cover).
+	config.ApplyAppearanceConfig(userConfig)
+
 	config.ApplyOverrides(config.Overrides{
 		ASCIIOnly:           asciiOnly,
 		BorderStyle:         borderStyle,
@@ -198,6 +203,7 @@ func runLocal() error {
 
 	initialOS := app.NewOS(app.OSOptions{
 		KeybindRegistry:           keybindRegistry,
+		UserConfig:                userConfig,
 		ShowKeys:                  showKeys,
 		IsDaemonSession:           isDaemonSession,
 		EnableGraphicsPassthrough: true,

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -264,6 +264,14 @@ func runDaemonSession(sessionName string, createNew bool) error {
 		}()
 	})
 
+	// Handle unexpected daemon disconnect (crash/reset/desync): quit cleanly
+	// instead of leaving the TUI frozen.
+	client.OnDisconnect(func(err error) {
+		go func() {
+			p.Send(app.DaemonDisconnectedMsg{Err: err})
+		}()
+	})
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -86,6 +86,10 @@ func runDaemonSession(sessionName string, createNew bool) error {
 		userConfig = config.DefaultConfig()
 	}
 
+	// Apply the config appearance globals as the baseline before CLI flags win.
+	// LoadUserConfig no longer applies globals itself.
+	config.ApplyAppearanceConfig(userConfig)
+
 	config.ApplyOverrides(config.Overrides{
 		ASCIIOnly:           asciiOnly,
 		BorderStyle:         borderStyle,
@@ -148,6 +152,7 @@ func runDaemonSession(sessionName string, createNew bool) error {
 
 	initialOS := app.NewOS(app.OSOptions{
 		KeybindRegistry:           keybindRegistry,
+		UserConfig:                userConfig,
 		ShowKeys:                  showKeys,
 		IsDaemonSession:           true,
 		DaemonClient:              client,

--- a/cmd/tuios/tape_commands.go
+++ b/cmd/tuios/tape_commands.go
@@ -44,6 +44,11 @@ func runTapeInteractive(tapeFile string) error {
 		userConfig = config.DefaultConfig()
 	}
 
+	// LoadUserConfig no longer applies globals; apply the config appearance so
+	// tape playback honors the user's borders/dock/etc. Animations are forced
+	// off below for deterministic playback.
+	config.ApplyAppearanceConfig(userConfig)
+
 	if err := theme.Initialize(themeName); err != nil {
 		log.Printf("Warning: Failed to load theme '%s': %v", themeName, err)
 	}

--- a/cmd/tuios/tape_commands.go
+++ b/cmd/tuios/tape_commands.go
@@ -52,6 +52,11 @@ func runTapeInteractive(tapeFile string) error {
 
 	keybindRegistry := config.NewKeybindRegistry(userConfig)
 
+	// Force animations off for deterministic playback of hand-written tapes,
+	// matching recorded tapes (the recorder prepends DisableAnimations). Tapes
+	// can still re-enable them explicitly with EnableAnimations.
+	config.AnimationsEnabled = false
+
 	player := tape.NewPlayer(commands)
 
 	initialOS := &app.OS{

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -25,7 +25,8 @@ TUIOS can be accessed through any modern web browser using the `tuios-web` binar
 **Separate Binary Required:**
 
 ```bash
-# Homebrew (macOS/Linux)
+# Homebrew (macOS/Linux) - ships via the maintainer's tap
+brew tap Gaurav-Gosain/tap
 brew install tuios-web
 
 # Arch Linux (AUR)

--- a/internal/app/client_event_test.go
+++ b/internal/app/client_event_test.go
@@ -1,0 +1,72 @@
+package app
+
+import "testing"
+
+// TestListenForClientEventsMapping verifies that each ClientEvent type is mapped
+// to the matching Bubble Tea message so the daemon read-loop goroutine never
+// mutates model state directly.
+func TestListenForClientEventsMapping(t *testing.T) {
+	tests := []struct {
+		name  string
+		event ClientEvent
+		check func(t *testing.T, msg any)
+	}{
+		{
+			name:  "joined",
+			event: ClientEvent{Type: "joined", ClientID: "a", ClientCount: 2, Width: 80, Height: 24},
+			check: func(t *testing.T, msg any) {
+				m, ok := msg.(ClientJoinedMsg)
+				if !ok {
+					t.Fatalf("expected ClientJoinedMsg, got %T", msg)
+				}
+				if m.Width != 80 || m.Height != 24 || m.ClientCount != 2 {
+					t.Fatalf("unexpected payload: %+v", m)
+				}
+			},
+		},
+		{
+			name:  "left",
+			event: ClientEvent{Type: "left", ClientID: "a", ClientCount: 1},
+			check: func(t *testing.T, msg any) {
+				if _, ok := msg.(ClientLeftMsg); !ok {
+					t.Fatalf("expected ClientLeftMsg, got %T", msg)
+				}
+			},
+		},
+		{
+			name:  "resize",
+			event: ClientEvent{Type: "resize", ClientCount: 3, Width: 120, Height: 40},
+			check: func(t *testing.T, msg any) {
+				m, ok := msg.(SessionResizeMsg)
+				if !ok {
+					t.Fatalf("expected SessionResizeMsg, got %T", msg)
+				}
+				if m.Width != 120 || m.Height != 40 || m.ClientCount != 3 {
+					t.Fatalf("unexpected payload: %+v", m)
+				}
+			},
+		},
+		{
+			name:  "refresh",
+			event: ClientEvent{Type: "refresh", Reason: "theme"},
+			check: func(t *testing.T, msg any) {
+				m, ok := msg.(ForceRefreshMsg)
+				if !ok {
+					t.Fatalf("expected ForceRefreshMsg, got %T", msg)
+				}
+				if m.Reason != "theme" {
+					t.Fatalf("unexpected reason: %q", m.Reason)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan ClientEvent, 1)
+			ch <- tc.event
+			msg := ListenForClientEvents(ch)()
+			tc.check(t, msg)
+		})
+	}
+}

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -14,6 +14,13 @@ type OSOptions struct {
 	// KeybindRegistry is required for keybinding support.
 	KeybindRegistry *config.KeybindRegistry
 
+	// UserConfig is the already-loaded user configuration. When set, NewOS uses
+	// it directly instead of re-reading config.toml, so it never re-applies file
+	// values over CLI flags (or races other sessions) via a second load. Callers
+	// are responsible for applying the appearance globals once (via ApplyOverrides
+	// and/or ApplyAppearanceConfig) before constructing the OS.
+	UserConfig *config.UserConfig
+
 	// ShowKeys enables the key display overlay.
 	ShowKeys bool
 
@@ -116,10 +123,19 @@ func NewOS(opts OSOptions) *OS {
 		})
 	}
 
-	// Initialize hooks manager and load user-defined hooks from config
+	// Initialize hooks manager and load user-defined hooks from config. Prefer
+	// the config the caller already loaded so we never trigger a second load
+	// (which used to re-apply appearance globals over CLI flags and, on the
+	// per-connection server paths, race other sessions). Loading is now pure and
+	// has no package-global side effects, so the fallback is safe too.
 	os.HookManager = hooks.NewManager()
-	cfg, cfgErr := config.LoadUserConfig()
-	if cfgErr == nil {
+	cfg := opts.UserConfig
+	if cfg == nil {
+		if loaded, err := config.LoadUserConfig(); err == nil {
+			cfg = loaded
+		}
+	}
+	if cfg != nil {
 		// Hold the loaded config so the in-app settings page can persist live
 		// changes back to disk.
 		os.UserConfig = cfg

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// TestNewOS_DoesNotClobberAppearanceGlobals is a regression test for the config
+// reload bug: NewOS used to call LoadUserConfig a second time, re-applying the
+// file's appearance over CLI flags already reconciled at startup (e.g.
+// `tuios --no-animations` starting with animations on). NewOS must now use the
+// passed-in config without mutating any appearance package global.
+func TestNewOS_DoesNotClobberAppearanceGlobals(t *testing.T) {
+	original := config.AnimationsEnabled
+	defer func() { config.AnimationsEnabled = original }()
+
+	// Simulate a CLI flag having forced animations off at startup.
+	config.AnimationsEnabled = false
+
+	// A user config that enables animations, as it would be on disk.
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Appearance.AnimationsEnabled = &enabled
+
+	os := NewOS(OSOptions{UserConfig: cfg})
+
+	if config.AnimationsEnabled {
+		t.Error("NewOS must not re-apply config appearance and re-enable animations")
+	}
+	if os.UserConfig != cfg {
+		t.Error("NewOS should hold the passed-in config for the settings page to persist")
+	}
+}

--- a/internal/app/kitty_minimize_test.go
+++ b/internal/app/kitty_minimize_test.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// TestKittyPlacementSurvivesMinimize drives the real render-path callback
+// (GetKittyGraphicsCmd) and verifies that minimizing a window showing a kitty
+// image HIDES its placement but keeps tracking it, so the image reappears on
+// restore without the guest retransmitting. Previously minimized/off-workspace
+// windows were omitted from the callback, RefreshAllPlacements saw info==nil,
+// and it permanently destroyed the placement.
+func TestKittyPlacementSurvivesMinimize(t *testing.T) {
+	kp := newTestKittyPassthrough(t)
+	kp.screenWidth = 80
+	kp.screenHeight = 24
+
+	win := &terminal.Window{
+		ID:        "test-window-id-abcdef12",
+		X:         0,
+		Y:         0,
+		Width:     80,
+		Height:    24,
+		Workspace: 1,
+		Tiled:     true, // BorderOffset 0
+	}
+
+	const hostID uint32 = 1
+	kp.placements[win.ID] = map[uint32]*PassthroughPlacement{
+		hostID: {
+			GuestImageID: 1,
+			HostImageID:  hostID,
+			WindowID:     win.ID,
+			GuestX:       0,
+			AbsoluteLine: 0,
+			Cols:         5,
+			Rows:         3,
+			DisplayRows:  3,
+			Hidden:       true, // freshly transmitted; refresh places it
+		},
+	}
+
+	m := &OS{
+		Width:            80,
+		Height:           24,
+		CurrentWorkspace: 1,
+		KittyPassthrough: kp,
+		Windows:          []*terminal.Window{win},
+	}
+
+	// Visible: placement becomes active.
+	m.GetKittyGraphicsCmd()
+	if p := kp.placements[win.ID][hostID]; p == nil || p.Hidden {
+		t.Fatalf("after visible refresh: expected placed (not hidden), got %+v", p)
+	}
+
+	// Minimize the window, then refresh: hide but KEEP tracking.
+	win.Minimized = true
+	m.GetKittyGraphicsCmd()
+	p := kp.placements[win.ID][hostID]
+	if p == nil {
+		t.Fatal("BUG: minimizing destroyed the placement; image cannot reappear on restore")
+	}
+	if !p.Hidden {
+		t.Fatal("minimized placement should be hidden")
+	}
+
+	// Restore: re-placed from surviving tracking.
+	win.Minimized = false
+	m.GetKittyGraphicsCmd()
+	if p := kp.placements[win.ID][hostID]; p == nil || p.Hidden {
+		t.Fatalf("after restore refresh: expected re-placed (not hidden), got %+v", p)
+	}
+}
+
+// TestKittyPlacementSurvivesWorkspaceSwitch is the workspace-switch analogue:
+// a window on a non-current workspace must keep its placement tracking.
+func TestKittyPlacementSurvivesWorkspaceSwitch(t *testing.T) {
+	kp := newTestKittyPassthrough(t)
+	kp.screenWidth = 80
+	kp.screenHeight = 24
+
+	win := &terminal.Window{
+		ID: "test-window-id-abcdef12", X: 0, Y: 0, Width: 80, Height: 24,
+		Workspace: 1, Tiled: true,
+	}
+	const hostID uint32 = 1
+	kp.placements[win.ID] = map[uint32]*PassthroughPlacement{
+		hostID: {HostImageID: hostID, WindowID: win.ID, Cols: 5, Rows: 3, DisplayRows: 3, Hidden: true},
+	}
+	m := &OS{Width: 80, Height: 24, CurrentWorkspace: 1, KittyPassthrough: kp, Windows: []*terminal.Window{win}}
+
+	m.GetKittyGraphicsCmd()
+	if kp.placements[win.ID][hostID].Hidden {
+		t.Fatal("expected placed while on current workspace")
+	}
+
+	// Switch to another workspace: window is now off-current; keep tracking.
+	m.CurrentWorkspace = 2
+	m.GetKittyGraphicsCmd()
+	if kp.placements[win.ID] == nil || kp.placements[win.ID][hostID] == nil {
+		t.Fatal("BUG: switching workspace destroyed the placement")
+	}
+	if !kp.placements[win.ID][hostID].Hidden {
+		t.Fatal("off-workspace placement should be hidden")
+	}
+}
+
+// TestKittyPlacementDeletedWhenWindowGone verifies the info==nil path still
+// tears down tracking for windows genuinely removed from the model (closed),
+// so tracking does not leak.
+func TestKittyPlacementDeletedWhenWindowGone(t *testing.T) {
+	kp := newTestKittyPassthrough(t)
+	winID := "test-window-id-abcdef12"
+
+	kp.placements[winID] = map[uint32]*PassthroughPlacement{
+		1: {HostImageID: 1, WindowID: winID, Cols: 5, Rows: 3, Hidden: false},
+	}
+
+	// No windows in the model -> the window is genuinely gone.
+	m := &OS{Width: 80, Height: 24, CurrentWorkspace: 1, KittyPassthrough: kp}
+	m.GetKittyGraphicsCmd()
+
+	if _, ok := kp.placements[winID]; ok {
+		t.Error("expected placement tracking removed for a closed (absent) window")
+	}
+}

--- a/internal/app/kitty_passthrough.go
+++ b/internal/app/kitty_passthrough.go
@@ -21,18 +21,43 @@ func kittyPassthroughLog(format string, args ...any) {
 	_, _ = fmt.Fprintf(f, "[%s] KITTY-PASSTHROUGH: %s\n", time.Now().Format("15:04:05.000"), fmt.Sprintf(format, args...))
 }
 
-// isKittyResponse checks if data looks like a kitty graphics protocol response
-// rather than real image data. Responses are "OK" or POSIX error names like
-// "ENOENT", "EINVAL", "EBADMSG" (start with 'E' followed by uppercase).
-func isKittyResponse(data []byte) bool {
-	if len(data) == 0 {
+// isKittyResponse checks if a graphics payload looks like an echoed kitty
+// protocol response rather than real image data.
+//
+// It is matched against the RAW wire payload (the base64 text between ';' and
+// the APC terminator), NOT the base64-decoded bytes. A real transmit payload
+// is a long base64 string that decodes cleanly; an echoed response is a short
+// status token: "OK", or a POSIX error name optionally followed by a ":message"
+// (e.g. "ENOENT", "EINVAL:bad params"). Matching the decoded bytes instead let
+// arbitrary binary chunks (a chafa/mpv direct stream) collide with the 'E'+A-Z
+// shape ~0.04% of the time and silently drop a chunk, corrupting the image.
+//
+// The shape required is ^(OK|E[A-Z]+(:.*)?)$ with a hard length cap so that a
+// legitimate (necessarily longer, mixed-case) base64 payload cannot match.
+func isKittyResponse(payload string) bool {
+	if len(payload) == 0 || len(payload) > 256 {
 		return false
 	}
-	if string(data) == "OK" {
+	if payload == "OK" {
 		return true
 	}
-	// POSIX error codes: start with 'E', second char is uppercase A-Z
-	return len(data) >= 2 && data[0] == 'E' && data[1] >= 'A' && data[1] <= 'Z'
+	// POSIX error name: 'E' followed by one or more uppercase letters, then an
+	// optional ":<message>". A base64 image payload is not all-uppercase.
+	if payload[0] != 'E' {
+		return false
+	}
+	i := 1
+	for i < len(payload) && payload[i] >= 'A' && payload[i] <= 'Z' {
+		i++
+	}
+	if i < 2 {
+		// Need at least one uppercase letter after the leading 'E'.
+		return false
+	}
+	if i == len(payload) {
+		return true
+	}
+	return payload[i] == ':'
 }
 
 type KittyPassthrough struct {

--- a/internal/app/kitty_passthrough_forward.go
+++ b/internal/app/kitty_passthrough_forward.go
@@ -943,7 +943,13 @@ func (kp *KittyPassthrough) forwardPlace(
 		ZIndex:       cmd.ZIndex,
 		Virtual:      cmd.Virtual,
 	}
-	kp.placements[windowID][cmd.ImageID] = placement
+	// Key by hostID (allocated above), consistent with forwardTransmit,
+	// forwardFileTransmit, forwardFileTransmitInline, and the by-ID delete
+	// paths. Keying by the guest cmd.ImageID here left delete-by-ID unable to
+	// find this placement (RefreshAllPlacements kept re-emitting a=p forever)
+	// and let a guest ID that numerically equals another image's host ID
+	// silently overwrite that entry.
+	kp.placements[windowID][hostID] = placement
 }
 
 // deleteAllWindowPlacements removes all placements for a window from the host terminal

--- a/internal/app/kitty_passthrough_forward.go
+++ b/internal/app/kitty_passthrough_forward.go
@@ -44,8 +44,8 @@ func (kp *KittyPassthrough) ForwardCommand(
 	// Responses have format "i=N;OK" or "i=N;ERROR_MSG" or just "OK"/"ERROR_MSG"
 	// When parsed, they appear as transmit commands with Data="OK" or error message.
 	// Real transmit commands have binary/base64 image data, not status strings.
-	if cmd.Action == vt.KittyActionTransmit && len(cmd.Data) > 0 && isKittyResponse(cmd.Data) {
-		kittyPassthroughLog("ForwardCommand: DISCARDING echoed response: %q", cmd.Data)
+	if cmd.Action == vt.KittyActionTransmit && len(cmd.RawPayload) > 0 && isKittyResponse(cmd.RawPayload) {
+		kittyPassthroughLog("ForwardCommand: DISCARDING echoed response: %q", cmd.RawPayload)
 		return nil
 	}
 

--- a/internal/app/kitty_passthrough_placement.go
+++ b/internal/app/kitty_passthrough_placement.go
@@ -18,7 +18,11 @@ func (kp *KittyPassthrough) isOccludedByHigherWindow(
 	excludeWindowID string,
 ) bool {
 	for id, info := range allWindows {
-		if id == excludeWindowID || info.WindowZ <= windowZ {
+		// Off-workspace / minimized windows are now present in allWindows with
+		// Visible:false (so their own images get hidden rather than deleted).
+		// Such a window is not on screen and cannot occlude anything, even if
+		// its retained geometry still overlaps the image region.
+		if id == excludeWindowID || !info.Visible || info.WindowZ <= windowZ {
 			continue
 		}
 		// Check if higher-z window overlaps the image region

--- a/internal/app/kitty_place_delete_test.go
+++ b/internal/app/kitty_place_delete_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+func newTestKittyPassthrough(t *testing.T) *KittyPassthrough {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = devnull.Close() })
+	kp := NewKittyPassthroughWithOptions(KittyPassthroughOptions{
+		ForceEnable: true,
+		Output:      devnull,
+	})
+	kp.enabled = true
+	return kp
+}
+
+// TestForwardPlaceKeyedByHostID reproduces the transmit->place->delete-by-id
+// flow (ratatui-image, timg). forwardPlace previously keyed its tracked
+// placement by the guest image ID while every other path (and the by-id delete)
+// keys by host ID, so a guest delete-by-id could not find the placement and
+// RefreshAllPlacements kept re-emitting a=p forever. After placing then
+// deleting an image by its guest id, no placement should remain.
+func TestForwardPlaceKeyedByHostID(t *testing.T) {
+	kp := newTestKittyPassthrough(t)
+	winID := "test-window-id-abcdef12"
+
+	const guestID uint32 = 5
+
+	// Standard flow: a plain a=t direct transmit is passed through raw; the
+	// subsequent a=p is where forwardPlace registers the tracked placement.
+	place := &vt.KittyCommand{Action: vt.KittyActionPlace, ImageID: guestID, Columns: 10, Rows: 5}
+	kp.ForwardCommand(place, nil, winID, 0, 0, 80, 24, 0, 0, 0, 0, 0, false, nil)
+
+	kp.mu.Lock()
+	hostID, mapped := kp.imageIDMap[winID][guestID]
+	placements := kp.placements[winID]
+	_, keyedByHost := placements[hostID]
+	kp.mu.Unlock()
+
+	if !mapped {
+		t.Fatal("expected guest image id to be mapped to a host id after a=p")
+	}
+	if len(placements) != 1 {
+		t.Fatalf("expected exactly one tracked placement, got %d", len(placements))
+	}
+	if !keyedByHost {
+		t.Fatalf("placement must be keyed by host id %d, got keys %v", hostID, placementKeys(placements))
+	}
+
+	// Guest deletes the image by its guest id (a=d,d=i,i=5). forwardDelete
+	// resolves guestID->hostID and deletes placements[win][hostID].
+	del := &vt.KittyCommand{Action: vt.KittyActionDelete, Delete: vt.KittyDeleteByID, ImageID: guestID}
+	kp.ForwardCommand(del, nil, winID, 0, 0, 80, 24, 0, 0, 0, 0, 0, false, nil)
+
+	kp.mu.Lock()
+	remaining := len(kp.placements[winID])
+	kp.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("BUG: delete-by-id left %d stale placement(s); RefreshAllPlacements would re-emit a=p forever", remaining)
+	}
+}
+
+func placementKeys(m map[uint32]*PassthroughPlacement) []uint32 {
+	keys := make([]uint32, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/app/kitty_response_test.go
+++ b/internal/app/kitty_response_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// TestIsKittyResponse verifies the tightened echoed-response heuristic. It runs
+// against the RAW wire payload (base64 text), not decoded bytes, so a real
+// image chunk that decodes cleanly is never mistaken for a status response.
+func TestIsKittyResponse(t *testing.T) {
+	responses := []string{
+		"OK",
+		"ENOENT",
+		"EINVAL",
+		"EBADMSG",
+		"ENOENT:No such file or directory",
+		"EINVAL:bad graphics params",
+	}
+	for _, r := range responses {
+		if !isKittyResponse(r) {
+			t.Errorf("isKittyResponse(%q) = false, want true (real echoed response)", r)
+		}
+	}
+
+	notResponses := []string{
+		"",
+		"E",                        // 'E' with no following uppercase letter
+		"Elephant",                 // lowercase after first uppercase -> real data
+		"OKgood",                   // not exactly "OK"
+		"ENOENTdata",               // trailing lowercase, no ':' separator
+		"iVBORw0KGgoAAAANSUhEUgAA", // typical base64 PNG header, mixed case
+		strings.Repeat("E", 300),   // over the length cap
+		"EABCDEF" + "abc",          // uppercase run then lowercase, no ':'
+	}
+	for _, d := range notResponses {
+		if isKittyResponse(d) {
+			t.Errorf("isKittyResponse(%q) = true, want false (real image data)", d)
+		}
+	}
+}
+
+// TestIsKittyResponseDoesNotDropBase64Chunks feeds a large number of realistic
+// base64 image chunks (as produced by base64-encoding random-looking binary)
+// and asserts none are misclassified as a response. The old decoded-byte
+// heuristic dropped ~0.04% of raw binary chunks; the wire-text heuristic must
+// drop none.
+func TestIsKittyResponseDoesNotDropBase64Chunks(t *testing.T) {
+	// Deterministic pseudo-random bytes so the test is reproducible.
+	var seed uint32 = 0x12345678
+	next := func() byte {
+		seed = seed*1664525 + 1013904223
+		return byte(seed >> 16)
+	}
+	for range 5000 {
+		raw := make([]byte, 4096)
+		for i := range raw {
+			raw[i] = next()
+		}
+		payload := base64.StdEncoding.EncodeToString(raw)
+		if isKittyResponse(payload) {
+			t.Fatalf("isKittyResponse misclassified a base64 image chunk as a response: %q...", payload[:16])
+		}
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -4,6 +4,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 
@@ -200,6 +201,11 @@ type OS struct {
 	ScriptExecutor     any       // *tape.CommandExecutor - executes tape commands
 	ScriptSleepUntil   time.Time // When to resume after a sleep command
 	ScriptFinishedTime time.Time // When the script finished (for auto-hide)
+	// WaitUntilRegex playback state. When ScriptWaitRegex is non-nil, playback
+	// blocks until the focused window's screen matches it or ScriptWaitDeadline
+	// passes, whichever comes first.
+	ScriptWaitRegex    *regexp.Regexp
+	ScriptWaitDeadline time.Time
 	// Tape manager UI
 	ShowTapeManager    bool              // True when showing tape manager overlay
 	TapeManager        *TapeManagerState // Tape manager state

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -375,7 +375,11 @@ func (m *OS) SwitchToSession(targetSession string) error {
 	m.NextBSPWindowID = 1
 	m.Animations = nil
 	m.MultifocusSet = nil
-	m.CurrentWorkspace = 0
+	// Default to workspace 1, not 0: a brand-new target session has no windows,
+	// so RestoreFromState (which repairs the workspace) never runs, and any
+	// window then created would land on workspace 0, which SwitchToWorkspace
+	// refuses to navigate to, leaving it permanently invisible.
+	m.CurrentWorkspace = 1
 	m.SubscribedPTYs = make(map[string]bool)
 
 	// 3. Detach + attach in one operation (safe with read loop running)

--- a/internal/app/os_render.go
+++ b/internal/app/os_render.go
@@ -1,12 +1,16 @@
 package app
 
-// MarkAllDirty marks all windows as dirty for re-rendering.
+// MarkAllDirty marks all windows as dirty for re-rendering. It goes through
+// MarkContentDirty so ContentDirty always implies the cached content string is
+// dropped; otherwise renderTerminal's unfocused early return would hand back
+// the stale cache and ClearDirtyFlags would then discard the repaint request.
 func (m *OS) MarkAllDirty() {
 	m.terminalMu.Lock()
 	defer m.terminalMu.Unlock()
 	for i := range m.Windows {
-		m.Windows[i].Dirty = true
-		m.Windows[i].ContentDirty = true
+		if m.Windows[i] != nil {
+			m.Windows[i].MarkContentDirty()
+		}
 	}
 	m.cachedViewContent = "" // Invalidate view cache
 }

--- a/internal/app/os_tape_executor.go
+++ b/internal/app/os_tape_executor.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 	"image/color"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1187,6 +1189,63 @@ func (m *OS) findWindowInDirection(from *terminal.Window, dx, dy int) int {
 	}
 
 	return targetIndex
+}
+
+// startScriptWaitRegex arms a WaitUntilRegex condition for tape playback. It
+// compiles Args[0] as the pattern and Args[1] (optional, milliseconds) as the
+// timeout, defaulting to 5000ms. A bad or missing pattern is reported and the
+// command is skipped without arming a wait.
+func (m *OS) startScriptWaitRegex(cmd *tape.Command) {
+	if len(cmd.Args) == 0 {
+		m.ShowNotification("WaitUntilRegex: missing pattern", "error", config.NotificationDuration)
+		return
+	}
+	re, err := regexp.Compile(cmd.Args[0])
+	if err != nil {
+		m.ShowNotification(fmt.Sprintf("WaitUntilRegex: invalid pattern: %v", err), "error", config.NotificationDuration)
+		return
+	}
+	timeout := 5000 * time.Millisecond
+	if len(cmd.Args) > 1 {
+		if ms, convErr := strconv.Atoi(cmd.Args[1]); convErr == nil && ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+	}
+	m.ScriptWaitRegex = re
+	m.ScriptWaitDeadline = time.Now().Add(timeout)
+}
+
+// checkScriptWaitRegex reports whether a pending WaitUntilRegex condition is
+// satisfied, so playback may resume. It returns true (clearing the wait state)
+// on a match against the focused window's visible screen or once the deadline
+// passes, warning on timeout. It returns false while still waiting.
+func (m *OS) checkScriptWaitRegex() bool {
+	if m.ScriptWaitRegex == nil {
+		return true
+	}
+
+	matched := false
+	if win := m.GetFocusedWindow(); win != nil && win.Terminal != nil {
+		win.RLockIO()
+		content := win.Terminal.String()
+		win.RUnlockIO()
+		matched = m.ScriptWaitRegex.MatchString(content)
+	}
+
+	if matched {
+		m.ScriptWaitRegex = nil
+		m.ScriptWaitDeadline = time.Time{}
+		return true
+	}
+
+	if !m.ScriptWaitDeadline.IsZero() && time.Now().After(m.ScriptWaitDeadline) {
+		m.ShowNotification("WaitUntilRegex: timed out", "warning", config.NotificationDuration)
+		m.ScriptWaitRegex = nil
+		m.ScriptWaitDeadline = time.Time{}
+		return true
+	}
+
+	return false
 }
 
 // capturePane captures the content of a pane.

--- a/internal/app/os_tape_executor_test.go
+++ b/internal/app/os_tape_executor_test.go
@@ -2,11 +2,90 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/session"
+	"github.com/Gaurav-Gosain/tuios/internal/tape"
 	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
 )
+
+// focusedOS builds a minimal OS with a single focused window whose terminal
+// renders the given screen content.
+func focusedOS(t *testing.T, screen string) *OS {
+	t.Helper()
+	em := vt.NewEmulator(80, 24)
+	if _, err := em.Write([]byte(screen)); err != nil {
+		t.Fatalf("write to emulator: %v", err)
+	}
+	win := &terminal.Window{Terminal: em, Workspace: 1}
+	return &OS{
+		Windows:          []*terminal.Window{win},
+		FocusedWindow:    0,
+		CurrentWorkspace: 1,
+	}
+}
+
+func TestStartScriptWaitRegexBadPattern(t *testing.T) {
+	m := &OS{}
+	m.startScriptWaitRegex(&tape.Command{Type: tape.CommandTypeWaitUntilRegex, Args: []string{"("}})
+	if m.ScriptWaitRegex != nil {
+		t.Error("expected no wait to be armed for an invalid pattern")
+	}
+
+	m.startScriptWaitRegex(&tape.Command{Type: tape.CommandTypeWaitUntilRegex})
+	if m.ScriptWaitRegex != nil {
+		t.Error("expected no wait to be armed for a missing pattern")
+	}
+}
+
+func TestScriptWaitRegexDefaultTimeout(t *testing.T) {
+	m := &OS{}
+	before := time.Now()
+	m.startScriptWaitRegex(&tape.Command{Type: tape.CommandTypeWaitUntilRegex, Args: []string{"x"}})
+	if m.ScriptWaitRegex == nil {
+		t.Fatal("expected wait to be armed")
+	}
+	// Default timeout is 5000ms; deadline should be roughly now+5s.
+	if got := m.ScriptWaitDeadline.Sub(before); got < 4*time.Second || got > 6*time.Second {
+		t.Errorf("default timeout deadline = %v, want ~5s", got)
+	}
+}
+
+func TestCheckScriptWaitRegexMatch(t *testing.T) {
+	m := focusedOS(t, "build complete\n")
+	m.startScriptWaitRegex(&tape.Command{
+		Type: tape.CommandTypeWaitUntilRegex,
+		Args: []string{"build complete", "3000"},
+	})
+	if !m.checkScriptWaitRegex() {
+		t.Error("expected match to resume playback")
+	}
+	if m.ScriptWaitRegex != nil {
+		t.Error("expected wait state cleared after match")
+	}
+}
+
+func TestCheckScriptWaitRegexBlocksThenTimesOut(t *testing.T) {
+	m := focusedOS(t, "still running\n")
+	m.startScriptWaitRegex(&tape.Command{
+		Type: tape.CommandTypeWaitUntilRegex,
+		Args: []string{"never appears", "5000"},
+	})
+	if m.checkScriptWaitRegex() {
+		t.Error("expected to keep waiting while pattern is absent")
+	}
+
+	// Force the deadline into the past to exercise the timeout path.
+	m.ScriptWaitDeadline = time.Now().Add(-time.Millisecond)
+	if !m.checkScriptWaitRegex() {
+		t.Error("expected timeout to resume playback")
+	}
+	if m.ScriptWaitRegex != nil {
+		t.Error("expected wait state cleared after timeout")
+	}
+}
 
 // TestParseKeyToMessage tests the key parsing function
 func TestParseKeyToMessage(t *testing.T) {

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -442,30 +442,37 @@ func (m *OS) GetKittyGraphicsCmd() tea.Cmd {
 			screenHeight := m.GetRenderHeight()
 			n := 0
 			for _, w := range m.Windows {
-				if w.Workspace == m.CurrentWorkspace && !w.Minimized {
-					scrollbackLen := 0
-					if w.Terminal != nil {
-						scrollbackLen = w.Terminal.ScrollbackLen()
-					}
-					backing[n] = WindowPositionInfo{
-						WindowX:            w.X,
-						WindowY:            w.Y,
-						ContentOffsetX:     w.BorderOffset(),
-						ContentOffsetY:     w.BorderOffset(),
-						Width:              w.Width,
-						Height:             w.Height,
-						Visible:            true,
-						ScrollbackLen:      scrollbackLen,
-						ScrollOffset:       w.ScrollbackOffset,
-						IsBeingManipulated: w.IsBeingManipulated,
-						WindowZ:            w.Z,
-						IsAltScreen:        w.IsAltScreen(),
-						ScreenWidth:        screenWidth,
-						ScreenHeight:       screenHeight,
-					}
-					m.kittyPosMap[w.ID] = &backing[n]
-					n++
+				// Include EVERY window, but mark off-workspace/minimized ones
+				// Visible:false. RefreshAllPlacements then HIDES their images
+				// (d=i, keeping the bytes in the host store) instead of deleting
+				// tracking. Omitting them made info==nil, which RefreshAllPlacements
+				// treats as "window gone" and permanently destroys the placement,
+				// so a minimized icat/chafa image never reappeared on restore.
+				// The info==nil delete is now reserved for windows genuinely
+				// removed from m.Windows (closed).
+				visible := w.Workspace == m.CurrentWorkspace && !w.Minimized
+				scrollbackLen := 0
+				if w.Terminal != nil {
+					scrollbackLen = w.Terminal.ScrollbackLen()
 				}
+				backing[n] = WindowPositionInfo{
+					WindowX:            w.X,
+					WindowY:            w.Y,
+					ContentOffsetX:     w.BorderOffset(),
+					ContentOffsetY:     w.BorderOffset(),
+					Width:              w.Width,
+					Height:             w.Height,
+					Visible:            visible,
+					ScrollbackLen:      scrollbackLen,
+					ScrollOffset:       w.ScrollbackOffset,
+					IsBeingManipulated: w.IsBeingManipulated,
+					WindowZ:            w.Z,
+					IsAltScreen:        w.IsAltScreen(),
+					ScreenWidth:        screenWidth,
+					ScreenHeight:       screenHeight,
+				}
+				m.kittyPosMap[w.ID] = &backing[n]
+				n++
 			}
 			return m.kittyPosMap
 		})

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -167,6 +167,16 @@ func convertBSPNode(node *layout.SerializedNode) *session.SerializedBSPNode {
 	}
 }
 
+// clampWorkspace returns a valid workspace index. Workspaces are 1-based and
+// SwitchToWorkspace refuses anything below 1, so a persisted or synced value of
+// 0 must be normalized to 1 to keep every workspace reachable.
+func clampWorkspace(ws int) int {
+	if ws < 1 {
+		return 1
+	}
+	return ws
+}
+
 // RestoreFromState restores the OS state from a SessionState.
 // This is called when attaching to an existing session.
 // The caller must set up PTY output handlers after calling this.
@@ -179,7 +189,10 @@ func (m *OS) RestoreFromState(state *session.SessionState) error {
 	m.LogInfo("[RESTORE] RestoreFromState: restoring %d windows", len(state.Windows))
 
 	m.SessionName = state.Name
-	m.CurrentWorkspace = state.CurrentWorkspace
+	// Clamp to a valid workspace: SwitchToWorkspace rejects workspace < 1, so a
+	// state carrying 0 (legacy, or a freshly created session with no windows)
+	// would strand every subsequently created window on an unreachable workspace.
+	m.CurrentWorkspace = clampWorkspace(state.CurrentWorkspace)
 	m.MasterRatio = state.MasterRatio
 	m.AutoTiling = state.AutoTiling
 	m.Mode = Mode(state.Mode)
@@ -407,7 +420,7 @@ func (m *OS) ApplyStateSync(state *session.SessionState) error {
 
 	// Update global state
 	m.SessionName = state.Name
-	m.CurrentWorkspace = state.CurrentWorkspace
+	m.CurrentWorkspace = clampWorkspace(state.CurrentWorkspace)
 	m.MasterRatio = state.MasterRatio
 	m.AutoTiling = state.AutoTiling
 

--- a/internal/app/session_workspace_test.go
+++ b/internal/app/session_workspace_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/session"
+)
+
+func TestClampWorkspace(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{-1, 1},
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{9, 9},
+	}
+	for _, c := range cases {
+		if got := clampWorkspace(c.in); got != c.want {
+			t.Errorf("clampWorkspace(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRestoreFromStateClampsWorkspace verifies that restoring a session whose
+// persisted CurrentWorkspace is 0 (legacy or freshly created with no windows)
+// normalizes to workspace 1, which is reachable, instead of stranding future
+// windows on the unreachable workspace 0.
+func TestRestoreFromStateClampsWorkspace(t *testing.T) {
+	m := &OS{}
+	state := &session.SessionState{
+		Name:             "fresh",
+		CurrentWorkspace: 0,
+	}
+	if err := m.RestoreFromState(state); err != nil {
+		t.Fatalf("RestoreFromState returned error: %v", err)
+	}
+	if m.CurrentWorkspace != 1 {
+		t.Errorf("CurrentWorkspace = %d after restoring workspace 0, want 1", m.CurrentWorkspace)
+	}
+}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -83,6 +83,12 @@ func (m *OS) applyTheme(name string) {
 	} else {
 		_ = theme.Initialize(name)
 	}
+	// Push the new palette into every emulator: SGR indexed colors resolve
+	// through the emulator's color table at render time, so without this the
+	// chrome recolors but terminal content keeps the old palette until fresh
+	// guest output arrives. MarkAllDirty then forces a repaint with dropped
+	// caches.
+	m.UpdateAllWindowThemes()
 	m.MarkAllDirty()
 }
 

--- a/internal/app/sixel_passthrough.go
+++ b/internal/app/sixel_passthrough.go
@@ -259,11 +259,16 @@ func (sp *SixelPassthrough) RefreshAllPlacements(getWindowInfo func(windowID str
 		if contentHeight <= 0 {
 			contentHeight = info.Height
 		}
-		viewportTop := 0
-		if info.ScrollbackLen > contentHeight {
-			viewportTop = info.ScrollbackLen - info.ScrollOffset - contentHeight
-		}
-		viewportBottom := info.ScrollbackLen - info.ScrollOffset
+		// viewportTop is the absolute scrollback line at the top row of the
+		// content viewport, matching the kitty path
+		// (kitty_passthrough_placement.go). AbsoluteLine is also absolute
+		// (scrollbackLen+cursorY at placement time), so relativeY =
+		// AbsoluteLine - viewportTop is the on-screen row directly. The old
+		// formula subtracted an extra contentHeight, so once scrollback grew
+		// past the window height relativeY overshot by contentHeight and the
+		// bottom-edge guards hid the image.
+		viewportTop := info.ScrollbackLen - info.ScrollOffset
+		viewportBottom := viewportTop + contentHeight
 
 		for _, p := range placements {
 			// Check if placement matches current screen mode

--- a/internal/app/sixel_viewport_test.go
+++ b/internal/app/sixel_viewport_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"os"
+	"testing"
+)
+
+// TestSixelVisibleWhenScrollbackExceedsHeight reproduces the viewport-math bug:
+// once a window's scrollback grew past its content height, the sixel refresh
+// computed relativeY with an extra -contentHeight term, so hostY fell past the
+// window bottom and the bottom-edge guards hid the image. The image must stay
+// visible at its true on-screen row, matching the kitty convention.
+func TestSixelVisibleWhenScrollbackExceedsHeight(t *testing.T) {
+	prevCaps := cachedCapabilities
+	cachedCapabilities = &HostCapabilities{CellWidth: 9, CellHeight: 20, Cols: 80, Rows: 40}
+	t.Cleanup(func() { cachedCapabilities = prevCaps })
+
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = devnull.Close() })
+	sp := NewSixelPassthroughWithOptions(SixelPassthroughOptions{ForceEnable: true, Output: devnull})
+	sp.enabled = true
+
+	winID := "test-window-id-abcdef12"
+
+	const (
+		scrollbackLen = 100
+		contentHeight = 24 // window height, borderless
+		onScreenRow   = 2
+	)
+	// Image placed at on-screen row 2 while at the bottom of 100 lines of
+	// scrollback: AbsoluteLine = scrollbackLen + cursorY.
+	sp.placements[winID] = []*SixelPassthroughPlacement{
+		{
+			WindowID:     winID,
+			AbsoluteLine: scrollbackLen + onScreenRow,
+			GuestX:       0,
+			Width:        90,
+			Height:       100,
+			Rows:         5,
+			Cols:         10,
+			Hidden:       true,
+			RawSequence:  []byte("0;1;0;0#0"),
+		},
+	}
+
+	sp.RefreshAllPlacements(func(windowID string) *WindowPositionInfo {
+		if windowID != winID {
+			return nil
+		}
+		return &WindowPositionInfo{
+			WindowX: 0, WindowY: 0,
+			Width: 80, Height: contentHeight,
+			ContentOffsetX: 0, ContentOffsetY: 0,
+			Visible:       true,
+			ScrollbackLen: scrollbackLen,
+			ScrollOffset:  0,
+			ScreenWidth:   80,
+			ScreenHeight:  40,
+		}
+	})
+
+	p := sp.placements[winID][0]
+	if p.Hidden {
+		t.Fatal("BUG: sixel hidden when scrollback exceeds window height; image reserves space but never displays")
+	}
+	if p.HostY != onScreenRow {
+		t.Errorf("expected hostY=%d (on-screen row), got %d", onScreenRow, p.HostY)
+	}
+}

--- a/internal/app/sysinfo.go
+++ b/internal/app/sysinfo.go
@@ -191,9 +191,15 @@ func getCPUUsageLinux() float64 {
 }
 
 // getCPUUsageDarwin retrieves CPU usage on macOS systems using gopsutil.
+//
+// It uses a zero interval so the call never sleeps: gopsutil retains the CPU
+// times from the previous call and returns the usage over the elapsed window
+// (here ~500ms, one CPUUpdateInterval). A blocking cpu.Percent(100ms, ...) here
+// would stall the single Bubble Tea goroutine 100ms out of every 500ms whenever
+// ShowCPU is enabled. The first call has no baseline and returns 0, mirroring
+// the Linux delta path.
 func getCPUUsageDarwin() float64 {
-	// Get CPU percent over a short interval
-	percentages, err := cpu.Percent(100*time.Millisecond, false)
+	percentages, err := cpu.Percent(0, false)
 	if err != nil || len(percentages) == 0 {
 		return 0
 	}

--- a/internal/app/theme_picker.go
+++ b/internal/app/theme_picker.go
@@ -61,10 +61,18 @@ func (m *OS) CloseThemePicker() {
 }
 
 // CancelThemePicker restores the theme that was active when the picker opened
-// and closes it. Used for Esc, so live preview does not stick.
+// and closes it. Used for Esc, so live preview does not stick. It only persists
+// when a live preview actually changed the active theme, so a no-op cancel does
+// not rewrite config.toml (and cannot overwrite the configured theme).
 func (m *OS) CancelThemePicker() {
+	current := theme.CurrentThemeID()
+	if current == "" {
+		current = themeNone
+	}
 	m.applyTheme(m.ThemePickerOriginal)
-	m.persistThemeSelection(m.ThemePickerOriginal)
+	if current != m.ThemePickerOriginal {
+		m.persistThemeSelection(m.ThemePickerOriginal)
+	}
 	m.CloseThemePicker()
 }
 

--- a/internal/app/tiling.go
+++ b/internal/app/tiling.go
@@ -333,7 +333,12 @@ func (m *OS) RestoreWorkspaceLayout(workspace int) {
 		}
 	}
 
-	m.WorkspaceHasCustom[workspace] = true
+	// Do NOT force WorkspaceHasCustom = true here. SaveCurrentLayout runs on
+	// every workspace switch, so a saved layout always exists after the first
+	// switch; marking it custom on restore permanently suppressed the
+	// retile-if-not-custom check (workspace.go), disabling auto-retiling for
+	// both workspaces after a single round-trip. The custom flag is owned by
+	// MarkLayoutCustom, which fires on an actual user resize.
 }
 
 // MarkLayoutCustom marks the current workspace as having a custom layout

--- a/internal/app/tiling_workspace_test.go
+++ b/internal/app/tiling_workspace_test.go
@@ -1,0 +1,47 @@
+package app
+
+import "testing"
+
+// TestRestoreWorkspaceLayoutDoesNotForceCustom verifies that restoring a saved
+// layout does not mark the workspace as custom. SaveCurrentLayout runs on every
+// workspace switch, so a saved layout always exists after the first switch;
+// forcing the custom flag here previously suppressed the retile-if-not-custom
+// check permanently, disabling auto-retiling after a single round-trip.
+func TestRestoreWorkspaceLayoutDoesNotForceCustom(t *testing.T) {
+	m := &OS{
+		AutoTiling: true,
+		WorkspaceLayouts: map[int][]WindowLayout{
+			2: {{WindowID: "nonexistent", X: 0, Y: 0, Width: 10, Height: 10}},
+		},
+		WorkspaceMasterRatio: map[int]float64{},
+		WorkspaceHasCustom:   map[int]bool{},
+	}
+
+	m.RestoreWorkspaceLayout(2)
+
+	if m.WorkspaceHasCustom[2] {
+		t.Error("RestoreWorkspaceLayout must not mark a workspace custom; only MarkLayoutCustom (a real user resize) may")
+	}
+}
+
+// TestRestoreWorkspaceLayoutRoundTripKeepsRetiling simulates two workspace-switch
+// saves followed by a restore and confirms auto-retiling stays enabled (the
+// workspace is not stuck as custom), which is what previously broke.
+func TestRestoreWorkspaceLayoutRoundTripKeepsRetiling(t *testing.T) {
+	m := &OS{
+		AutoTiling:           true,
+		WorkspaceLayouts:     map[int][]WindowLayout{},
+		WorkspaceMasterRatio: map[int]float64{},
+		WorkspaceHasCustom:   map[int]bool{},
+		CurrentWorkspace:     1,
+	}
+
+	// Simulate a switch away from workspace 1 (saves its layout).
+	m.SaveCurrentLayout()
+	// Simulate switching back to workspace 1 (restores the just-saved layout).
+	m.RestoreWorkspaceLayout(1)
+
+	if m.WorkspaceHasCustom[1] {
+		t.Error("auto-retiling permanently disabled: workspace 1 marked custom after a plain save/restore round-trip")
+	}
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -123,13 +123,16 @@ type ClientLeftMsg struct {
 	ClientCount int
 }
 
-// ClientEvent represents a client join or leave event for channel-based notification.
+// ClientEvent represents a multi-client notification delivered to the Bubble Tea
+// event loop so the work happens on the program goroutine instead of the daemon
+// read-loop goroutine.
 type ClientEvent struct {
-	Type        string // "joined" or "left"
+	Type        string // "joined", "left", "resize", or "refresh"
 	ClientID    string
 	ClientCount int
-	Width       int // only for "joined"
-	Height      int // only for "joined"
+	Width       int    // "joined" and "resize"
+	Height      int    // "joined" and "resize"
+	Reason      string // "refresh"
 }
 
 // SessionResizeMsg is sent when the effective session size changes (min of all clients).
@@ -236,17 +239,27 @@ func ListenForClientEvents(eventChan chan ClientEvent) tea.Cmd {
 			// Channel closed, return nil to stop listening
 			return nil
 		}
-		if event.Type == "joined" {
+		switch event.Type {
+		case "joined":
 			return ClientJoinedMsg{
 				ClientID:    event.ClientID,
 				ClientCount: event.ClientCount,
 				Width:       event.Width,
 				Height:      event.Height,
 			}
-		}
-		return ClientLeftMsg{
-			ClientID:    event.ClientID,
-			ClientCount: event.ClientCount,
+		case "resize":
+			return SessionResizeMsg{
+				Width:       event.Width,
+				Height:      event.Height,
+				ClientCount: event.ClientCount,
+			}
+		case "refresh":
+			return ForceRefreshMsg{Reason: event.Reason}
+		default:
+			return ClientLeftMsg{
+				ClientID:    event.ClientID,
+				ClientCount: event.ClientCount,
+			}
 		}
 	}
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -147,6 +147,13 @@ type ForceRefreshMsg struct {
 	Reason string
 }
 
+// DaemonDisconnectedMsg is sent when the daemon connection is lost unexpectedly
+// (crash, reset, or framing desync). The app cannot recover the session, so it
+// surfaces the reason and quits cleanly instead of hanging.
+type DaemonDisconnectedMsg struct {
+	Err error
+}
+
 // InputHandler is a function type that handles input messages.
 // This allows the Update method to delegate to the input package without creating a circular dependency.
 type InputHandler func(msg tea.Msg, o *OS) (tea.Model, tea.Cmd)
@@ -802,6 +809,11 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// Force re-render
 		m.MarkAllDirty()
 		return m, nil
+
+	case DaemonDisconnectedMsg:
+		// The daemon connection was lost and cannot be recovered; quit cleanly
+		// so the user is not left staring at a frozen, unresponsive session.
+		return m, tea.Quit
 
 	case ConfigReloadedMsg:
 		// Apply appearance config parsed by the watcher goroutine here, on the

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -433,6 +433,13 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 					return m, TickCmd()
 				}
 
+				// Check if we're blocking on a WaitUntilRegex condition from a
+				// previously dispatched command.
+				if m.ScriptWaitRegex != nil && !m.checkScriptWaitRegex() {
+					// Condition not met and not timed out yet, keep waiting.
+					return m, TickCmd()
+				}
+
 				// Check if we're waiting for a sleep to finish
 				if !m.ScriptSleepUntil.IsZero() && time.Now().Before(m.ScriptSleepUntil) {
 					// Still waiting, don't advance yet
@@ -443,13 +450,19 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 				nextCmd := player.NextCommand()
 				if nextCmd != nil {
-					// Handle Sleep commands specially
-					if nextCmd.Type == tape.CommandTypeSleep && nextCmd.Delay > 0 {
+					switch {
+					// Sleep and its Wait alias both just delay playback.
+					case (nextCmd.Type == tape.CommandTypeSleep || nextCmd.Type == tape.CommandTypeWait) && nextCmd.Delay > 0:
 						// Set the sleep deadline
 						m.ScriptSleepUntil = time.Now().Add(nextCmd.Delay)
 						// Advance to next command but don't execute anything yet
 						player.Advance()
-					} else {
+					case nextCmd.Type == tape.CommandTypeWaitUntilRegex:
+						// Arm the wait; playback blocks above until it resolves.
+						// Don't dispatch it to the executor.
+						m.startScriptWaitRegex(nextCmd)
+						player.Advance()
+					default:
 						// Queue the command as a message instead of executing directly
 						cmds = append(cmds, func() tea.Msg {
 							return ScriptCommandMsg{Command: nextCmd}

--- a/internal/app/workspace.go
+++ b/internal/app/workspace.go
@@ -285,10 +285,21 @@ func (m *OS) GetWorkspaceWindowCount(workspace int) int {
 
 // TileVisibleWorkspaceWindows tiles all visible windows in the current workspace with animations.
 func (m *OS) TileVisibleWorkspaceWindows() {
-	// Only tile windows in current workspace
+	// BSP and scrolling layouts carry their own geometry (split ratios, column
+	// offsets) that the master-stack tiler below would silently overwrite,
+	// desyncing the separator overlay and eventually tripping the stale-ID check
+	// in TileAllWindows (which then discards the whole tree). Defer to
+	// TileAllWindows, which branches correctly per layout mode and filters
+	// floating windows.
+	if m.UseBSPLayout || m.UseScrollingLayout {
+		m.TileAllWindows()
+		return
+	}
+
+	// Master-stack path: animate visible, non-floating windows into place.
 	visibleWindows := make([]int, 0)
 	for i, w := range m.Windows {
-		if w.Workspace == m.CurrentWorkspace && !w.Minimized && !w.Minimizing {
+		if w.Workspace == m.CurrentWorkspace && !w.Minimized && !w.Minimizing && !w.IsFloating {
 			visibleWindows = append(visibleWindows, i)
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -505,6 +505,43 @@ func TestApplyOverrides_NoAnimations(t *testing.T) {
 	}
 }
 
+// TestStartupPrecedence_FlagWinsOverConfig checks the startup application order:
+// ApplyAppearanceConfig establishes the config baseline, then ApplyOverrides
+// lets CLI flags win. This is the sequence LoadUserConfig no longer performs
+// implicitly, and the fix that keeps `--no-animations` from being reverted by
+// animations_enabled = true.
+func TestStartupPrecedence_FlagWinsOverConfig(t *testing.T) {
+	original := config.AnimationsEnabled
+	defer func() { config.AnimationsEnabled = original }()
+
+	enabled := true
+	userCfg := config.DefaultConfig()
+	userCfg.Appearance.AnimationsEnabled = &enabled
+
+	config.ApplyAppearanceConfig(userCfg)                                // baseline: on
+	config.ApplyOverrides(config.Overrides{NoAnimations: true}, userCfg) // flag wins: off
+
+	if config.AnimationsEnabled {
+		t.Error("CLI --no-animations must win over config animations_enabled = true")
+	}
+}
+
+// TestLoadUserConfig_Pure verifies LoadUserConfig has no package-global side
+// effects, so a second load (e.g. inside NewOS or per server connection) cannot
+// clobber previously applied globals or race other sessions.
+func TestLoadUserConfig_Pure(t *testing.T) {
+	original := config.AnimationsEnabled
+	defer func() { config.AnimationsEnabled = original }()
+
+	config.AnimationsEnabled = false
+	if _, err := config.LoadUserConfig(); err != nil {
+		t.Skipf("LoadUserConfig unavailable in this environment: %v", err)
+	}
+	if config.AnimationsEnabled {
+		t.Error("LoadUserConfig must not mutate appearance globals")
+	}
+}
+
 func TestApplyOverrides_LeaderKey(t *testing.T) {
 	// Save original value
 	originalLeader := config.LeaderKey

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -420,9 +420,11 @@ func LoadUserConfig() (*UserConfig, error) {
 		}
 	}
 
-	// Apply appearance globals at startup (single-threaded, before the program runs).
-	ApplyAppearanceConfig(&cfg)
-
+	// Loading is pure: it never mutates package globals. Callers apply the
+	// appearance globals exactly once, on the Bubble Tea goroutine, via
+	// ApplyOverrides (which lets CLI flags win) and/or ApplyAppearanceConfig.
+	// This keeps a second load (e.g. inside NewOS) from clobbering CLI flags and
+	// stops the per-connection server paths from racing other sessions' globals.
 	return &cfg, nil
 }
 

--- a/internal/input/handler.go
+++ b/internal/input/handler.go
@@ -161,22 +161,12 @@ func HandleKeyPress(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return o, nil
 	}
 
-	// Record keystrokes when recording is active (before any other handling)
-	// Only record in terminal mode - WM mode actions are recorded at dispatch time
-	if o.TapeRecorder != nil && o.TapeRecorder.IsRecording() && !o.ShowTapeManager {
-		if o.Mode == app.TerminalMode {
-			keyStr := msg.String()
-			// Skip workspace switch keys - they're recorded by SwitchToWorkspace
-			if isWorkspaceSwitchKey(keyStr) {
-				// Don't record - will be captured by SwitchToWorkspace
-			} else if len(keyStr) == 1 && keyStr[0] >= 32 && keyStr[0] < 127 {
-				// Accumulate printable characters as Type command
-				o.TapeRecorder.RecordType(keyStr)
-			} else {
-				o.TapeRecorder.RecordKey(keyStr)
-			}
-		}
-	}
+	// Terminal-mode keystrokes are recorded at the point they are actually
+	// forwarded to the PTY (see recordTerminalKey in HandleTerminalModeKey), not
+	// here: recording before prefix/overlay routing captured prefix chords,
+	// copy-mode keys, palette queries, and transition-suppressed fragments that
+	// never reach the shell, so tapes replayed garbage. WM-mode actions are
+	// recorded at dispatch time.
 
 	// Handle tape manager overlay (high priority - intercepts keys when shown)
 	if o.ShowTapeManager {
@@ -623,13 +613,3 @@ func logScrollBounds(screenHeight, totalLogs int) (logsPerPage, maxScroll int) {
 	return logsPerPage, maxScroll
 }
 
-// isWorkspaceSwitchKey returns true if the key is a workspace switch shortcut
-// These are recorded separately by SwitchToWorkspace, not as raw keystrokes
-func isWorkspaceSwitchKey(key string) bool {
-	switch key {
-	case "alt+1", "alt+2", "alt+3", "alt+4", "alt+5", "alt+6", "alt+7", "alt+8", "alt+9",
-		"opt+1", "opt+2", "opt+3", "opt+4", "opt+5", "opt+6", "opt+7", "opt+8", "opt+9":
-		return true
-	}
-	return false
-}

--- a/internal/input/keybindings.go
+++ b/internal/input/keybindings.go
@@ -8,9 +8,21 @@
 package input
 
 import (
+	"runtime"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/vt"
 )
+
+// runtimeIsDarwin reports whether the process is running on macOS.
+// The macOS Option-key character tables (IsMacOSOptionKey, IsMacOSOptionTab)
+// must only be consulted on darwin: their glyphs (¡ ™ £ ¢ ∞ § ¶ • ª, ⇥ ⇤) are
+// ordinary typed characters on many non-US layouts (e.g. £ is Shift+3 on UK),
+// so treating them as workspace/window shortcuts on other platforms hijacks
+// real input before it reaches the shell.
+func runtimeIsDarwin() bool {
+	return runtime.GOOS == "darwin"
+}
 
 // Ctrl key combinations mapping
 // Maps the character code to its control code equivalent

--- a/internal/input/keyboard.go
+++ b/internal/input/keyboard.go
@@ -14,8 +14,9 @@ import (
 func handleWindowCycle(msg tea.KeyPressMsg, o *app.OS) bool {
 	keyStr := msg.String()
 
-	// Check for macOS Option+Tab unicode characters first
-	if len(keyStr) > 0 {
+	// Check for macOS Option+Tab unicode characters first (darwin only; ⇥/⇤ are
+	// ordinary characters elsewhere and must fall through to the shell).
+	if runtimeIsDarwin() && len(keyStr) > 0 {
 		if dir := IsMacOSOptionTab([]rune(keyStr)[0]); dir != "" {
 			if o.AutoTiling && o.UseScrollingLayout {
 				if dir == "next" {

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -814,8 +814,9 @@ func handleTerminalWindowSelection(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea
 func handleWorkspaceSwitch(msg tea.KeyPressMsg, o *app.OS) bool {
 	keyStr := msg.String()
 
-	// Check for macOS Option+digit keys
-	if len(keyStr) > 0 {
+	// Check for macOS Option+digit keys (darwin only; these glyphs are ordinary
+	// typed characters on non-US layouts and must fall through to the shell there).
+	if runtimeIsDarwin() && len(keyStr) > 0 {
 		firstRune := []rune(keyStr)[0]
 		if digit, ok := IsMacOSOptionKey(firstRune); ok {
 			o.SwitchToWorkspace(digit)

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -344,6 +344,11 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		}
 
 		if len(rawInput) > 0 {
+			// Record the keystroke for tape capture here, at the point where it
+			// is actually forwarded to the PTY. Recording earlier (before prefix,
+			// overlay, and copy-mode routing) captured keys that never reach the
+			// shell, so tapes replayed prefix chords and stray characters.
+			recordTerminalKey(o, msg)
 			if err := focusedWindow.SendInput(rawInput); err != nil {
 				// Terminal unavailable, switch back to window mode
 				o.Mode = app.WindowManagementMode
@@ -365,6 +370,24 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		o.Mode = app.WindowManagementMode
 	}
 	return o, nil
+}
+
+// recordTerminalKey records a keystroke that is being forwarded to the focused
+// window's PTY into the active tape recording. Printable single-byte ASCII is
+// accumulated as a Type command; everything else is recorded as a KeyCombo.
+// Workspace switches, mode switches, and overlay/prefix keys return before the
+// PTY-forward path, so they are never recorded here (workspace switches are
+// captured separately by SwitchToWorkspace).
+func recordTerminalKey(o *app.OS, msg tea.KeyPressMsg) {
+	if o.TapeRecorder == nil || !o.TapeRecorder.IsRecording() || o.ShowTapeManager {
+		return
+	}
+	keyStr := msg.String()
+	if len(keyStr) == 1 && keyStr[0] >= 32 && keyStr[0] < 127 {
+		o.TapeRecorder.RecordType(keyStr)
+	} else {
+		o.TapeRecorder.RecordKey(keyStr)
+	}
 }
 
 // handleTerminalWorkspacePrefix handles workspace prefix commands in terminal mode

--- a/internal/input/keyboard_test.go
+++ b/internal/input/keyboard_test.go
@@ -203,3 +203,31 @@ func TestPrefixCommandsAvailableInBothModes(t *testing.T) {
 		t.Error("window management mode: ctrl+b P should open command palette")
 	}
 }
+
+// TestMacOSOptionKeysGatedToDarwin verifies that the macOS Option-key character
+// tables only trigger workspace/window shortcuts on darwin. On other platforms
+// these glyphs (e.g. £, ⇥) are ordinary typed characters and must fall through
+// to the shell rather than being intercepted.
+func TestMacOSOptionKeysGatedToDarwin(t *testing.T) {
+	// £ is Option+3 on a US Mac layout, but Shift+3 on a UK layout.
+	poundMsg := tea.KeyPressMsg{Code: '£', Text: "£"}
+
+	o := &app.OS{Mode: app.TerminalMode, CurrentWorkspace: 1}
+	handled := handleWorkspaceSwitch(poundMsg, o)
+	if handled != runtimeIsDarwin() {
+		t.Errorf("handleWorkspaceSwitch(£) = %v, want %v on GOOS-gated path", handled, runtimeIsDarwin())
+	}
+
+	// ⇥ is Option+Tab on macOS, but an ordinary glyph elsewhere.
+	tabMsg := tea.KeyPressMsg{Code: '⇥', Text: "⇥"}
+	o2 := &app.OS{Mode: app.TerminalMode}
+	handledCycle := handleWindowCycle(tabMsg, o2)
+	if handledCycle != runtimeIsDarwin() {
+		t.Errorf("handleWindowCycle(⇥) = %v, want %v on GOOS-gated path", handledCycle, runtimeIsDarwin())
+	}
+
+	// The pure lookup helper must remain platform-independent so it stays testable.
+	if digit, ok := IsMacOSOptionKey('£'); !ok || digit != 3 {
+		t.Errorf("IsMacOSOptionKey(£) = (%d, %v), want (3, true)", digit, ok)
+	}
+}

--- a/internal/input/keyboard_test.go
+++ b/internal/input/keyboard_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/tape"
 )
 
 // TestTransitionGuardCondition directly tests the guard condition that suppresses
@@ -229,5 +230,56 @@ func TestMacOSOptionKeysGatedToDarwin(t *testing.T) {
 	// The pure lookup helper must remain platform-independent so it stays testable.
 	if digit, ok := IsMacOSOptionKey('£'); !ok || digit != 3 {
 		t.Errorf("IsMacOSOptionKey(£) = (%d, %v), want (3, true)", digit, ok)
+	}
+}
+
+// TestTerminalPrefixChordNotRecorded verifies that prefix chords in terminal
+// mode are not captured into a tape recording. Previously the leader key and
+// its following command key were recorded before prefix routing, so a
+// ctrl+b <cmd> chord replayed a stray 0x02 and command character into the shell.
+func TestTerminalPrefixChordNotRecorded(t *testing.T) {
+	rec := tape.NewRecorder()
+	rec.Start()
+	o := &app.OS{Mode: app.TerminalMode, TapeRecorder: rec}
+
+	// ctrl+b activates prefix mode and must not be recorded.
+	ctrlB := tea.KeyPressMsg{Code: 'b', Mod: tea.ModCtrl}
+	HandleTerminalModeKey(ctrlB, o)
+	if !o.PrefixActive {
+		t.Fatal("ctrl+b should activate prefix mode")
+	}
+
+	// The following prefix command key routes to the prefix dispatcher, not the
+	// PTY, and must not be recorded either.
+	esc := tea.KeyPressMsg{Code: tea.KeyEscape}
+	HandleTerminalModeKey(esc, o)
+
+	if got := rec.CommandCount(); got != 0 {
+		t.Errorf("prefix chord recorded %d commands, want 0: %+v", got, rec.GetCommands())
+	}
+}
+
+// TestRecordTerminalKeyClassification verifies that keys forwarded to the PTY
+// are classified correctly: printable ASCII accumulates as a Type command while
+// special keys are recorded as KeyCombos (and flush any pending typed text).
+func TestRecordTerminalKeyClassification(t *testing.T) {
+	rec := tape.NewRecorder()
+	rec.Start()
+	o := &app.OS{TapeRecorder: rec}
+
+	recordTerminalKey(o, tea.KeyPressMsg{Code: 'l', Text: "l"})
+	recordTerminalKey(o, tea.KeyPressMsg{Code: 's', Text: "s"})
+	recordTerminalKey(o, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	cmds := rec.GetCommands()
+	// "ls" accumulates into one Type command, flushed by the Enter KeyCombo.
+	if len(cmds) != 2 {
+		t.Fatalf("got %d commands, want 2: %+v", len(cmds), cmds)
+	}
+	if cmds[0].Type != tape.CommandTypeType || len(cmds[0].Args) == 0 || cmds[0].Args[0] != "ls" {
+		t.Errorf("first command = %+v, want Type \"ls\"", cmds[0])
+	}
+	if cmds[1].Type != tape.CommandTypeEnter {
+		t.Errorf("second command = %+v, want Enter", cmds[1])
 	}
 }

--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -342,25 +342,31 @@ func registerMultiClientHandlers(m *app.OS, client *session.TUIClient) {
 		}
 	})
 
-	// Handle session resize (min of all clients)
+	// Handle session resize (min of all clients). The callback runs on the daemon
+	// read-loop goroutine, so the actual geometry mutation (TileAllWindows,
+	// emulator resizes) must happen in Update; route it through the event channel.
 	client.OnSessionResize(func(width, height, clientCount int) {
 		log.Printf("[SSH] Session resize: %dx%d (clients: %d)", width, height, clientCount)
-		// Update effective size to match the session size (min of all clients)
-		// This ensures all clients see the same content
-		if m.EffectiveWidth != width || m.EffectiveHeight != height {
-			m.EffectiveWidth = width
-			m.EffectiveHeight = height
-			m.MarkAllDirty()
-			if m.AutoTiling {
-				m.TileAllWindows()
+		if m.ClientEventChan != nil {
+			select {
+			case m.ClientEventChan <- app.ClientEvent{Type: "resize", ClientCount: clientCount, Width: width, Height: height}:
+			default:
+				log.Printf("[SSH] Warning: ClientEventChan full, dropping session resize event")
 			}
 		}
 	})
 
-	// Handle force refresh
+	// Handle force refresh (also on the read-loop goroutine; MarkAllDirty must run
+	// on the program goroutine).
 	client.OnForceRefresh(func(reason string) {
 		log.Printf("[SSH] Force refresh requested: %s", reason)
-		m.MarkAllDirty()
+		if m.ClientEventChan != nil {
+			select {
+			case m.ClientEventChan <- app.ClientEvent{Type: "refresh", Reason: reason}:
+			default:
+				log.Printf("[SSH] Warning: ClientEventChan full, dropping force refresh event")
+			}
+		}
 	})
 }
 

--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -38,6 +38,15 @@ var sshServerConfig *SSHServerConfig
 func StartSSHServer(ctx context.Context, cfg *SSHServerConfig) error {
 	sshServerConfig = cfg
 
+	// Apply the user config's appearance globals once, at server startup and
+	// single-threaded, so every per-connection session shares a consistent view
+	// of them. LoadUserConfig is pure and NewOS no longer re-applies per
+	// connection, so this replaces the old per-connection global writes that
+	// raced other sessions' render loops.
+	if userConfig, err := config.LoadUserConfig(); err == nil {
+		config.ApplyAppearanceConfig(userConfig)
+	}
+
 	// Determine host key path
 	var hostKeyPath string
 	if cfg.KeyPath != "" {
@@ -182,6 +191,7 @@ func createEphemeralTUIOSInstance(sshSession ssh.Session, width, height int) (te
 
 	tuiosInstance := app.NewOS(app.OSOptions{
 		KeybindRegistry: keybindRegistry,
+		UserConfig:      userConfig,
 		Width:           width,
 		Height:          height,
 		IsSSHMode:       true,
@@ -261,6 +271,7 @@ func createDaemonTUIOSInstance(sshSession ssh.Session, sessionName string, width
 	// Create TUIOS instance connected to daemon
 	tuiosInstance := app.NewOS(app.OSOptions{
 		KeybindRegistry:           keybindRegistry,
+		UserConfig:                userConfig,
 		Width:                     width,
 		Height:                    height,
 		IsSSHMode:                 true,

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -176,6 +176,18 @@ func (cs *connState) closeDone() {
 	cs.doneOnce.Do(func() { close(cs.done) })
 }
 
+// drop tears a client down after an unrecoverable send failure. A write that
+// fails mid-frame (e.g. a slow client hitting the write deadline) leaves a
+// partial frame on the wire and permanently desyncs framing, so the only
+// coherent recovery is to close done and the connection: that unblocks the read
+// loop, whose deferred cleanup then unsubscribes every PTY, removes the client,
+// and purges its pending requests. Safe to call from any goroutine and more than
+// once (closeDone is once-guarded and Close is idempotent).
+func (cs *connState) drop() {
+	cs.closeDone()
+	_ = cs.conn.Close()
+}
+
 func (d *Daemon) shutdown() error {
 	d.shutdownOnce.Do(func() {
 		log.Println("Shutting down daemon...")

--- a/internal/session/daemon_stream.go
+++ b/internal/session/daemon_stream.go
@@ -13,13 +13,23 @@ import (
 func (d *Daemon) streamPTYOutput(cs *connState, pty *PTY) {
 	outputCh := pty.Subscribe(cs.clientID)
 
+	// On any exit, stop receiving from the PTY and drop the subscription entry so
+	// the connState is left coherent: a later re-subscribe must not be blocked by
+	// a stale "already subscribed" guard (daemon_handlers.go), and no PTY keeps
+	// broadcasting into an unread channel.
+	defer func() {
+		pty.Unsubscribe(cs.clientID)
+		cs.mu.Lock()
+		delete(cs.ptySubscriptions, pty.ID)
+		cs.mu.Unlock()
+	}()
+
 	const maxBatch = 256 * 1024
 	batch := make([]byte, 0, maxBatch)
 
 	for {
 		select {
 		case <-cs.done:
-			pty.Unsubscribe(cs.clientID)
 			return
 		case <-d.ctx.Done():
 			return
@@ -45,10 +55,13 @@ func (d *Daemon) streamPTYOutput(cs *connState, pty *PTY) {
 			err := WritePTYOutput(cs.conn, pty.ID, batch)
 			cs.sendMu.Unlock()
 			if err != nil {
-				pty.Unsubscribe(cs.clientID)
+				// The write failed mid-frame (a slow/stuck client hitting the 5s
+				// deadline): the wire now carries a partial frame and every later
+				// send would append onto a desynced stream. Tear the whole client
+				// down rather than leaving it half-subscribed and desynced.
+				cs.drop()
 				return
 			}
-
 		}
 	}
 }
@@ -99,10 +112,16 @@ func (d *Daemon) sendMessage(cs *connState, msgType MessageType, payload any) er
 	}
 
 	cs.sendMu.Lock()
-	defer cs.sendMu.Unlock()
-
 	_ = cs.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-	return WriteMessageWithCodec(cs.conn, msg, cs.codec)
+	err = WriteMessageWithCodec(cs.conn, msg, cs.codec)
+	cs.sendMu.Unlock()
+	if err != nil {
+		// A mid-frame write failure permanently desyncs framing for this
+		// connection; drop the client so the read loop runs its full cleanup
+		// instead of appending later frames onto a corrupt stream.
+		cs.drop()
+	}
+	return err
 }
 
 func (d *Daemon) sendError(cs *connState, code int, message string) error {

--- a/internal/session/daemon_stream_test.go
+++ b/internal/session/daemon_stream_test.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// newFailingConnState returns a connState whose connection always fails writes,
+// simulating a slow/stuck client, plus the peer end (already closed).
+func newFailingConnState(t *testing.T) *connState {
+	t.Helper()
+	server, client := net.Pipe()
+	// Closing the read side makes every write on `client` fail immediately
+	// instead of blocking, standing in for a client that never drains.
+	_ = server.Close()
+	return &connState{
+		conn:             client,
+		clientID:         "test-client",
+		done:             make(chan struct{}),
+		codec:            DefaultCodec(),
+		ptySubscriptions: make(map[string]struct{}),
+	}
+}
+
+// TestSendMessageDropsClientOnWriteError verifies that a failed send tears the
+// client down (closes done) rather than leaving a desynced connection healthy.
+func TestSendMessageDropsClientOnWriteError(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{})
+	cs := newFailingConnState(t)
+
+	if err := d.sendMessage(cs, MsgPong, nil); err == nil {
+		t.Fatal("expected sendMessage to return a write error")
+	}
+
+	select {
+	case <-cs.done:
+		// Good: client dropped.
+	default:
+		t.Fatal("sendMessage did not drop the client (done not closed) on write error")
+	}
+}
+
+// TestStreamPTYOutputDropsOnWriteError verifies that when streaming to a stuck
+// client fails, streamPTYOutput tears the whole client down and leaves the
+// connState coherent: the subscription is removed and the PTY subscriber gone.
+func TestStreamPTYOutputDropsOnWriteError(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{})
+
+	pty := &PTY{
+		ID:          "ptytest-00000001",
+		subscribers: make(map[string]chan []byte),
+		// Pre-seed buffered output so Subscribe immediately delivers a chunk that
+		// streamPTYOutput will try (and fail) to write.
+		outputBuffer: []byte("hello world"),
+		outputPos:    len("hello world"),
+	}
+
+	cs := newFailingConnState(t)
+	cs.ptySubscriptions[pty.ID] = struct{}{}
+
+	go d.streamPTYOutput(cs, pty)
+
+	select {
+	case <-cs.done:
+		// Good: client dropped on write failure.
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamPTYOutput did not drop the client on write failure")
+	}
+
+	// The deferred cleanup (unsubscribe + drop subscription) runs after the
+	// goroutine returns, so poll until the connState is coherent.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		cs.mu.Lock()
+		_, stillSubscribed := cs.ptySubscriptions[pty.ID]
+		cs.mu.Unlock()
+
+		pty.subscribersMu.RLock()
+		_, stillBroadcasting := pty.subscribers[cs.clientID]
+		pty.subscribersMu.RUnlock()
+
+		if !stillSubscribed && !stillBroadcasting {
+			break
+		}
+		if time.Now().After(deadline) {
+			if stillSubscribed {
+				t.Fatal("ptyID was not removed from ptySubscriptions on exit")
+			}
+			t.Fatal("PTY subscriber was not removed on streamPTYOutput exit")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/session/tuiclient.go
+++ b/internal/session/tuiclient.go
@@ -28,6 +28,11 @@ type ClientLeftHandler func(clientID string, clientCount int)
 type SessionResizeHandler func(width, height, clientCount int)
 type ForceRefreshHandler func(reason string)
 
+// DisconnectHandler is called once when the read loop tears the connection down
+// because of an unexpected disconnect (daemon crash, reset, or framing desync).
+// It is not called for an app-initiated Close.
+type DisconnectHandler func(err error)
+
 // TUIClient is used by the TUIOS TUI to communicate with the daemon.
 // It handles PTY I/O and state synchronization.
 type TUIClient struct {
@@ -67,6 +72,8 @@ type TUIClient struct {
 	clientLeftHandler    ClientLeftHandler
 	sessionResizeHandler SessionResizeHandler
 	forceRefreshHandler  ForceRefreshHandler
+	disconnectHandler    DisconnectHandler
+	disconnectOnce       sync.Once // gates the single disconnect notification
 	multiClientMu        sync.RWMutex
 
 	// Request/response handling for synchronous calls after readLoop starts
@@ -451,6 +458,37 @@ func (c *TUIClient) OnForceRefresh(handler ForceRefreshHandler) {
 	c.multiClientMu.Unlock()
 }
 
+// OnDisconnect registers a handler invoked when the daemon connection is torn
+// down unexpectedly (crash, reset, or framing desync). It fires at most once and
+// runs on the read-loop goroutine, so the handler should only signal the UI
+// (e.g. p.Send), never mutate model state directly.
+func (c *TUIClient) OnDisconnect(handler DisconnectHandler) {
+	c.multiClientMu.Lock()
+	c.disconnectHandler = handler
+	c.multiClientMu.Unlock()
+}
+
+// handleDisconnect tears the connection down and notifies the app exactly once.
+// If Close was already called by the app, the disconnect is expected teardown
+// and no notification fires.
+func (c *TUIClient) handleDisconnect(err error) {
+	select {
+	case <-c.done:
+		// App-initiated Close already ran; stay quiet.
+		return
+	default:
+	}
+	_ = c.Close() // closes done + conn, idempotent
+	c.disconnectOnce.Do(func() {
+		c.multiClientMu.RLock()
+		handler := c.disconnectHandler
+		c.multiClientMu.RUnlock()
+		if handler != nil {
+			handler(err)
+		}
+	})
+}
+
 // SendWindowList sends a window list response back to the daemon.
 func (c *TUIClient) SendWindowList(payload *WindowListPayload) error {
 	msg, err := NewMessageWithCodec(MsgWindowList, payload, c.codec)
@@ -628,12 +666,22 @@ func (c *TUIClient) readLoop() {
 		if err != nil {
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
+				// Deadline hit at a message boundary; loop to re-check c.done.
 				continue
 			}
 			if errors.Is(err, io.EOF) {
+				// Clean daemon-side close.
+				c.handleDisconnect(err)
 				return
 			}
-			continue
+			// Any other error is fatal and non-recoverable: a daemon crash
+			// (ECONNRESET) or a framing desync ("message too large" leaves the
+			// payload in the stream) makes every subsequent read fail instantly.
+			// Continuing would busy-loop at 100% CPU forever, so tear the
+			// connection down and surface a clean disconnect instead.
+			debugLog("[CLIENT] readLoop fatal error, disconnecting: %v", err)
+			c.handleDisconnect(err)
+			return
 		}
 
 		// Check if there's a pending response channel for this message type

--- a/internal/session/tuiclient_disconnect_test.go
+++ b/internal/session/tuiclient_disconnect_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// newTestTUIClient builds a TUIClient wired to one end of an in-memory pipe so
+// the read loop can be exercised without a real daemon.
+func newTestTUIClient(conn net.Conn) *TUIClient {
+	c := NewTUIClient()
+	c.conn = conn
+	return c
+}
+
+// TestReadLoopDisconnectFiresHandler verifies that when the daemon side closes
+// the connection unexpectedly, the read loop tears down and fires the disconnect
+// handler exactly once instead of busy-looping.
+func TestReadLoopDisconnectFiresHandler(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	c := newTestTUIClient(client)
+
+	fired := make(chan error, 4)
+	c.OnDisconnect(func(err error) {
+		fired <- err
+	})
+
+	c.StartReadLoop()
+
+	// Simulate an unexpected daemon-side close.
+	_ = server.Close()
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("disconnect handler did not fire after daemon close")
+	}
+
+	// done must be closed so pending callers unblock.
+	select {
+	case <-c.done:
+	default:
+		t.Fatal("c.done was not closed on disconnect")
+	}
+
+	// Handler must fire at most once.
+	select {
+	case <-fired:
+		t.Fatal("disconnect handler fired more than once")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestReadLoopAppCloseNoDisconnect verifies that an app-initiated Close is
+// treated as expected teardown and does NOT fire the disconnect handler.
+func TestReadLoopAppCloseNoDisconnect(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	c := newTestTUIClient(client)
+
+	fired := make(chan error, 1)
+	c.OnDisconnect(func(err error) {
+		fired <- err
+	})
+
+	c.StartReadLoop()
+
+	// App-initiated close: closes done then conn.
+	_ = c.Close()
+
+	select {
+	case <-fired:
+		t.Fatal("disconnect handler fired on app-initiated Close")
+	case <-time.After(300 * time.Millisecond):
+		// Good: no spurious disconnect notification.
+	}
+}

--- a/internal/tape/executor.go
+++ b/internal/tape/executor.go
@@ -292,11 +292,12 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 			return ce.executor.SendToWindow(ce.executor.GetFocusedWindowID(), keyBytes)
 		}
 
-	case CommandTypeWaitUntilRegex:
-		// WaitUntilRegex requires special handling - it needs to be processed in a different way
-		// by the script playback system since it requires checking PTY output
-		// For now, we return a special error to signal this to the playback system
-		// The actual implementation will be handled in the playback loop
+	case CommandTypeWait, CommandTypeWaitUntilRegex:
+		// Wait (a Sleep alias) and WaitUntilRegex are handled by the interactive
+		// playback loop (internal/app/update.go), which needs to block across
+		// ticks while checking timers and screen contents. They are intentionally
+		// no-ops here so the remote/daemon exec path (which is fire-and-forget)
+		// simply skips them.
 		return nil
 
 	case CommandTypeEnableAnimations:

--- a/internal/tape/parser.go
+++ b/internal/tape/parser.go
@@ -509,7 +509,8 @@ func (p *Parser) parseWindowRenameCommand() (Command, bool) {
 	return cmd, true
 }
 
-// parseWaitCommand parses Wait commands (for future use)
+// parseWaitCommand parses Wait <duration> commands. Wait is an alias for Sleep:
+// it delays playback for the given duration.
 func (p *Parser) parseWaitCommand() (Command, bool) {
 	cmd := Command{
 		Type:   CommandTypeWait,
@@ -519,10 +520,23 @@ func (p *Parser) parseWaitCommand() (Command, bool) {
 
 	p.nextToken() // consume Wait
 
-	// Collect all arguments until newline
-	for p.curTok.Type != TokenNewline && p.curTok.Type != TokenEOF {
-		cmd.Args = append(cmd.Args, p.curTok.Literal)
+	if p.curTok.Type == TokenDuration {
+		duration, err := ParseDuration(p.curTok.Literal)
+		if err != nil {
+			p.addError(fmt.Sprintf("invalid duration: %s", p.curTok.Literal))
+		}
+		cmd.Args = []string{p.curTok.Literal}
+		cmd.Delay = duration
+		cmd.Raw = fmt.Sprintf("Wait %s", p.curTok.Literal)
 		p.nextToken()
+	} else {
+		p.addError(fmt.Sprintf("Wait command expects a duration, got %v", p.curTok.Type))
+		p.skipToNextLine()
+		return cmd, false
+	}
+
+	if p.curTok.Type != TokenNewline && p.curTok.Type != TokenEOF {
+		p.skipToNextLine()
 	}
 
 	return cmd, true

--- a/internal/tape/parser_test.go
+++ b/internal/tape/parser_test.go
@@ -131,6 +131,55 @@ func TestParserSleepCommand(t *testing.T) {
 	}
 }
 
+func TestParserWaitAliasesSleep(t *testing.T) {
+	commands, errors := ParseFile("Wait 750ms")
+	if len(errors) != 0 {
+		t.Fatalf("Unexpected parse errors: %v", errors)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("Expected 1 command, got %d", len(commands))
+	}
+	cmd := commands[0]
+	if cmd.Type != CommandTypeWait {
+		t.Errorf("Expected CommandTypeWait, got %v", cmd.Type)
+	}
+	if cmd.Delay != 750*time.Millisecond {
+		t.Errorf("Expected delay 750ms, got %v", cmd.Delay)
+	}
+
+	// Wait without a duration is an error.
+	_, errors = ParseFile("Wait")
+	if len(errors) == 0 {
+		t.Error("Expected an error for Wait without a duration")
+	}
+}
+
+func TestParserWaitUntilRegex(t *testing.T) {
+	commands, errors := ParseFile(`WaitUntilRegex "\$" 3000`)
+	if len(errors) != 0 {
+		t.Fatalf("Unexpected parse errors: %v", errors)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("Expected 1 command, got %d", len(commands))
+	}
+	cmd := commands[0]
+	if cmd.Type != CommandTypeWaitUntilRegex {
+		t.Errorf("Expected CommandTypeWaitUntilRegex, got %v", cmd.Type)
+	}
+	if len(cmd.Args) != 2 || cmd.Args[0] != `$` || cmd.Args[1] != "3000" {
+		t.Errorf("Unexpected args: %v", cmd.Args)
+	}
+
+	// Default timeout: no numeric arg.
+	commands, errors = ParseFile(`WaitUntilRegex "done"`)
+	if len(errors) != 0 {
+		t.Fatalf("Unexpected parse errors: %v", errors)
+	}
+	if len(commands) != 1 || len(commands[0].Args) != 1 || commands[0].Args[0] != "done" {
+		t.Errorf("Unexpected parse result: %+v", commands)
+	}
+}
+
 func TestParserKeyCombo(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/terminal/update_theme_colors_test.go
+++ b/internal/terminal/update_theme_colors_test.go
@@ -1,0 +1,42 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// TestUpdateThemeColors_InvalidatesCache verifies that pushing a new theme into
+// a window drops the cached render (both the content string and the styled
+// layer) and marks the window dirty, so the next render repaints with the new
+// palette instead of returning the stale cache.
+func TestUpdateThemeColors_InvalidatesCache(t *testing.T) {
+	w := &Window{
+		Terminal:      vt.NewEmulator(80, 24),
+		CachedContent: "stale content",
+		Dirty:         false,
+		ContentDirty:  false,
+	}
+
+	w.UpdateThemeColors()
+
+	if w.CachedContent != "" {
+		t.Errorf("CachedContent should be cleared after theme change, got %q", w.CachedContent)
+	}
+	if w.CachedLayer != nil {
+		t.Error("CachedLayer should be nil after theme change")
+	}
+	if !w.Dirty || !w.ContentDirty {
+		t.Error("window should be marked Dirty and ContentDirty after theme change")
+	}
+}
+
+// TestUpdateThemeColors_NilTerminal makes sure a theme change on a window that
+// is being torn down (Terminal already nil) does not panic on the UI goroutine.
+func TestUpdateThemeColors_NilTerminal(t *testing.T) {
+	w := &Window{CachedContent: "stale"}
+	w.UpdateThemeColors()
+	if w.CachedContent != "" {
+		t.Errorf("CachedContent should still be cleared with a nil Terminal, got %q", w.CachedContent)
+	}
+}

--- a/internal/terminal/window.go
+++ b/internal/terminal/window.go
@@ -227,6 +227,15 @@ type Window struct {
 	// Used by MarkTerminalsWithNewContent to avoid unconditional dirty-marking.
 	HasNewOutput atomic.Bool
 
+	// coalesceSignal is the daemon renderCoalescer's own render-trigger flag.
+	// outputWriter sets it after each batch; renderCoalescer consumes it at a
+	// capped rate to fire PTYDataChan. It is separate from HasNewOutput so the
+	// coalescer no longer consumes that flag: HasNewOutput survives for the UI
+	// goroutine's MarkTerminalsWithNewContent, which does the dirty-marking.
+	// This keeps window model fields (Dirty/ContentDirty/CachedContent) off the
+	// background goroutine, which otherwise races the renderer and Close().
+	coalesceSignal atomic.Bool
+
 	// PTYDataChan is a shared channel (buffered 1) that PTY readers signal
 	// to trigger rendering. Non-blocking send coalesces rapid updates.
 	PTYDataChan chan struct{}

--- a/internal/terminal/window_diff.go
+++ b/internal/terminal/window_diff.go
@@ -79,8 +79,13 @@ func unpackDiffAttrs(attrs uint16) uint8 {
 	return uint8(attrs & 0xFF)
 }
 
-// UpdateThemeColors updates the terminal colors when the theme changes
+// UpdateThemeColors pushes the active theme's palette into the emulator so
+// already-rendered SGR indexed colors resolve to the new theme on the next
+// render. SetThemeColors mutates the emulator's color table, which the PTY
+// reader goroutine reads under ioMu inside Terminal.Write, so it is taken here
+// (this runs on the UI goroutine) to avoid a torn interface-value read.
 func (w *Window) UpdateThemeColors() {
+	w.ioMu.Lock()
 	if w.Terminal != nil {
 		if theme.IsEnabled() {
 			w.Terminal.SetThemeColors(
@@ -92,8 +97,12 @@ func (w *Window) UpdateThemeColors() {
 		} else {
 			w.Terminal.SetThemeColors(nil, nil, nil, [16]color.Color{})
 		}
-		// Mark the window as dirty to trigger a redraw
-		w.Dirty = true
-		w.ContentDirty = true
 	}
+	w.ioMu.Unlock()
+
+	// Mark dirty and drop the cached render: the palette changed, so both the
+	// cached content string and the cached styled layer are stale.
+	w.Dirty = true
+	w.ContentDirty = true
+	w.InvalidateCache()
 }

--- a/internal/terminal/window_io.go
+++ b/internal/terminal/window_io.go
@@ -25,6 +25,12 @@ import (
 // the same technique prise uses (8ms render timer) to eliminate flicker
 // from fast-updating TUIs.
 func (w *Window) outputWriter() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("window %s outputWriter panic: %v\n%s", w.ID, r, debug.Stack())
+		}
+	}()
+
 	if w.outputDone == nil || w.outputChan == nil {
 		return
 	}
@@ -56,11 +62,17 @@ func (w *Window) outputWriter() {
 		}
 
 	write:
-		if w.Terminal != nil {
-			w.ioMu.Lock()
-			_, _ = w.Terminal.Write(batch)
-			w.ioMu.Unlock()
+		// Snapshot and dereference Terminal entirely under ioMu: Close()
+		// nils the field under the same lock, so an unlocked check-then-use
+		// would panic once teardown races an in-flight batch.
+		w.ioMu.Lock()
+		t := w.Terminal
+		if t != nil {
+			_, _ = t.Write(batch)
+		}
+		w.ioMu.Unlock()
 
+		if t != nil {
 			w.HasNewOutput.Store(true)
 			w.MarkContentDirty()
 			// Don't signal PTYDataChan here. The renderCoalescer
@@ -108,11 +120,25 @@ func (w *Window) StartDaemonResponseReader() {
 	}
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("window %s daemon response reader panic: %v\n%s", w.ID, r, debug.Stack())
+			}
+		}()
+
+		// Snapshot Terminal once. Re-reading w.Terminal each iteration would
+		// race Close(), which nils the field under ioMu and dereferences nil.
+		// Terminal.Close() unblocks the pending Read with EOF, so the loop
+		// still exits promptly on teardown.
+		term := w.Terminal
+		if term == nil {
+			return
+		}
 		buf := make([]byte, 4096)
 		for {
 			// Terminal.Read() blocks, so we can't use select here.
 			// The goroutine will exit when Terminal is closed (returns error).
-			_, err := w.Terminal.Read(buf)
+			_, err := term.Read(buf)
 			if err != nil {
 				return
 			}
@@ -124,26 +150,38 @@ func (w *Window) StartDaemonResponseReader() {
 // WriteOutput writes output data to the terminal emulator.
 // Used in daemon mode to process PTY output received from the daemon.
 func (w *Window) WriteOutput(data []byte) {
-	if w.Terminal != nil {
-		w.HasNewOutput.Store(true)
-		if w.PTYDataChan != nil {
-			select {
-			case w.PTYDataChan <- struct{}{}:
-			default:
-			}
-		}
-		w.ioMu.Lock()
-		_, _ = w.Terminal.Write(data)
-		w.ioMu.Unlock()
-		w.MarkContentDirty()
+	// Snapshot and write under ioMu so Close() nilling w.Terminal cannot
+	// slip between the check and the dereference.
+	w.ioMu.Lock()
+	t := w.Terminal
+	if t != nil {
+		_, _ = t.Write(data)
 	}
+	w.ioMu.Unlock()
+
+	if t == nil {
+		return
+	}
+	w.HasNewOutput.Store(true)
+	if w.PTYDataChan != nil {
+		select {
+		case w.PTYDataChan <- struct{}{}:
+		default:
+		}
+	}
+	w.MarkContentDirty()
 }
 
 // WriteOutputAsync writes output data to the terminal emulator without blocking.
 // Used in daemon mode to process PTY output received from the daemon.
 // Data is queued to a channel and written in order by the outputWriter goroutine.
 func (w *Window) WriteOutputAsync(data []byte) {
-	if w.Terminal == nil || w.outputChan == nil {
+	// outputChan is set once at construction and never nilled, so reading it
+	// here is safe. w.Terminal must NOT be read: Close() nils it under ioMu,
+	// so an unlocked read would race teardown. The closed flag below is the
+	// real lifecycle guard, and outputWriter drops the batch under ioMu if
+	// Terminal is already gone.
+	if w.outputChan == nil {
 		return
 	}
 	// Close() runs on the UI goroutine while this runs on the daemon readLoop
@@ -209,18 +247,26 @@ func (w *Window) handleIOOperations() {
 		bufPtr := pool.GetByteSlice()
 		buf := *bufPtr
 		defer pool.PutByteSlice(bufPtr)
+
+		// Snapshot the PTY once under the lock. Close() nils w.Pty under
+		// ioMu; re-reading the interface value each iteration without the
+		// lock is a torn read (undefined behaviour) and calling Read on a
+		// nilled interface panics. Pty.Close() unblocks the pending Read,
+		// so the snapshot still tears down promptly. The sibling
+		// Terminal->PTY goroutine below uses the same discipline.
+		w.ioMu.RLock()
+		pty := w.Pty
+		w.ioMu.RUnlock()
+		if pty == nil {
+			return
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				// Context cancelled, exit gracefully
 				return
 			default:
-				// Set a reasonable timeout for read operations
-				if w.Pty == nil {
-					return
-				}
-
-				n, err := w.Pty.Read(buf)
+				n, err := pty.Read(buf)
 				if err != nil {
 					if err != io.EOF && !strings.Contains(err.Error(), "file already closed") &&
 						!strings.Contains(err.Error(), "input/output error") {
@@ -446,17 +492,24 @@ func (w *Window) Close() {
 
 	// Mark closed before touching outputChan so the external sender
 	// (WriteOutputAsync on the daemon readLoop goroutine) stops queuing.
-	w.closed.Store(true)
+	// CompareAndSwap makes Close idempotent: a second (or concurrent) call
+	// returns early instead of double-closing outputDone below.
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 
 	// Disable terminal features before closing
 	w.disableTerminalFeatures()
 
 	// Stop daemon output writer goroutine if running. outputChan has an
 	// external sender (WriteOutputAsync), so it is never closed; closing
-	// outputDone stops outputWriter, which selects on it.
+	// outputDone stops outputWriter and renderCoalescer, which select on it.
+	// The field is deliberately NOT nilled: both goroutines re-read it on
+	// every select iteration, and a nil channel blocks forever (leaking the
+	// goroutines, the 8ms ticker, and the whole Window/Emulator). The CAS
+	// above guarantees this close runs exactly once.
 	if w.outputDone != nil {
 		close(w.outputDone)
-		w.outputDone = nil
 	}
 
 	// Cancel all goroutines first

--- a/internal/terminal/window_io.go
+++ b/internal/terminal/window_io.go
@@ -73,10 +73,17 @@ func (w *Window) outputWriter() {
 		w.ioMu.Unlock()
 
 		if t != nil {
+			// HasNewOutput drives the UI goroutine's dirty-marking;
+			// coalesceSignal drives the render trigger. Do NOT mark the
+			// window dirty here: Dirty/ContentDirty/CachedContent are
+			// window model fields owned by the UI goroutine, and writing
+			// them from this background goroutine races the renderer and
+			// Close(). MarkTerminalsWithNewContent marks them on the UI
+			// goroutine once the coalescer fires PTYDataChan.
 			w.HasNewOutput.Store(true)
-			w.MarkContentDirty()
+			w.coalesceSignal.Store(true)
 			// Don't signal PTYDataChan here. The renderCoalescer
-			// goroutine checks HasNewOutput at a capped rate and
+			// goroutine checks coalesceSignal at a capped rate and
 			// signals then. This prevents partial-frame renders.
 		}
 	}
@@ -95,7 +102,9 @@ func (w *Window) renderCoalescer() {
 		case <-w.outputDone:
 			return
 		case <-ticker.C:
-			if w.HasNewOutput.CompareAndSwap(true, false) {
+			// Consume the coalescer's own flag, not HasNewOutput, so the
+			// latter survives for the UI goroutine's MarkTerminalsWithNewContent.
+			if w.coalesceSignal.CompareAndSwap(true, false) {
 				if w.PTYDataChan != nil {
 					select {
 					case w.PTYDataChan <- struct{}{}:

--- a/internal/terminal/window_io_race_test.go
+++ b/internal/terminal/window_io_race_test.go
@@ -1,0 +1,67 @@
+package terminal
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestDaemonWindowCloseUnderOutputFlood is a race-detector regression test for
+// the window teardown races in window_io.go: Close() closing outputDone while
+// outputWriter/renderCoalescer select on it, and the unlocked w.Terminal /
+// w.Pty dereferences in the reader goroutines that panicked after Close nilled
+// the fields. It opens a daemon window (which starts outputWriter and
+// renderCoalescer), floods it with output from several goroutines, and closes
+// it concurrently. Run with -race to detect torn field access; a passing run
+// also proves Close is panic-free and idempotent under load.
+func TestDaemonWindowCloseUnderOutputFlood(t *testing.T) {
+	ptyDataChan := make(chan struct{}, 1)
+
+	// Drain the render signal channel so renderCoalescer's non-blocking sends
+	// never matter, mirroring the UI goroutine on the real path.
+	drainDone := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ptyDataChan:
+			case <-drainDone:
+				return
+			}
+		}
+	}()
+	defer close(drainDone)
+
+	w := NewDaemonWindow("race-window-0001", "race", 0, 0, 80, 24, 0, "pty-race-0001", ptyDataChan)
+
+	var wg sync.WaitGroup
+
+	// Flood output from several goroutines, as the daemon readLoop does.
+	const floodGoroutines = 8
+	payload := []byte("hello world \x1b[31mcolored\x1b[0m output line\r\n")
+	for i := 0; i < floodGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 2000; j++ {
+				w.WriteOutputAsync(payload)
+			}
+		}()
+	}
+
+	// Close concurrently with the flood, from two goroutines to also exercise
+	// the idempotent double-close guard.
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		w.Close()
+	}()
+
+	wg.Wait()
+
+	// A post-teardown write must be a no-op, not a panic.
+	w.WriteOutputAsync(payload)
+	w.WriteOutput(payload)
+}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -46,14 +46,14 @@ func Initialize(themeName string) error {
 	}
 
 	enabled = true
-	tint.NewDefaultRegistry()
 
-	// Load custom themes from user's themes directory
-	if themesDir, err := GetThemesDir(); err == nil {
-		if _, err := LoadCustomThemes(themesDir); err != nil {
-			log.Printf("Warning: error loading custom themes: %v", err)
-		}
-	}
+	// Build the tint registry (built-ins plus custom themes) exactly once for
+	// the process, via the same sync.Once EnsureRegistry uses. Calling
+	// tint.NewDefaultRegistry() directly here would let a later EnsureRegistry()
+	// (fired when the settings page or theme picker first opens) rebuild the
+	// global registry and reset the active tint to the library default,
+	// silently discarding the configured theme.
+	EnsureRegistry()
 
 	// Try to set the theme by ID. An unknown name leaves the registry on its
 	// current tint; warn so a typo is visible instead of silently applying the

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -59,6 +59,29 @@ func TestCurrent(t *testing.T) {
 	}
 }
 
+// TestInitialize_RegistryEnsuredKeepsTheme is a regression test for the bug
+// where opening the settings page or theme picker (which call EnsureRegistry)
+// rebuilt the tint registry and reset the configured theme to the bubbletint
+// default (dracula_plus). Initialize must build the registry through the same
+// sync.Once EnsureRegistry uses, so a later EnsureRegistry() is a no-op and
+// leaves the active theme untouched.
+func TestInitialize_RegistryEnsuredKeepsTheme(t *testing.T) {
+	if err := Initialize("nord"); err != nil {
+		t.Fatalf("Initialize error: %v", err)
+	}
+	before := CurrentThemeID()
+	if before != "nord" {
+		t.Fatalf("expected active theme %q after Initialize, got %q", "nord", before)
+	}
+
+	// Simulate opening the settings page / theme picker.
+	EnsureRegistry()
+
+	if after := CurrentThemeID(); after != before {
+		t.Fatalf("EnsureRegistry reset the active theme: before=%q after=%q", before, after)
+	}
+}
+
 // TestGetANSIPalette tests ANSI palette retrieval
 func TestGetANSIPalette(t *testing.T) {
 	// Test with disabled theme (fallback colors)

--- a/internal/vt/emulator.go
+++ b/internal/vt/emulator.go
@@ -739,7 +739,7 @@ func (e *Emulator) Write(p []byte) (n int, err error) {
 
 // WriteString writes a string to the terminal output buffer.
 func (e *Emulator) WriteString(s string) (n int, err error) {
-	return io.WriteString(e, s) //nolint:wrapcheck
+	return e.Write([]byte(s)) //nolint:wrapcheck
 }
 
 // InputPipe returns the terminal's input pipe.

--- a/internal/vt/emulator_test.go
+++ b/internal/vt/emulator_test.go
@@ -56,6 +56,28 @@ func TestEmulator_PlainText(t *testing.T) {
 	}
 }
 
+// TestEmulator_WriteString verifies that WriteString writes through to the
+// terminal without recursing into itself. Previously WriteString delegated
+// to io.WriteString(e, s), which detects that *Emulator implements
+// io.StringWriter and calls e.WriteString again, causing infinite recursion
+// and a stack overflow.
+func TestEmulator_WriteString(t *testing.T) {
+	emu := vt.NewEmulator(80, 24)
+
+	n, err := emu.WriteString("Hello, World!")
+	if err != nil {
+		t.Fatalf("WriteString failed: %v", err)
+	}
+	if n != len("Hello, World!") {
+		t.Errorf("Expected n=%d, got %d", len("Hello, World!"), n)
+	}
+
+	got := emu.String()
+	if !strings.Contains(got, "Hello, World!") {
+		t.Errorf("Expected output to contain %q, got %q", "Hello, World!", got)
+	}
+}
+
 // =============================================================================
 // Cursor Movement Tests
 // =============================================================================

--- a/pkg/tuios/tuios.go
+++ b/pkg/tuios/tuios.go
@@ -287,12 +287,18 @@ func newModel(options Options) *Model {
 		}
 	}
 
+	// LoadUserConfig no longer applies the appearance globals itself, so apply
+	// them here (after the embed options above) exactly once, and pass the
+	// config into NewOS so it does not re-load and re-apply.
+	config.ApplyAppearanceConfig(userConfig)
+
 	// Create keybind registry
 	keybindRegistry := config.NewKeybindRegistry(userConfig)
 
 	// Create the model using the factory function
 	return app.NewOS(app.OSOptions{
 		KeybindRegistry: keybindRegistry,
+		UserConfig:      userConfig,
 		ShowKeys:        options.ShowKeys,
 		NumWorkspaces:   options.Workspaces,
 		Width:           options.Width,


### PR DESCRIPTION
This is the first of four stacked branches. It targets `feat/overlay-ui`, which is its direct ancestor. Review this one first; each later PR targets the branch before it so the diffs stay scoped.

## What changed and why

Correctness work across window teardown, the daemon's multi-client paths, config and theme handling, graphics placement, and input, plus a set of open issue fixes.

**Window and terminal lifecycle**

- Window teardown dereferenced fields that a concurrent close could already have nil'd, and leaked goroutines and PTYs on some paths. Teardown is now guarded and releases what it owns.
- `outputWriter` called `MarkContentDirty()` from a background goroutine while the UI goroutine read and wrote the same window model fields, a real data race on a multi-word string header. `renderCoalescer` now owns a separate `coalesceSignal` flag so it stops consuming `HasNewOutput`, and dirty-marking happens on the UI goroutine.
- `vt.WriteString` recursed into itself, so a sufficiently long or well-shaped write could run the stack out. Fixed with a regression test.

**Daemon and multi-client**

- Slow clients desynced the output stream instead of being dropped. They are now dropped cleanly.
- The TUI client busy-looped on daemon disconnect.
- Multi-client resize and refresh bypassed the event loop and mutated shared state from the wrong goroutine. Both are routed through the event loop now.

**Config and theme**

- Config loading had side effects, so it could clobber CLI flags and race with concurrent readers. Loading is pure now and the caller applies the result.
- The settings page and the theme picker reset the configured theme on open. Live theme changes also failed to reach already-running emulators.

**Graphics and layout**

- Sixel viewport math was wrong once scrollback grew, so images drifted or vanished.
- Kitty placements were destroyed on minimize and workspace switch rather than hidden, so images did not come back. `forwardPlace` tracking is now keyed by host id, and the echoed-response heuristic is tightened to wire text.
- Workspace switches overwrote BSP layouts with master-stack positions and left both workspaces permanently marked custom, which disabled the retile check.

**Input**

- The macOS Option-key lookup tables were consulted on every platform, so ordinary characters on non-US layouts (UK `£`, Nordic `§`, AZERTY accented letters) were swallowed as shortcuts and never reached the shell. Both call sites are now gated on `runtime.GOOS == "darwin"`.
- Tape keystrokes are recorded at the PTY-forward point so recordings match what the shell actually received.
- Darwin CPU sampling was blocking the UI goroutine.

## Behavior changes to be aware of

- Unfocused daemon-window output now follows the same coalesced frame-skip cadence as local windows. Background daemon windows repaint less often than before. This is deliberate and is what the local PTY path has always done.
- BSP and scrolling workspace switches tile instantly. The slide animation on those switches is gone, because the animation path was the thing overwriting the tiled layout.

## Issues

Closes #55, by adding the `Wait` and `WaitUntilRegex` tape playback commands so tapes can wait on a state or an animation instead of guessing with `sleep`.
Closes #86, by pointing the `tuios-web` install instructions at the brew tap.

Three other issues in this area are already fixed on the base branch rather than in this diff, so I have not put closing keywords on them here. Noting them so they are not lost: #51 and #89 are both fixed by `b5d8d88` (plain Ctrl+V goes to the PTY, and the key normalizer accepts multi-byte keys such as `é`), and #88 is fixed by the existing `TUIOS_WINDOW_ID` export. None of those three are on `main` yet, so they close when `feat/overlay-ui` lands, not when this does.

This branch also carries the teardown nil-dereference guards that cover the recurring panic reported in #19. That trace comes in through the render path during teardown, and the guards address it, but since the report is a single stack from an older build I would rather leave #19 open until a reporter confirms.

## Verification

- `go build ./...` and `go vet ./...` clean on this branch.
- `staticcheck ./...`, the full `go test -race -count=1 ./...` suite, and the `-tags e2e` suite were run green on the tip of the four-branch stack, 17 packages, no failures.
- The daemon dirty-marking fix has a dedicated race-detector regression test that floods a daemon window from several goroutines while closing it concurrently.
