### PR TITLE
feat(session): restore sessions on daemon start

### DIFF
--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -413,6 +413,35 @@ This will close all windows in the session and disconnect any attached clients.`
 		},
 	}
 
+	resurrectCmd := &cobra.Command{
+		Use:   "resurrect [session-name]",
+		Short: "Restore a previously saved session",
+		Long: `Restore a session that was saved before a daemon restart, crash, or reboot.
+
+With no arguments, lists the sessions that can be resurrected (from saved
+state on disk). With a session name, restores that session in the daemon
+(respawning fresh shells in each window's saved working directory) and
+attaches to it.
+
+Sessions are normally auto-restored when the daemon starts; this command is
+useful when the daemon was started with --no-restore, or to bring back a
+specific session on demand.`,
+		Example: `  # List resurrectable sessions
+  tuios resurrect
+
+  # Restore and attach to a saved session
+  tuios resurrect mysession`,
+		Aliases: []string{"restore"},
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := ""
+			if len(args) > 0 {
+				name = args[0]
+			}
+			return runResurrect(name)
+		},
+	}
+
 	startDaemonCmd := &cobra.Command{
 		Use:   "start-server",
 		Short: "Start the TUIOS daemon",
@@ -424,11 +453,12 @@ run this command manually.`,
 		Example: `  tuios start-server`,
 		Hidden:  true,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runDaemon(false)
+			return runDaemon(false, false)
 		},
 	}
 
 	var daemonLogLevel string
+	var daemonNoRestore bool
 	daemonCmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Run the TUIOS daemon in the foreground",
@@ -450,10 +480,11 @@ Debug log levels:
 			if daemonLogLevel != "" {
 				session.SetDebugLevel(session.ParseDebugLevel(daemonLogLevel))
 			}
-			return runDaemon(true)
+			return runDaemon(true, daemonNoRestore)
 		},
 	}
 	daemonCmd.Flags().StringVar(&daemonLogLevel, "log-level", "", "Debug log level: off, errors, basic, messages, verbose, trace")
+	daemonCmd.Flags().BoolVar(&daemonNoRestore, "no-restore", false, "Do not auto-restore saved sessions on start (use 'tuios resurrect' to restore on demand)")
 
 	killDaemonCmd := &cobra.Command{
 		Use:   "kill-server",
@@ -893,7 +924,7 @@ Use --json for machine-readable output.`,
 	layoutCmd.AddCommand(layoutListCmd, layoutDeleteCmd, layoutDirCmd, layoutExportCmd)
 
 	rootCmd.AddCommand(sshCmd, configCmd, keybindsCmd, tapeCmd, layoutCmd)
-	rootCmd.AddCommand(attachCmd, newCmd, lsCmd, killSessionCmd)
+	rootCmd.AddCommand(attachCmd, newCmd, lsCmd, killSessionCmd, resurrectCmd)
 	rootCmd.AddCommand(startDaemonCmd, daemonCmd, killDaemonCmd)
 	rootCmd.AddCommand(sendKeysCmd, runCommandCmd, setConfigCmd, logsCmd, capturePaneCmd)
 	rootCmd.AddCommand(listWindowsCmd, getWindowCmd, sessionInfoCmd)

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -445,7 +445,115 @@ func runKillSession(sessionName string) error {
 	return nil
 }
 
-func runDaemon(foreground bool) error {
+// runResurrect lists resurrectable sessions (no name) or restores one on demand
+// and attaches to it (name given).
+func runResurrect(sessionName string) error {
+	if sessionName == "" {
+		return listResurrectableSessions()
+	}
+
+	// Ensure the daemon is running so it can hold the restored session.
+	if !session.IsDaemonRunning() {
+		fmt.Println("Starting TUIOS daemon...")
+		if err := startDaemonBackground(); err != nil {
+			return fmt.Errorf("failed to start daemon: %w", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Ask the daemon to restore the session from saved state. This is a no-op if
+	// the daemon already auto-restored it on start.
+	client := session.NewClient(&session.ClientConfig{Version: version})
+	if err := client.Connect(); err != nil {
+		return fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	if err := client.ResurrectSession(sessionName); err != nil {
+		_ = client.Close()
+		return err
+	}
+	_ = client.Close()
+
+	fmt.Printf("Resurrected session '%s'\n", sessionName)
+
+	// Attach to the now-live session.
+	return runDaemonSession(sessionName, false)
+}
+
+// listResurrectableSessions prints the sessions that can be restored from saved
+// state on disk.
+func listResurrectableSessions() error {
+	infos, err := session.ListResurrectableInfos()
+	if err != nil {
+		return err
+	}
+
+	// Sessions currently live in the daemon are already available via attach;
+	// still list them so the user sees the full set, but mark their status.
+	liveNames := make(map[string]bool)
+	if session.IsDaemonRunning() {
+		client := session.NewClient(&session.ClientConfig{Version: version})
+		if err := client.Connect(); err == nil {
+			if sessions, err := client.ListSessions(); err == nil {
+				for _, s := range sessions {
+					liveNames[s.Name] = true
+				}
+			}
+			_ = client.Close()
+		}
+	}
+
+	if len(infos) == 0 {
+		fmt.Println("No resurrectable sessions.")
+		return nil
+	}
+
+	rows := make([][]string, 0, len(infos))
+	for _, info := range infos {
+		status := "restorable"
+		if liveNames[info.Name] {
+			status = "live"
+		}
+		saved := "-"
+		if !info.SavedAt.IsZero() {
+			saved = formatTimeAgo(info.SavedAt.Unix())
+		}
+		rows = append(rows, []string{
+			info.Name,
+			fmt.Sprintf("%d", info.WindowCount),
+			status,
+			saved,
+		})
+	}
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("8"))).
+		Headers("NAME", "WINDOWS", "STATUS", "SAVED").
+		Rows(rows...).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			baseStyle := lipgloss.NewStyle().Padding(0, 1)
+			if row == table.HeaderRow {
+				return baseStyle.Bold(true).Foreground(lipgloss.Color("12"))
+			}
+			switch col {
+			case 0:
+				return baseStyle.Foreground(lipgloss.Color("3")).Bold(true)
+			case 2:
+				if rows[row][col] == "live" {
+					return baseStyle.Foreground(lipgloss.Color("10"))
+				}
+				return baseStyle.Foreground(lipgloss.Color("11"))
+			default:
+				return baseStyle.Foreground(lipgloss.Color("8"))
+			}
+		})
+
+	fmt.Println(t.Render())
+	fmt.Printf("\n%d resurrectable session(s). Use 'tuios resurrect <name>' to restore.\n", len(infos))
+	return nil
+}
+
+func runDaemon(foreground, disableAutoRestore bool) error {
 	if session.IsDaemonRunning() {
 		pid := session.GetDaemonPID()
 		if pid > 0 {
@@ -466,7 +574,8 @@ func runDaemon(foreground bool) error {
 	}
 
 	daemon := session.NewDaemon(&session.DaemonConfig{
-		Version: version,
+		Version:            version,
+		DisableAutoRestore: disableAutoRestore,
 	})
 
 	return daemon.Run()

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -148,6 +148,41 @@ func (c *Client) KillSession(name string) error {
 	}
 }
 
+// ResurrectSession asks the daemon to restore a saved session on demand. It is
+// a no-op (success) if the session is already live.
+func (c *Client) ResurrectSession(name string) error {
+	msg, err := NewMessageWithCodec(MsgResurrect, &ResurrectPayload{
+		SessionName: name,
+	}, c.codec)
+	if err != nil {
+		return err
+	}
+
+	if err := c.send(msg); err != nil {
+		return err
+	}
+
+	resp, err := c.recv()
+	if err != nil {
+		return err
+	}
+
+	switch resp.Type {
+	case MsgSessionList:
+		return nil // Success
+
+	case MsgError:
+		var errPayload ErrorPayload
+		if err := resp.ParsePayloadWithCodec(&errPayload, c.codec); err != nil {
+			return fmt.Errorf("resurrect failed")
+		}
+		return fmt.Errorf("resurrect failed: %s", errPayload.Message)
+
+	default:
+		return fmt.Errorf("unexpected response type: %d", resp.Type)
+	}
+}
+
 func (c *Client) sendHello() error {
 	// Detect terminal capabilities
 	termType, colorTerm := detectTerminalEnv()

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -39,6 +39,11 @@ type Daemon struct {
 
 	// Configuration
 	version string
+
+	// disableAutoRestore, when true, skips cold-start resurrection of saved
+	// sessions on daemon start. Sessions can still be brought back on demand
+	// with the resurrect verb.
+	disableAutoRestore bool
 }
 
 // pendingRequest tracks a routed command awaiting its result, with the time it
@@ -95,6 +100,8 @@ type DaemonConfig struct {
 	SocketPath string
 	Foreground bool
 	LogFile    string
+	// DisableAutoRestore skips restoring saved sessions on daemon start.
+	DisableAutoRestore bool
 }
 
 // NewDaemon creates a new daemon instance.
@@ -102,12 +109,13 @@ func NewDaemon(cfg *DaemonConfig) *Daemon {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	d := &Daemon{
-		manager:         NewManager(),
-		ctx:             ctx,
-		cancel:          cancel,
-		clients:         make(map[string]*connState),
-		pendingRequests: make(map[string]*pendingRequest),
-		version:         cfg.Version,
+		manager:            NewManager(),
+		ctx:                ctx,
+		cancel:             cancel,
+		clients:            make(map[string]*connState),
+		pendingRequests:    make(map[string]*pendingRequest),
+		version:            cfg.Version,
+		disableAutoRestore: cfg.DisableAutoRestore,
 	}
 
 	if cfg.SocketPath != "" {
@@ -147,6 +155,13 @@ func (d *Daemon) Start() error {
 	}
 
 	log.Printf("TUIOS daemon started on %s (PID %d)", socketPath, os.Getpid())
+
+	// Restore sessions saved before the previous shutdown/crash before we start
+	// accepting clients, so an attach immediately after start finds them. Runs
+	// synchronously; a single corrupt file is archived and skipped, never fatal.
+	if !d.disableAutoRestore {
+		d.restoreAllSessions()
+	}
 
 	go d.handleSignals()
 	go d.acceptLoop()
@@ -386,6 +401,8 @@ func (d *Daemon) handleMessage(cs *connState, msg *Message) error {
 		return d.handleList(cs)
 	case MsgKill:
 		return d.handleKill(cs, msg)
+	case MsgResurrect:
+		return d.handleResurrect(cs, msg)
 	case MsgInput:
 		return d.handleInput(cs, msg)
 	case MsgResize:

--- a/internal/session/daemon_handlers.go
+++ b/internal/session/daemon_handlers.go
@@ -235,6 +235,34 @@ func (d *Daemon) handleKill(cs *connState, msg *Message) error {
 	return d.handleList(cs)
 }
 
+func (d *Daemon) handleResurrect(cs *connState, msg *Message) error {
+	var payload ResurrectPayload
+	if err := msg.ParsePayloadWithCodec(&payload, cs.codec); err != nil {
+		return fmt.Errorf("invalid resurrect payload: %w", err)
+	}
+
+	if payload.SessionName == "" {
+		return d.sendError(cs, ErrCodeInvalidMessage, "session name required")
+	}
+
+	// Already live (e.g. auto-restored on start): nothing to do, report success.
+	if d.manager.GetSession(payload.SessionName) != nil {
+		return d.handleList(cs)
+	}
+
+	state, err := LoadResurrectionState(payload.SessionName)
+	if err != nil {
+		return d.sendError(cs, ErrCodeSessionNotFound, err.Error())
+	}
+
+	if _, err := d.restoreSession(state); err != nil {
+		return d.sendError(cs, ErrCodeInternal, fmt.Sprintf("failed to restore session: %v", err))
+	}
+
+	log.Printf("Resurrected session %q on demand (%d windows)", payload.SessionName, len(state.Windows))
+	return d.handleList(cs)
+}
+
 func (d *Daemon) handleInput(cs *connState, msg *Message) error {
 	if cs.sessionID == "" {
 		return nil

--- a/internal/session/daemon_resurrect.go
+++ b/internal/session/daemon_resurrect.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"fmt"
+	"log"
+)
+
+// restoreAllSessions recreates every resurrectable session that is not already
+// live. It is called once on daemon start (unless auto-restore is disabled).
+// Corrupt or incompatible state files are archived and skipped; a failure to
+// restore one session never blocks the others or the daemon.
+func (d *Daemon) restoreAllSessions() {
+	names, err := ListResurrectableSessions()
+	if err != nil {
+		LogError("Failed to list resurrectable sessions: %v", err)
+		return
+	}
+
+	for _, name := range names {
+		if d.manager.GetSession(name) != nil {
+			continue // already live
+		}
+		state, err := LoadResurrectionState(name)
+		if err != nil {
+			// Corrupt/incompatible files are archived inside LoadResurrectionState.
+			log.Printf("Skipping resurrection of %q: %v", name, err)
+			continue
+		}
+		if _, err := d.restoreSession(state); err != nil {
+			LogError("Failed to restore session %q: %v", name, err)
+			continue
+		}
+		log.Printf("Restored session %q (%d windows)", name, len(state.Windows))
+	}
+}
+
+// restoreSession recreates a single session from a saved SessionState. It
+// respawns a fresh shell for every window (in the window's saved cwd, marked as
+// restored) and remaps each window to its new PTY, since the PTY IDs from the
+// previous daemon are dead. If the session is already live it is returned
+// unchanged.
+func (d *Daemon) restoreSession(state *SessionState) (*Session, error) {
+	if state == nil || state.Name == "" {
+		return nil, fmt.Errorf("cannot restore session from empty state")
+	}
+
+	if existing := d.manager.GetSession(state.Name); existing != nil {
+		return existing, nil
+	}
+
+	width, height := state.Width, state.Height
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = 24
+	}
+
+	// No client is connected at restore time, so the shell/term config falls
+	// back to daemon defaults (getShell uses $SHELL).
+	sess, err := d.manager.CreateSession(state.Name, &SessionConfig{}, width, height)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := sess.ID
+	onExit := func(ptyID string) {
+		d.notifyPTYClosed(sessionID, ptyID)
+	}
+
+	// Work on a copy so the original (loaded) state is untouched.
+	restored := *state
+	restored.Windows = make([]WindowState, len(state.Windows))
+	copy(restored.Windows, state.Windows)
+
+	for i := range restored.Windows {
+		w := &restored.Windows[i]
+
+		// WindowState dimensions are the outer window box (including the border);
+		// the shell gets the inner content size, matching AddDaemonWindow.
+		ptyWidth := max(w.Width-2, 1)
+		ptyHeight := max(w.Height-2, 1)
+
+		pty, err := sess.RestorePTY(w.ID, ptyWidth, ptyHeight, w.Cwd, onExit)
+		if err != nil {
+			LogError("Failed to respawn shell for restored window %s: %v", shortID(w.ID), err)
+			continue
+		}
+		w.PTYID = pty.ID
+	}
+
+	sess.UpdateState(&restored)
+	return sess, nil
+}

--- a/internal/session/daemon_resurrect_test.go
+++ b/internal/session/daemon_resurrect_test.go
@@ -1,0 +1,185 @@
+package session
+
+import (
+	"os"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+// TestDaemonRestartRestoresWindows proves that windows saved before a daemon
+// stops come back after a fresh daemon starts: the new daemon reads the saved
+// state, recreates the session, and respawns a live PTY for every window in the
+// window's saved cwd, clearly marked as restored.
+func TestDaemonRestartRestoresWindows(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	cwd1 := t.TempDir()
+	cwd2 := t.TempDir()
+
+	// Simulate the state written by a previous daemon just before shutdown: a
+	// two-window, two-workspace session. (Writing the file directly stands in
+	// for the periodic/Stop save of the prior daemon.)
+	saved := &SessionState{
+		Name:             "work",
+		CurrentWorkspace: 1,
+		AutoTiling:       true,
+		Width:            120,
+		Height:           40,
+		Windows: []WindowState{
+			{ID: "win-1", Title: "shell", X: 0, Y: 0, Width: 60, Height: 40, Workspace: 1, PTYID: "dead-pty-1", Cwd: cwd1},
+			{ID: "win-2", Title: "editor", X: 60, Y: 0, Width: 60, Height: 40, Workspace: 2, PTYID: "dead-pty-2", Cwd: cwd2},
+		},
+	}
+	if err := SaveSessionForResurrection(saved); err != nil {
+		t.Fatalf("failed to save state: %v", err)
+	}
+
+	// Fresh daemon, empty manager: this is the "cold start".
+	d := NewDaemon(&DaemonConfig{})
+	d.restoreAllSessions()
+	defer d.manager.Shutdown()
+
+	sess := d.manager.GetSession("work")
+	if sess == nil {
+		t.Fatal("session 'work' was not restored")
+	}
+
+	state := sess.GetState()
+	if len(state.Windows) != 2 {
+		t.Fatalf("restored window count = %d, want 2", len(state.Windows))
+	}
+
+	// Workspaces preserved.
+	workspaces := map[int]bool{}
+	for _, w := range state.Windows {
+		workspaces[w.Workspace] = true
+	}
+	if !workspaces[1] || !workspaces[2] {
+		t.Errorf("restored windows lost their workspaces: %+v", state.Windows)
+	}
+
+	for _, w := range state.Windows {
+		// PTY IDs must have been remapped away from the dead ones.
+		if w.PTYID == "" || w.PTYID == "dead-pty-1" || w.PTYID == "dead-pty-2" {
+			t.Errorf("window %s has stale/empty PTYID %q", w.ID, w.PTYID)
+			continue
+		}
+		pty := sess.GetPTY(w.PTYID)
+		if pty == nil {
+			t.Errorf("no live PTY for restored window %s (PTYID %s)", w.ID, w.PTYID)
+			continue
+		}
+		if pty.IsExited() {
+			t.Errorf("restored PTY for window %s already exited", w.ID)
+		}
+		// Fresh shell must be marked restored.
+		if !slices.Contains(pty.cmd.Env, "TUIOS_RESTORED=1") {
+			t.Errorf("restored shell for window %s not marked (env: %v)", w.ID, pty.cmd.Env)
+		}
+	}
+
+	// Working directories must have been honored (only reliable where the shell
+	// can be started in a directory, which is all supported platforms).
+	pty1 := sess.GetPTY(state.Windows[0].PTYID)
+	if pty1 != nil && pty1.cmd.Dir != cwd1 {
+		t.Errorf("window 1 shell dir = %q, want %q", pty1.cmd.Dir, cwd1)
+	}
+}
+
+// TestDaemonRestoreSkipsLiveSession verifies restoreSession does not clobber a
+// session that is already live.
+func TestDaemonRestoreSkipsLiveSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	d := NewDaemon(&DaemonConfig{})
+	defer d.manager.Shutdown()
+
+	existing, err := d.manager.CreateSession("live", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	got, err := d.restoreSession(&SessionState{Name: "live", Width: 80, Height: 24})
+	if err != nil {
+		t.Fatalf("restoreSession failed: %v", err)
+	}
+	if got.ID != existing.ID {
+		t.Error("restoreSession replaced a live session instead of returning it")
+	}
+}
+
+// TestResurrectionStateCapturesCwd verifies that the daemon-side resurrection
+// state enriches each window with its live shell's working directory (which
+// clients never provide).
+func TestResurrectionStateCapturesCwd(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("processCwd reads /proc, only reliable on Linux")
+	}
+
+	sess, err := NewSession("cwd-test", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	defer sess.Stop()
+
+	pty, err := sess.CreatePTY("win-1", 40, 20, nil)
+	if err != nil {
+		t.Fatalf("CreatePTY failed: %v", err)
+	}
+
+	sess.UpdateState(&SessionState{
+		Name:    "cwd-test",
+		Windows: []WindowState{{ID: "win-1", PTYID: pty.ID}},
+	})
+
+	state := sess.ResurrectionState()
+	if len(state.Windows) != 1 {
+		t.Fatalf("windows = %d, want 1", len(state.Windows))
+	}
+	if state.Windows[0].Cwd == "" {
+		t.Error("ResurrectionState did not capture the shell cwd")
+	}
+	// The shell inherits the test process cwd.
+	if wd, err := os.Getwd(); err == nil && state.Windows[0].Cwd != wd {
+		t.Errorf("captured cwd = %q, want %q", state.Windows[0].Cwd, wd)
+	}
+}
+
+// TestKillRemovesResurrectionState verifies an explicit kill deletes the saved
+// state so the session is not resurrectable afterwards.
+func TestKillRemovesResurrectionState(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	mgr := NewManager()
+	if _, err := mgr.CreateSession("doomed", &SessionConfig{}, 80, 24); err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	// Seed a saved-state file as the periodic saver would have.
+	if err := SaveSessionForResurrection(&SessionState{Name: "doomed"}); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	if err := mgr.DeleteSession("doomed"); err != nil {
+		t.Fatalf("DeleteSession failed: %v", err)
+	}
+
+	if _, err := LoadResurrectionState("doomed"); err == nil {
+		t.Error("resurrection state should be removed after explicit kill")
+	}
+
+	names, err := ListResurrectableSessions()
+	if err != nil {
+		t.Fatalf("ListResurrectableSessions failed: %v", err)
+	}
+	if slices.Contains(names, "doomed") {
+		t.Error("killed session still listed as resurrectable")
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -117,8 +117,11 @@ func (m *Manager) DeleteSession(name string) error {
 	delete(m.byID, session.ID)
 	m.mu.Unlock()
 
-	// Stop the session (outside lock to avoid deadlock)
+	// Stop the session (outside lock to avoid deadlock). Stop performs a final
+	// resurrection save, so remove the state file afterwards: an explicit kill
+	// is a deliberate teardown and must not leave the session resurrectable.
 	session.Stop()
+	RemoveResurrectionState(name)
 	return nil
 }
 

--- a/internal/session/protocol.go
+++ b/internal/session/protocol.go
@@ -71,6 +71,10 @@ const (
 	MsgSessionResize   // Session effective size changed (min of all clients)
 	MsgForceRefresh    // Force all clients to re-render
 	MsgRequestFullSync // Client requests full state sync from leader
+
+	// Appended after all existing types to keep every value above stable for
+	// older clients that share this iota order.
+	MsgResurrect // Restore a saved session on demand (cold-start restore)
 )
 
 // Message is the base protocol message structure.
@@ -154,6 +158,11 @@ type SessionListPayload struct {
 // KillPayload requests termination of a session.
 type KillPayload struct {
 	SessionName string `json:"session_name"` // Session to kill
+}
+
+// ResurrectPayload requests restoring a saved session on demand.
+type ResurrectPayload struct {
+	SessionName string `json:"session_name"` // Session to resurrect from saved state
 }
 
 // ResizePayload notifies of terminal resize.

--- a/internal/session/resurrection.go
+++ b/internal/session/resurrection.go
@@ -15,6 +15,14 @@ import (
 const (
 	resurrectionDir      = "tuios/sessions"
 	resurrectionInterval = 30 * time.Second
+
+	// ResurrectionVersion is the current on-disk resurrection schema version.
+	// It is bumped only when the schema changes in a way older daemons cannot
+	// read. State whose ResurrectionVersion is greater than this is treated as
+	// incompatible and archived rather than loaded. Version 0 (files written
+	// before versioning existed) is a structural subset of the current schema
+	// and loads without issue.
+	ResurrectionVersion = 1
 )
 
 // resurrectionDirOverride is set during tests to use a temp directory.
@@ -33,11 +41,39 @@ func getResurrectionPath(sessionName string) string {
 	return filepath.Join(getResurrectionDir(), sessionName+".json")
 }
 
+// getResurrectionArchiveDir returns the directory where corrupt or incompatible
+// state files are moved instead of being deleted, so they can be inspected.
+func getResurrectionArchiveDir() string {
+	return filepath.Join(getResurrectionDir(), "archive")
+}
+
+// archiveResurrectionFile moves a bad state file into the archive directory,
+// tagging it with a timestamp. Best effort: on any failure the original file is
+// removed so it is not retried on every load. Never returns an error to callers
+// because the load must continue regardless.
+func archiveResurrectionFile(path string) {
+	archiveDir := getResurrectionArchiveDir()
+	if err := os.MkdirAll(archiveDir, 0700); err != nil {
+		_ = os.Remove(path)
+		return
+	}
+	base := filepath.Base(path)
+	dest := filepath.Join(archiveDir, fmt.Sprintf("%s.%d.bak", base, time.Now().UnixNano()))
+	if err := os.Rename(path, dest); err != nil {
+		_ = os.Remove(path)
+	}
+}
+
 // SaveSessionForResurrection persists the session state to disk.
 func SaveSessionForResurrection(state *SessionState) error {
 	if state == nil || state.Name == "" {
 		return nil
 	}
+
+	// Stamp the current schema version on every write regardless of caller, so
+	// the file is always self-describing even though clients that build the
+	// state do not set this field.
+	state.ResurrectionVersion = ResurrectionVersion
 
 	dir := getResurrectionDir()
 	if err := os.MkdirAll(dir, 0700); err != nil {
@@ -63,7 +99,9 @@ func SaveSessionForResurrection(state *SessionState) error {
 	return nil
 }
 
-// LoadResurrectionState loads a saved session state from disk.
+// LoadResurrectionState loads a saved session state from disk. Corrupt or
+// version-incompatible files are archived (not deleted) and returned as an
+// error, so a single bad file can never crash the daemon or block startup.
 func LoadResurrectionState(sessionName string) (*SessionState, error) {
 	path := getResurrectionPath(sessionName)
 	data, err := os.ReadFile(path) // #nosec G304
@@ -73,10 +111,62 @@ func LoadResurrectionState(sessionName string) (*SessionState, error) {
 
 	var state SessionState
 	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, fmt.Errorf("failed to parse resurrection data: %w", err)
+		archiveResurrectionFile(path)
+		return nil, fmt.Errorf("corrupt resurrection data for session %q (archived): %w", sessionName, err)
+	}
+
+	if state.ResurrectionVersion > ResurrectionVersion {
+		archiveResurrectionFile(path)
+		return nil, fmt.Errorf("incompatible resurrection version %d for session %q (archived), this daemon supports up to %d",
+			state.ResurrectionVersion, sessionName, ResurrectionVersion)
 	}
 
 	return &state, nil
+}
+
+// ResurrectableInfo summarizes a resurrectable session for listing.
+type ResurrectableInfo struct {
+	Name        string    // Session name
+	WindowCount int       // Number of windows saved
+	SavedAt     time.Time // Modification time of the state file
+}
+
+// ListResurrectableInfos returns metadata for every resurrectable session,
+// sorted by name. Corrupt/incompatible files are skipped (and archived).
+func ListResurrectableInfos() ([]ResurrectableInfo, error) {
+	names, err := ListResurrectableSessions()
+	if err != nil {
+		return nil, err
+	}
+
+	infos := make([]ResurrectableInfo, 0, len(names))
+	for _, name := range names {
+		state, err := LoadResurrectionState(name)
+		if err != nil {
+			continue
+		}
+		info := ResurrectableInfo{Name: name, WindowCount: len(state.Windows)}
+		if fi, statErr := os.Stat(getResurrectionPath(name)); statErr == nil {
+			info.SavedAt = fi.ModTime()
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+// processCwd returns the working directory of the process with the given PID.
+// It reads /proc/<pid>/cwd, which exists on Linux (and some BSDs). On platforms
+// without procfs the readlink fails and (,"", false) is returned, in which case
+// resurrection falls back to spawning the shell in its default directory.
+func processCwd(pid int) (string, bool) {
+	if pid <= 0 {
+		return "", false
+	}
+	cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+	if err != nil || cwd == "" {
+		return "", false
+	}
+	return cwd, true
 }
 
 // ListResurrectableSessions returns names of sessions that can be restored.

--- a/internal/session/resurrection_test.go
+++ b/internal/session/resurrection_test.go
@@ -6,6 +6,200 @@ import (
 	"testing"
 )
 
+// TestResurrectionRoundTripMultiWindowMultiWorkspace saves a session spanning
+// several windows across multiple workspaces (with tiling, focus, cwds and a
+// BSP tree) and verifies every structural field survives a save/load cycle.
+func TestResurrectionRoundTripMultiWindowMultiWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	original := &SessionState{
+		Name:             "multi",
+		CurrentWorkspace: 2,
+		AutoTiling:       true,
+		MasterRatio:      0.65,
+		Width:            200,
+		Height:           60,
+		Mode:             1,
+		FocusedWindowID:  "win-c",
+		Windows: []WindowState{
+			{ID: "win-a", Title: "shell", CustomName: "main", X: 0, Y: 0, Width: 100, Height: 30, Z: 0, Workspace: 1, PTYID: "pty-a", Cwd: "/home/user/project"},
+			{ID: "win-b", Title: "logs", X: 100, Y: 0, Width: 100, Height: 30, Z: 1, Workspace: 1, PTYID: "pty-b", Cwd: "/var/log"},
+			{ID: "win-c", Title: "vim", X: 0, Y: 0, Width: 200, Height: 60, Z: 2, Workspace: 2, PTYID: "pty-c", IsAltScreen: true, Cwd: "/tmp/edit"},
+		},
+		WorkspaceFocus: map[int]string{
+			1: "win-b",
+			2: "win-c",
+		},
+		WindowToBSPID:   map[string]int{"win-a": 1, "win-b": 2},
+		NextBSPWindowID: 3,
+		TilingScheme:    1,
+		WorkspaceTrees: map[int]*SerializedBSPTree{
+			1: {
+				AutoScheme:   1,
+				DefaultRatio: 0.5,
+				Root: &SerializedBSPNode{
+					SplitType:  1,
+					SplitRatio: 0.6,
+					Left:       &SerializedBSPNode{WindowID: 1},
+					Right:      &SerializedBSPNode{WindowID: 2},
+				},
+			},
+		},
+	}
+
+	if err := SaveSessionForResurrection(original); err != nil {
+		t.Fatalf("SaveSessionForResurrection failed: %v", err)
+	}
+
+	loaded, err := LoadResurrectionState("multi")
+	if err != nil {
+		t.Fatalf("LoadResurrectionState failed: %v", err)
+	}
+
+	if loaded.ResurrectionVersion != ResurrectionVersion {
+		t.Errorf("ResurrectionVersion = %d, want %d", loaded.ResurrectionVersion, ResurrectionVersion)
+	}
+	if loaded.CurrentWorkspace != 2 || !loaded.AutoTiling || loaded.MasterRatio != 0.65 {
+		t.Errorf("top-level fields not preserved: %+v", loaded)
+	}
+	if loaded.FocusedWindowID != "win-c" {
+		t.Errorf("FocusedWindowID = %q, want win-c", loaded.FocusedWindowID)
+	}
+	if len(loaded.Windows) != 3 {
+		t.Fatalf("windows = %d, want 3", len(loaded.Windows))
+	}
+	for i, w := range loaded.Windows {
+		o := original.Windows[i]
+		if w.ID != o.ID || w.Workspace != o.Workspace || w.PTYID != o.PTYID || w.Cwd != o.Cwd {
+			t.Errorf("window %d mismatch: got %+v want %+v", i, w, o)
+		}
+	}
+	if loaded.Windows[2].IsAltScreen != true {
+		t.Error("alt screen flag not preserved for win-c")
+	}
+	// Workspaces are distinct.
+	ws := map[int]bool{}
+	for _, w := range loaded.Windows {
+		ws[w.Workspace] = true
+	}
+	if len(ws) != 2 {
+		t.Errorf("expected windows across 2 workspaces, got %d", len(ws))
+	}
+	if loaded.WorkspaceFocus[1] != "win-b" || loaded.WorkspaceFocus[2] != "win-c" {
+		t.Errorf("WorkspaceFocus not preserved: %+v", loaded.WorkspaceFocus)
+	}
+	tree := loaded.WorkspaceTrees[1]
+	if tree == nil || tree.Root == nil || tree.Root.Left == nil || tree.Root.Right == nil {
+		t.Fatalf("BSP tree not preserved: %+v", loaded.WorkspaceTrees)
+	}
+	if tree.Root.SplitRatio != 0.6 || tree.Root.Left.WindowID != 1 || tree.Root.Right.WindowID != 2 {
+		t.Errorf("BSP tree content mismatch: %+v", tree.Root)
+	}
+	if loaded.NextBSPWindowID != 3 || loaded.WindowToBSPID["win-a"] != 1 {
+		t.Errorf("BSP id mapping not preserved: next=%d map=%+v", loaded.NextBSPWindowID, loaded.WindowToBSPID)
+	}
+}
+
+// TestLoadResurrectionCorruptFileArchived verifies a corrupt state file is
+// archived (not deleted, not fatal) and reported as an error.
+func TestLoadResurrectionCorruptFileArchived(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	path := filepath.Join(tmpDir, "broken.json")
+	if err := os.WriteFile(path, []byte("{ this is not valid json"), 0600); err != nil {
+		t.Fatalf("failed to seed corrupt file: %v", err)
+	}
+
+	_, err := LoadResurrectionState("broken")
+	if err == nil {
+		t.Fatal("expected error loading corrupt state")
+	}
+
+	// Original must be gone (moved to archive), not left to trip up every load.
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("corrupt file still present at original path (stat err: %v)", statErr)
+	}
+
+	// A .bak copy must exist in the archive directory.
+	archiveDir := filepath.Join(tmpDir, "archive")
+	entries, err := os.ReadDir(archiveDir)
+	if err != nil {
+		t.Fatalf("archive dir not created: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".bak" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an archived .bak file, got %d entries", len(entries))
+	}
+
+	// The corrupt session must not appear as resurrectable.
+	infos, err := ListResurrectableInfos()
+	if err != nil {
+		t.Fatalf("ListResurrectableInfos failed: %v", err)
+	}
+	for _, info := range infos {
+		if info.Name == "broken" {
+			t.Errorf("corrupt session should not be listed as resurrectable")
+		}
+	}
+}
+
+// TestLoadResurrectionIncompatibleVersionArchived verifies state written by a
+// newer, incompatible schema is archived and refused.
+func TestLoadResurrectionIncompatibleVersionArchived(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	// Write a state file directly with a future version. Bypass Save (which
+	// would stamp the current version) by writing JSON by hand.
+	path := filepath.Join(tmpDir, "future.json")
+	future := `{"name":"future","resurrection_version":999,"windows":[]}`
+	if err := os.WriteFile(path, []byte(future), 0600); err != nil {
+		t.Fatalf("failed to seed future file: %v", err)
+	}
+
+	_, err := LoadResurrectionState("future")
+	if err == nil {
+		t.Fatal("expected error loading incompatible-version state")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("incompatible file still present at original path")
+	}
+}
+
+// TestSaveStampsCurrentVersion verifies every save is self-describing even when
+// the in-memory state has no version set (clients never set it).
+func TestSaveStampsCurrentVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	resurrectionDirOverride = tmpDir
+	defer func() { resurrectionDirOverride = "" }()
+
+	state := &SessionState{Name: "stamp"} // ResurrectionVersion left at 0
+	if err := SaveSessionForResurrection(state); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+	// Save mutates the passed state's version in place.
+	if state.ResurrectionVersion != ResurrectionVersion {
+		t.Errorf("save did not stamp version on in-memory state: %d", state.ResurrectionVersion)
+	}
+	loaded, err := LoadResurrectionState("stamp")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if loaded.ResurrectionVersion != ResurrectionVersion {
+		t.Errorf("loaded version = %d, want %d", loaded.ResurrectionVersion, ResurrectionVersion)
+	}
+}
+
 func TestSaveAndLoadResurrection(t *testing.T) {
 	tmpDir := t.TempDir()
 	resurrectionDirOverride = tmpDir

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,6 +50,10 @@ type WindowState struct {
 	PreMinimizeH int    `json:"pre_minimize_h,omitempty"`
 	PTYID        string `json:"pty_id"`                  // Reference to daemon-managed PTY
 	IsAltScreen  bool   `json:"is_alt_screen,omitempty"` // Alternate screen buffer active (for mouse forwarding)
+	// Cwd is the working directory of the window's shell process, captured on the
+	// daemon side when saving resurrection state. On cold-start restore a fresh
+	// shell is respawned here. Empty for live state syncs (clients do not set it).
+	Cwd string `json:"cwd,omitempty"`
 }
 
 // SerializedBSPNode represents a BSP tree node for serialization
@@ -86,6 +90,12 @@ type SessionState struct {
 	WindowToBSPID   map[string]int             `json:"window_to_bsp_id,omitempty"` // Window UUID -> BSP int ID
 	NextBSPWindowID int                        `json:"next_bsp_window_id,omitempty"`
 	TilingScheme    int                        `json:"tiling_scheme,omitempty"` // Default auto-insertion scheme
+	// ResurrectionVersion tags the on-disk state schema. It is stamped by
+	// SaveSessionForResurrection (not by clients) and checked on load so that
+	// state written by a newer, incompatible tuios is archived rather than
+	// misinterpreted. Absent (0) means pre-versioning state, which is a
+	// structural subset of the current schema and loads fine.
+	ResurrectionVersion int `json:"resurrection_version,omitempty"`
 }
 
 // PTY represents a daemon-managed pseudo-terminal.
@@ -191,7 +201,7 @@ func NewSession(name string, cfg *SessionConfig, width, height int) (*Session, e
 
 	// Start periodic resurrection saving
 	session.stopResurrection = StartPeriodicSave(func() *SessionState {
-		return session.GetState()
+		return session.ResurrectionState()
 	})
 
 	return session, nil
@@ -202,6 +212,19 @@ func NewSession(name string, cfg *SessionConfig, width, height int) (*Session, e
 // non-nil, is invoked with the PTY ID when the process exits; it is set before
 // the monitor goroutine starts so it is always visible to monitorExit.
 func (s *Session) CreatePTY(windowID string, width, height int, onExit func(ptyID string)) (*PTY, error) {
+	return s.createPTY(windowID, width, height, "", false, onExit)
+}
+
+// RestorePTY creates a fresh PTY for a resurrected window. It behaves like
+// CreatePTY but starts the shell in cwd (when that directory still exists) and
+// marks the shell as restored: the shell's environment carries TUIOS_RESTORED=1
+// and a one-line banner is written to the terminal so the user can see the
+// process is a freshly respawned shell, not the original long-lived one.
+func (s *Session) RestorePTY(windowID string, width, height int, cwd string, onExit func(ptyID string)) (*PTY, error) {
+	return s.createPTY(windowID, width, height, cwd, true, onExit)
+}
+
+func (s *Session) createPTY(windowID string, width, height int, cwd string, restored bool, onExit func(ptyID string)) (*PTY, error) {
 	s.ptysMu.Lock()
 	defer s.ptysMu.Unlock()
 
@@ -219,7 +242,14 @@ func (s *Session) CreatePTY(windowID string, width, height int, onExit func(ptyI
 
 	// Create command
 	cmd := exec.Command(shell)
-	cmd.Env = s.buildEnv(windowID)
+	cmd.Env = s.buildEnv(windowID, restored)
+	// Start a restored shell in its saved working directory when it still
+	// exists; otherwise fall back to the shell's default (inherited) directory.
+	if restored && cwd != "" {
+		if info, statErr := os.Stat(cwd); statErr == nil && info.IsDir() {
+			cmd.Dir = cwd
+		}
+	}
 
 	// Set up the command to use the PTY as controlling terminal
 	// This is required for interactive shells to work properly
@@ -237,6 +267,15 @@ func (s *Session) CreatePTY(windowID string, width, height int, onExit func(ptyI
 	// This maintains scrollback, screen content, cursor position across reconnects
 	terminal := vt.NewEmulator(width, height)
 	terminal.SetScrollbackMaxLines(10000) // Match default scrollback
+
+	// For a restored shell, seed the emulator with a one-line banner so the
+	// respawned process is clearly marked. This is written directly (before the
+	// reader/writer goroutines start) so it lands at the top of the screen ahead
+	// of the shell's first prompt; it only touches the daemon-side emulator and
+	// never the real PTY, so the shell is unaffected.
+	if restored {
+		_, _ = terminal.Write([]byte(restoredBanner(cwd)))
+	}
 
 	pty := &PTY{
 		ID:           id,
@@ -339,6 +378,26 @@ func (s *Session) GetState() *SessionState {
 	return &stateCopy
 }
 
+// ResurrectionState returns a copy of the session state enriched for on-disk
+// resurrection: each window's Cwd is filled from its live PTY process so a
+// cold-start restore can respawn the shell in the same directory. Clients never
+// send Cwd, so this daemon-side capture is the only source of it.
+func (s *Session) ResurrectionState() *SessionState {
+	state := s.GetState()
+	for i := range state.Windows {
+		ptyID := state.Windows[i].PTYID
+		if ptyID == "" {
+			continue
+		}
+		if pty := s.GetPTY(ptyID); pty != nil {
+			if cwd, ok := pty.ProcessCwd(); ok {
+				state.Windows[i].Cwd = cwd
+			}
+		}
+	}
+	return state
+}
+
 // UpdateState updates the session state.
 func (s *Session) UpdateState(state *SessionState) {
 	s.stateMu.Lock()
@@ -353,8 +412,8 @@ func (s *Session) Stop() {
 	if s.stopResurrection != nil {
 		s.stopResurrection()
 	}
-	// Final save before stopping
-	_ = SaveSessionForResurrection(s.GetState())
+	// Final save before stopping. Capture cwds while the shells are still alive.
+	_ = SaveSessionForResurrection(s.ResurrectionState())
 
 	s.ptysMu.Lock()
 	defer s.ptysMu.Unlock()
@@ -426,7 +485,7 @@ func (s *Session) getShell() string {
 	return "/bin/sh"
 }
 
-func (s *Session) buildEnv(windowID string) []string {
+func (s *Session) buildEnv(windowID string, restored bool) []string {
 	env := os.Environ()
 
 	term := "xterm-256color"
@@ -446,8 +505,25 @@ func (s *Session) buildEnv(windowID string) []string {
 	if windowID != "" {
 		env = append(env, "TUIOS_WINDOW_ID="+windowID)
 	}
+	// Mark restored shells so the user's shell rc (and scripts) can react, and
+	// so the restore is observable without relying on the visual banner.
+	if restored {
+		env = append(env, "TUIOS_RESTORED=1")
+	}
 
 	return env
+}
+
+// restoredBanner returns the dim one-line notice written to a restored shell's
+// terminal emulator. cwd, when set, is included so the user sees where the
+// fresh shell was spawned.
+func restoredBanner(cwd string) string {
+	msg := "-- tuios: session restored, fresh shell"
+	if cwd != "" {
+		msg += " in " + cwd
+	}
+	msg += " --"
+	return "\x1b[2m" + msg + "\x1b[0m\r\n"
 }
 
 // PTY methods
@@ -739,6 +815,16 @@ func (p *PTY) Close() error {
 		return p.pty.Close()
 	}
 	return nil
+}
+
+// ProcessCwd returns the current working directory of the PTY's shell process.
+// The second return is false when it cannot be determined (process gone, or an
+// unsupported platform). Used to capture cwd for session resurrection.
+func (p *PTY) ProcessCwd() (string, bool) {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return "", false
+	}
+	return processCwd(p.cmd.Process.Pid)
 }
 
 // IsExited returns true if the shell process has exited.


### PR DESCRIPTION
Second of four stacked branches. Targets `fix/window-lifecycle-and-open-issues`. Small on purpose, two commits.

## What changed and why

The daemon lost every session when it exited. Sessions only survived as long as the process did, so a machine reboot or a `kill-server` meant rebuilding the layout by hand.

This adds cold-start session restore. The daemon writes session state to disk and reads it back on start, recreating the sessions and their windows.

- Session state files are versioned, so a state file written by an older or newer build is recognised rather than misparsed. An unreadable or unknown-version file is skipped instead of taking the daemon down with it.
- Each window records its working directory, so a restored window comes back where it was rather than in `$HOME`.
- A `resurrect` verb triggers the same restore path on demand, which is what makes it testable and what later branches build the CLI surface on.

## User-visible effect

Sessions survive a daemon restart. Windows come back with their names, their layout, and their working directories. The shells themselves are new processes; scrollback and running programs are not restored, only the structure.

## Design notes

Restore is a daemon-side operation that reconstructs canonical state, not a client-side replay. That matters for the branches after this one: the control plane and the state-convergence work both assume the daemon can build a session without a client attached, and this is where that ability comes from.

The state file is versioned from the start rather than adding a version later, since the format is expected to move as convergence stages land.

## What is not done

Restoring process state is out of scope. There is no attempt to re-run whatever was in the window, and no scrollback persistence.

## Verification

- `go build ./...` and `go vet ./...` clean on this branch.
- Full `go test -race -count=1 ./...` and `-tags e2e` green on the tip of the stack.
- The e2e suite in the next branch adds coverage that resurrection state settles before teardown, which is what shook out the ordering bugs fixed there.
