### PR TITLE
feat(session): add a JSON verb control protocol on the daemon socket

### DIFF
--- a/cmd/tuios/diagnostics.go
+++ b/cmd/tuios/diagnostics.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Gaurav-Gosain/tuios/internal/session"
+	"github.com/charmbracelet/fang"
+	"golang.org/x/term"
+)
+
+// This file is the CLI's shared vocabulary for failure. Every user-reachable
+// error the tuios command prints should answer three questions in order:
+//
+//	what failed, the most likely cause, and the exact command that fixes it.
+//
+// diagnosticError is the shape that enforces it, and the helpers below build one
+// for each degraded state the CLI can reach.
+
+// diagnosticError is an error whose message is structured as what/why/fix. It
+// renders as three lines so a user reading a terminal sees the fix without
+// parsing prose.
+type diagnosticError struct {
+	// What failed, in the imperative past: "Session 'work' was not found."
+	What string
+	// Why it most likely happened.
+	Cause string
+	// Fix is the exact command to run, copy-pasteable.
+	Fix string
+	// Extra holds optional detail lines shown between the cause and the fix,
+	// such as the list of session names that do exist.
+	Extra []string
+	// Err is the underlying error, preserved for errors.Is/As.
+	Err error
+}
+
+func (e *diagnosticError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.What)
+	if e.Cause != "" {
+		b.WriteString("\nMost likely cause: " + e.Cause)
+	}
+	for _, line := range e.Extra {
+		b.WriteString("\n" + line)
+	}
+	if e.Fix != "" {
+		b.WriteString("\nFix: " + e.Fix)
+	}
+	return b.String()
+}
+
+func (e *diagnosticError) Unwrap() error { return e.Err }
+
+// diagnosticErrorHandler renders errors for the CLI. A diagnostic error is
+// printed with its line structure intact, because the whole value of the
+// what/why/fix layout is lost when it is reflowed into one paragraph; every
+// other error falls through to fang's styled default.
+func diagnosticErrorHandler(w io.Writer, styles fang.Styles, err error) {
+	var diag *diagnosticError
+	var mismatch *session.ProtocolMismatchError
+	if !errors.As(err, &diag) && !errors.As(err, &mismatch) {
+		fang.DefaultErrorHandler(w, styles, err)
+		return
+	}
+
+	// Match fang's default behavior for a non-tty: no styling, no decoration,
+	// so piped output and CI logs stay parseable.
+	if f, ok := w.(interface{ Fd() uintptr }); ok && !term.IsTerminal(int(f.Fd())) {
+		_, _ = fmt.Fprintln(w, err.Error())
+		return
+	}
+
+	_, _ = fmt.Fprintln(w, styles.ErrorHeader.String())
+	for _, line := range strings.Split(err.Error(), "\n") {
+		_, _ = fmt.Fprintln(w, styles.ErrorText.UnsetTransform().Render(line))
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// requireDaemon returns a diagnostic error when no daemon is reachable, naming
+// which of the several "not running" states this actually is.
+func requireDaemon() error {
+	d := session.DiagnoseDaemon()
+	if d.Running() {
+		return nil
+	}
+	return &diagnosticError{What: d.Explain(), Err: d.Err}
+}
+
+// dialVerb connects to the daemon for a JSON verb-protocol call. Every failure
+// it can produce is explained: the daemon being absent, a stale or unreachable
+// socket, and an old daemon left running across an upgrade.
+func dialVerb() (*session.VerbClient, error) {
+	if err := requireDaemon(); err != nil {
+		return nil, err
+	}
+
+	client, err := session.DialVerbClientAs(version)
+	if err != nil {
+		return nil, explainDialError(err)
+	}
+	return client, nil
+}
+
+// explainDialError turns a verb-client dial failure into an actionable message.
+// A protocol mismatch already carries its own full explanation, so it is passed
+// through untouched; anything else is a socket problem, re-diagnosed so the user
+// is told which one.
+func explainDialError(err error) error {
+	var mismatch *session.ProtocolMismatchError
+	if errors.As(err, &mismatch) {
+		return mismatch
+	}
+
+	d := session.DiagnoseDaemon()
+	if !d.Running() {
+		// The daemon disappeared between the check and the dial, which is
+		// itself worth reporting accurately.
+		return &diagnosticError{What: d.Explain(), Err: err}
+	}
+	return &diagnosticError{
+		What:  fmt.Sprintf("Could not open a control connection to the TUIOS daemon: %v.", err),
+		Cause: "the daemon is running but rejected or dropped the connection, which usually means it is shutting down or is a different build.",
+		Fix:   "run 'tuios kill-server', then run this command again.",
+		Err:   err,
+	}
+}
+
+// explainVerbError renders a failed verb call for a human, folding in the
+// structured hint the daemon attached. The daemon already computed the remedy;
+// the CLI's job is to show it rather than invent a second, possibly different
+// one.
+func explainVerbError(verb string, err error) error {
+	var callErr *session.VerbCallError
+	if !errors.As(err, &callErr) {
+		return err
+	}
+
+	d := &diagnosticError{
+		What: fmt.Sprintf("%s failed: %s.", verb, strings.TrimSuffix(callErr.Message, ".")),
+		Err:  err,
+	}
+
+	hint := callErr.Hint
+	if hint == nil {
+		d.Cause = fmt.Sprintf("the daemon reported %s.", callErr.Code)
+		return d
+	}
+
+	if hint.DidYouMean != "" {
+		d.Extra = append(d.Extra, fmt.Sprintf("Did you mean %q?", hint.DidYouMean))
+	}
+	if len(hint.Accepted) > 0 {
+		d.Extra = append(d.Extra, fmt.Sprintf("Accepted values for %s: %s.",
+			nonEmpty(hint.Param, "this parameter"), strings.Join(hint.Accepted, ", ")))
+	}
+	if len(hint.Available) > 0 {
+		d.Extra = append(d.Extra, "Available: "+strings.Join(truncateList(hint.Available, 12), ", ")+".")
+	}
+	if hint.Detail != "" {
+		d.Cause = hint.Detail
+	} else {
+		d.Cause = fmt.Sprintf("the daemon reported %s.", callErr.Code)
+	}
+
+	switch {
+	case hint.Command != "":
+		d.Fix = "run '" + hint.Command + "'."
+	case hint.Verb != "":
+		d.Fix = "call the '" + hint.Verb + "' verb to see valid targets."
+	}
+	return d
+}
+
+// nonEmpty returns s, or fallback when s is empty.
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// truncateList caps a list for display so a hundred window ids do not bury the
+// fix line.
+func truncateList(items []string, limit int) []string {
+	if len(items) <= limit {
+		return items
+	}
+	out := make([]string, 0, limit+1)
+	out = append(out, items[:limit]...)
+	return append(out, fmt.Sprintf("and %d more", len(items)-limit))
+}
+
+// explainMissingSession builds the error for a session name that does not
+// resolve, listing the names that do exist and suggesting the closest one. It is
+// used by commands that resolve a session before opening a verb connection, so
+// the user never sees a bare "not found".
+func explainMissingSession(name string, available []string) error {
+	e := &diagnosticError{
+		What: fmt.Sprintf("Session %q was not found.", name),
+	}
+
+	sorted := append([]string(nil), available...)
+	sort.Strings(sorted)
+
+	switch {
+	case len(sorted) == 0:
+		e.Cause = "the daemon is running but holds no sessions."
+		e.Fix = fmt.Sprintf("run 'tuios new %s' to create it, or 'tuios resurrect' to see saved sessions.", name)
+	default:
+		e.Cause = "the name does not match any live session."
+		if closest := closestName(name, sorted); closest != "" {
+			e.Extra = append(e.Extra, fmt.Sprintf("Did you mean %q?", closest))
+		}
+		e.Extra = append(e.Extra, "Sessions: "+strings.Join(truncateList(sorted, 12), ", ")+".")
+		e.Fix = fmt.Sprintf("run 'tuios ls' to list sessions, or 'tuios new %s' to create this one.", name)
+	}
+	return e
+}
+
+// closestName is the CLI-side spelling suggestion, matching the policy the
+// daemon uses for its hints so the two never disagree.
+func closestName(target string, candidates []string) string {
+	if target == "" {
+		return ""
+	}
+	limit := min(len(target)/4+1, 3)
+
+	best, bestDist := "", limit+1
+	for _, c := range candidates {
+		if c == target {
+			continue
+		}
+		d := editDistance(strings.ToLower(target), strings.ToLower(c))
+		if d < bestDist {
+			bestDist, best = d, c
+		}
+	}
+	if bestDist > limit {
+		return ""
+	}
+	return best
+}
+
+// editDistance is the Levenshtein distance between a and b.
+func editDistance(a, b string) int {
+	ar, br := []rune(a), []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			cur[j] = min(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(br)]
+}
+
+// Terminal capability checks. These run before the TUI takes over the screen,
+// because a TUI that cannot render is far harder to diagnose from inside itself.
+
+// minTerminalWidth and minTerminalHeight are the smallest terminal the window
+// manager can lay out: below this the dockbar, borders, and a usable pane no
+// longer fit, and the UI is unreadable rather than merely cramped.
+const (
+	minTerminalWidth  = 40
+	minTerminalHeight = 12
+)
+
+// checkTerminal verifies the terminal can host the TUI, returning a diagnostic
+// error when it cannot. It checks the three things that produce an unusable or
+// blank screen: not being a terminal at all, being too small, and a TERM value
+// with no capabilities to render with.
+func checkTerminal() error {
+	fd := int(os.Stdout.Fd())
+
+	if !term.IsTerminal(fd) {
+		return &diagnosticError{
+			What:  "Standard output is not a terminal, so the TUIOS interface cannot be displayed.",
+			Cause: "the command was run in a pipe, a redirect, or a non-interactive environment such as CI.",
+			Fix:   "run 'tuios attach' from an interactive terminal. For scripted use, drive the session with 'tuios send-keys' and 'tuios capture-pane' instead.",
+		}
+	}
+
+	if err := checkTerminalSize(fd); err != nil {
+		return err
+	}
+	return checkTerminalCapabilities(os.Getenv("TERM"))
+}
+
+// checkTerminalSize rejects a terminal too small to lay out a session.
+func checkTerminalSize(fd int) error {
+	width, height, err := term.GetSize(fd)
+	if err != nil {
+		// The size is unknowable; that is not itself fatal, and the TUI copes
+		// with a default. Do not block the user on it.
+		return nil
+	}
+	if width >= minTerminalWidth && height >= minTerminalHeight {
+		return nil
+	}
+	return &diagnosticError{
+		What: fmt.Sprintf("The terminal is %dx%d, which is too small to render a TUIOS session (minimum %dx%d).",
+			width, height, minTerminalWidth, minTerminalHeight),
+		Cause: "the window, font size, or split pane leaves too few rows and columns for the dockbar and a usable window.",
+		Fix:   "resize the terminal or reduce the font size, then run this command again.",
+	}
+}
+
+// checkTerminalCapabilities rejects a TERM value that cannot express the cursor
+// movement and styling the renderer needs. Only "dumb" and an unset TERM are
+// genuinely unusable; everything else is allowed through, because guessing at
+// terminfo coverage would reject working terminals.
+func checkTerminalCapabilities(termEnv string) error {
+	switch termEnv {
+	case "":
+		return &diagnosticError{
+			What:  "TERM is not set, so TUIOS cannot tell what the terminal can render.",
+			Cause: "the shell was started without a terminal type, which happens over bare ssh commands, in some CI runners, and inside minimal containers.",
+			Fix:   "set a terminal type, for example 'TERM=xterm-256color tuios attach'.",
+		}
+	case "dumb":
+		return &diagnosticError{
+			What:  `TERM is "dumb", which has no cursor movement or styling, so TUIOS cannot draw its interface.`,
+			Cause: "the terminal reports no capabilities. Emacs shell buffers, some CI runners, and minimal containers do this.",
+			Fix:   "set a capable terminal type, for example 'TERM=xterm-256color tuios attach'.",
+		}
+	}
+	return nil
+}

--- a/cmd/tuios/diagnostics.go
+++ b/cmd/tuios/diagnostics.go
@@ -315,6 +315,13 @@ func checkTerminalSize(fd int) error {
 		// with a default. Do not block the user on it.
 		return nil
 	}
+	// A zero dimension means the terminal has no window size set (a pty opened
+	// by script(1), some CI runners, a detached pty). That is unknown, not
+	// small: the renderer sizes itself from the first resize event instead, so
+	// blocking here would reject setups that go on to work.
+	if width == 0 || height == 0 {
+		return nil
+	}
 	if width >= minTerminalWidth && height >= minTerminalHeight {
 		return nil
 	}

--- a/cmd/tuios/diagnostics_test.go
+++ b/cmd/tuios/diagnostics_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gaurav-Gosain/tuios/internal/app"
 	"github.com/Gaurav-Gosain/tuios/internal/session"
 )
 
@@ -280,5 +281,50 @@ func TestClosestNameMatchesTheDaemonPolicy(t *testing.T) {
 		if got := closestName(tc.target, names); got != tc.want {
 			t.Errorf("closestName(%q) = %q, want %q", tc.target, got, tc.want)
 		}
+	}
+}
+
+// TestReportSessionExitDistinguishesTheOutcomes pins the three ways an attached
+// client can stop. A kill and a lost daemon are not detaches: they must be
+// reported as such and must not exit zero, or a script cannot tell whether its
+// session survived.
+func TestReportSessionExitDistinguishesTheOutcomes(t *testing.T) {
+	tests := []struct {
+		name      string
+		reason    app.ExitReason
+		wantError bool
+		want      []string
+	}{
+		{
+			name:      "normal detach",
+			reason:    app.ExitNormal,
+			wantError: false,
+		},
+		{
+			name:      "session killed underneath the client",
+			reason:    app.ExitSessionKilled,
+			wantError: true,
+			want:      []string{`Session "work" was terminated`, "kill-session", "tuios ls"},
+		},
+		{
+			name:      "daemon lost",
+			reason:    app.ExitDaemonLost,
+			wantError: true,
+			want:      []string{"connection to the TUIOS daemon was lost", "tuios attach work"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := reportSessionExit("work", tc.reason)
+
+			if !tc.wantError {
+				if err != nil {
+					t.Fatalf("a normal detach must not be an error, got: %v", err)
+				}
+				return
+			}
+			requireLines(t, tc.name, err, tc.want...)
+		})
 	}
 }

--- a/cmd/tuios/diagnostics_test.go
+++ b/cmd/tuios/diagnostics_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/session"
+)
+
+// requireLines asserts the three obligations every user-facing failure message
+// carries: it says what failed, it names a likely cause, and it gives a command
+// to run. The whole point of the diagnostic layer is that no message may skip
+// one of these, so this is applied to every case rather than spot-checked.
+func requireLines(t *testing.T, context string, err error, wantFragments ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected an error", context)
+	}
+	msg := err.Error()
+
+	if !strings.Contains(msg, "Most likely cause:") {
+		t.Errorf("%s: message names no likely cause:\n%s", context, msg)
+	}
+	if !strings.Contains(msg, "Fix:") {
+		t.Errorf("%s: message names no fix:\n%s", context, msg)
+	}
+	if !strings.Contains(msg, "tuios ") {
+		t.Errorf("%s: fix does not name a tuios command:\n%s", context, msg)
+	}
+	for _, want := range wantFragments {
+		if !strings.Contains(msg, want) {
+			t.Errorf("%s: message missing %q:\n%s", context, want, msg)
+		}
+	}
+}
+
+// TestDegradedStateMessages is the table of every degraded state the CLI can
+// put in front of a user, and what each must say. Each row asserts the specific
+// remedy alongside the shared what/why/fix structure.
+func TestDegradedStateMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "daemon never started",
+			err:  &diagnosticError{What: session.DaemonDiagnosis{State: session.DaemonAbsent}.Explain()},
+			want: []string{"is not running", "tuios new"},
+		},
+		{
+			name: "stale socket left by a crash",
+			err: &diagnosticError{What: session.DaemonDiagnosis{
+				State:      session.DaemonStaleSocket,
+				SocketPath: "/run/user/1000/tuios/tuios.sock",
+			}.Explain()},
+			want: []string{"stale socket", "/run/user/1000/tuios/tuios.sock", "tuios kill-server"},
+		},
+		{
+			name: "socket owned by another user",
+			err: &diagnosticError{What: session.DaemonDiagnosis{
+				State:      session.DaemonPermissionDenied,
+				SocketPath: "/run/user/1000/tuios/tuios.sock",
+			}.Explain()},
+			want: []string{"Permission denied", "another user", "XDG_RUNTIME_DIR"},
+		},
+		{
+			name: "session name that does not exist",
+			err:  explainMissingSession("wrok", []string{"work", "notes"}),
+			want: []string{`"wrok" was not found`, `Did you mean "work"`, "Sessions: notes, work.", "tuios ls"},
+		},
+		{
+			name: "session name with no sessions at all",
+			err:  explainMissingSession("work", nil),
+			want: []string{"holds no sessions", "tuios new work", "tuios resurrect"},
+		},
+		{
+			name: "terminal too small to render",
+			err: &diagnosticError{
+				What:  "The terminal is 20x5, which is too small to render a TUIOS session (minimum 40x12).",
+				Cause: "the window is too small.",
+				Fix:   "resize the terminal, then run 'tuios attach' again.",
+			},
+			want: []string{"20x5", "too small", "minimum 40x12"},
+		},
+		{
+			name: "TERM with no capabilities",
+			err:  checkTerminalCapabilities("dumb"),
+			want: []string{`TERM is "dumb"`, "TERM=xterm-256color"},
+		},
+		{
+			name: "TERM not set at all",
+			err:  checkTerminalCapabilities(""),
+			want: []string{"TERM is not set", "TERM=xterm-256color"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requireLines(t, tc.name, tc.err, tc.want...)
+		})
+	}
+}
+
+// TestCapableTerminalsAreAccepted is the other half of the capability check:
+// it must not reject terminals that work, or it becomes the problem.
+func TestCapableTerminalsAreAccepted(t *testing.T) {
+	for _, termEnv := range []string{
+		"xterm", "xterm-256color", "screen", "screen-256color",
+		"tmux-256color", "alacritty", "kitty", "wezterm", "linux", "vt100",
+	} {
+		if err := checkTerminalCapabilities(termEnv); err != nil {
+			t.Errorf("TERM=%q was rejected but is renderable: %v", termEnv, err)
+		}
+	}
+}
+
+// TestExplainVerbErrorRendersTheDaemonHint checks the CLI shows the remedy the
+// daemon computed rather than inventing a second one, and that every hint field
+// reaches the user.
+func TestExplainVerbErrorRendersTheDaemonHint(t *testing.T) {
+	err := explainVerbError("list-windows", &session.VerbCallError{
+		Code:    session.ErrVerbSessionNotFound,
+		Message: "session wrok not found",
+		Hint: &session.VerbHint{
+			Param:      "session",
+			Command:    "tuios ls",
+			DidYouMean: "work",
+			Available:  []string{"work", "notes"},
+		},
+	})
+
+	msg := err.Error()
+	for _, want := range []string{
+		"list-windows failed",
+		"session wrok not found",
+		`Did you mean "work"?`,
+		"Available: work, notes.",
+		"Fix: run 'tuios ls'.",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestExplainVerbErrorNamesAcceptedValues covers the invalid_params shape an
+// agent hits most: a closed value set the caller guessed wrong.
+func TestExplainVerbErrorNamesAcceptedValues(t *testing.T) {
+	err := explainVerbError("wait-for", &session.VerbCallError{
+		Code:    session.ErrVerbInvalidParams,
+		Message: "unknown condition window-outpt",
+		Hint: &session.VerbHint{
+			Param:      "condition",
+			Accepted:   []string{"session-exists", "window-output", "window-exit", "window-idle"},
+			DidYouMean: "window-output",
+		},
+	})
+
+	msg := err.Error()
+	for _, want := range []string{
+		"Accepted values for condition:",
+		"window-output, window-exit, window-idle",
+		`Did you mean "window-output"?`,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestExplainVerbErrorWithoutHintStillNamesTheCode makes sure an error the
+// daemon did not annotate degrades to something usable rather than losing the
+// code entirely.
+func TestExplainVerbErrorWithoutHintStillNamesTheCode(t *testing.T) {
+	err := explainVerbError("resize", &session.VerbCallError{
+		Code:    session.ErrVerbInternal,
+		Message: "ioctl failed",
+	})
+	msg := err.Error()
+	if !strings.Contains(msg, "resize failed: ioctl failed") {
+		t.Errorf("message lost the failure: %s", msg)
+	}
+	if !strings.Contains(msg, session.ErrVerbInternal) {
+		t.Errorf("message lost the error code: %s", msg)
+	}
+}
+
+// TestExplainVerbErrorPassesThroughNonVerbErrors keeps transport failures from
+// being mislabeled as verb failures.
+func TestExplainVerbErrorPassesThroughNonVerbErrors(t *testing.T) {
+	original := errors.New("connection reset by peer")
+	if got := explainVerbError("send-keys", original); !errors.Is(got, original) {
+		t.Errorf("a non-verb error should pass through unchanged, got %v", got)
+	}
+}
+
+// TestExplainDialErrorPassesThroughMismatch is the CLI half of the upgrade bug:
+// the protocol mismatch must reach the user with its own message, not be
+// rewritten into a generic connection failure.
+func TestExplainDialErrorPassesThroughMismatch(t *testing.T) {
+	mismatch := &session.ProtocolMismatchError{
+		ClientVersion: "1.4.0",
+		DaemonVersion: "0.9.0",
+	}
+
+	got := explainDialError(mismatch)
+
+	var out *session.ProtocolMismatchError
+	if !errors.As(got, &out) {
+		t.Fatalf("mismatch was rewritten into %T: %v", got, got)
+	}
+	msg := got.Error()
+	for _, want := range []string{"daemon 0.9.0", "CLI 1.4.0", "tuios kill-server"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestDiagnosticErrorUnwraps keeps errors.Is/As working through the diagnostic
+// wrapper, so callers can still branch on the underlying cause.
+func TestDiagnosticErrorUnwraps(t *testing.T) {
+	underlying := errors.New("boom")
+	d := &diagnosticError{What: "Something failed.", Err: underlying}
+	if !errors.Is(d, underlying) {
+		t.Error("diagnosticError does not unwrap to its cause")
+	}
+}
+
+// TestDiagnosticErrorLayout pins the message shape, since the value of this
+// layer is that every message reads the same way.
+func TestDiagnosticErrorLayout(t *testing.T) {
+	d := &diagnosticError{
+		What:  "Session was not found.",
+		Cause: "the name is wrong.",
+		Extra: []string{"Sessions: a, b."},
+		Fix:   "run 'tuios ls'.",
+	}
+	want := "Session was not found.\n" +
+		"Most likely cause: the name is wrong.\n" +
+		"Sessions: a, b.\n" +
+		"Fix: run 'tuios ls'."
+	if got := d.Error(); got != want {
+		t.Errorf("layout:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestTruncateList keeps a long list of window ids from burying the fix line.
+func TestTruncateList(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	if got := truncateList(items, 10); len(got) != 5 {
+		t.Errorf("a short list should pass through unchanged, got %v", got)
+	}
+	got := truncateList(items, 2)
+	if len(got) != 3 || got[2] != "and 3 more" {
+		t.Errorf("truncateList = %v, want the first 2 plus a remainder note", got)
+	}
+}
+
+// TestClosestNameMatchesTheDaemonPolicy keeps the CLI's suggestion policy
+// aligned with the daemon's, so the two never disagree about what a typo meant.
+func TestClosestNameMatchesTheDaemonPolicy(t *testing.T) {
+	names := []string{"work", "notes", "scratch"}
+
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{"wrok", "work"},
+		{"scratchh", "scratch"},
+		{"note", "notes"},
+		{"work", ""},
+		{"", ""},
+		{"completely-different", ""},
+	}
+	for _, tc := range tests {
+		if got := closestName(tc.target, names); got != tc.want {
+			t.Errorf("closestName(%q) = %q, want %q", tc.target, got, tc.want)
+		}
+	}
+}

--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -890,6 +890,38 @@ Use --json for machine-readable output.`,
 	sessionInfoCmd.Flags().BoolVar(&sessionInfoJSON, "json", false, "Output as JSON")
 	_ = sessionInfoCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
 
+	var listVerbsJSON bool
+	listVerbsCmd := &cobra.Command{
+		Use:   "list-verbs [verb]",
+		Short: "List the control-protocol verbs the daemon supports",
+		Long: `List every verb the daemon's JSON control protocol supports, with its
+parameter schema and example requests.
+
+This is the discovery entry point for scripting and for agents driving TUIOS:
+it reports the protocol version, every verb and parameter, the stable error
+codes, and the request/response envelope shape, so no documentation is needed
+to drive the control plane.
+
+Name a verb to describe only that verb.`,
+		Example: `  # Every verb with its parameters
+  tuios list-verbs
+
+  # Just one verb
+  tuios list-verbs capture-pane
+
+  # Machine-readable, for an agent or a script
+  tuios list-verbs --json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			verb := ""
+			if len(args) > 0 {
+				verb = args[0]
+			}
+			return runListVerbs(verb, listVerbsJSON)
+		},
+	}
+	listVerbsCmd.Flags().BoolVar(&listVerbsJSON, "json", false, "Output as JSON")
+
 	// Layout template commands
 	layoutCmd := &cobra.Command{
 		Use:   "layout",
@@ -962,12 +994,13 @@ Use --json for machine-readable output.`,
 	rootCmd.AddCommand(attachCmd, newCmd, lsCmd, killSessionCmd, resurrectCmd)
 	rootCmd.AddCommand(startDaemonCmd, daemonCmd, killDaemonCmd)
 	rootCmd.AddCommand(sendKeysCmd, runCommandCmd, setConfigCmd, getConfigCmd, logsCmd, capturePaneCmd)
-	rootCmd.AddCommand(listWindowsCmd, getWindowCmd, sessionInfoCmd)
+	rootCmd.AddCommand(listWindowsCmd, getWindowCmd, sessionInfoCmd, listVerbsCmd)
 
 	if err := fang.Execute(
 		context.Background(),
 		rootCmd,
 		fang.WithVersion(fmt.Sprintf("%s\nCommit: %s\nBuilt: %s\nBy: %s", version, commit, date, builtBy)),
+		fang.WithErrorHandler(diagnosticErrorHandler),
 	); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -710,6 +710,29 @@ Supported configuration paths:
 	setConfigCmd.Flags().StringVarP(&setConfigSession, "session", "s", "", "Target session (default: most recently active)")
 	_ = setConfigCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
 
+	var getConfigSession string
+	getConfigCmd := &cobra.Command{
+		Use:   "get-config <path>",
+		Short: "Read a session option from a running TUIOS session",
+		Long: `Read a session option previously set with 'tuios set-config' from a
+running TUIOS session. Options are recorded in daemon-owned state, so this works
+whether or not a TUI client is attached.`,
+		Example: `  # Read the border style
+  tuios get-config border_style`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runGetConfig(getConfigSession, args[0])
+		},
+	}
+	getConfigCmd.Flags().StringVarP(&getConfigSession, "session", "s", "", "Target session (default: most recently active)")
+	_ = getConfigCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
+	getConfigCmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return getConfigPathCompletions(toComplete), cobra.ShellCompDirectiveNoFileComp
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// Add completion for set-config
 	setConfigCmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -938,7 +961,7 @@ Use --json for machine-readable output.`,
 	rootCmd.AddCommand(sshCmd, configCmd, keybindsCmd, tapeCmd, layoutCmd)
 	rootCmd.AddCommand(attachCmd, newCmd, lsCmd, killSessionCmd, resurrectCmd)
 	rootCmd.AddCommand(startDaemonCmd, daemonCmd, killDaemonCmd)
-	rootCmd.AddCommand(sendKeysCmd, runCommandCmd, setConfigCmd, logsCmd, capturePaneCmd)
+	rootCmd.AddCommand(sendKeysCmd, runCommandCmd, setConfigCmd, getConfigCmd, logsCmd, capturePaneCmd)
 	rootCmd.AddCommand(listWindowsCmd, getWindowCmd, sessionInfoCmd)
 
 	if err := fang.Execute(

--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -358,6 +358,7 @@ This requires the TUIOS daemon to be running.`,
 	}
 	attachCmd.Flags().BoolVarP(&createIfMissing, "create", "c", false, "Create session if it doesn't exist")
 
+	var newDetach bool
 	newCmd := &cobra.Command{
 		Use:   "new [session-name]",
 		Short: "Create a new TUIOS session",
@@ -366,22 +367,33 @@ This requires the TUIOS daemon to be running.`,
 This starts a new session in the daemon (starting the daemon if needed)
 and immediately attaches you to it.
 
+With --detach the session is created headless (no client attached): it
+gets an initial window, is immediately usable by control commands
+(send-keys, run-command, capture-pane), and can be attached later.
+
 Sessions persist even when you detach, allowing you to reconnect later
 with 'tuios attach'.`,
 		Example: `  # Create a new session with auto-generated name
   tuios new
 
   # Create a named session
-  tuios new mysession`,
+  tuios new mysession
+
+  # Create a headless session without attaching
+  tuios new mysession --detach`,
 		Aliases: []string{"n"},
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := ""
 			if len(args) > 0 {
 				name = args[0]
 			}
+			if newDetach {
+				return runNewSessionDetached(name)
+			}
 			return runNewSession(name)
 		},
 	}
+	newCmd.Flags().BoolVarP(&newDetach, "detach", "d", false, "Create the session headless without attaching a client")
 
 	var lsJSON bool
 	lsCmd := &cobra.Command{

--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -503,7 +503,11 @@ Debug log levels:
 		Short: "Stop the TUIOS daemon",
 		Long: `Stop the TUIOS daemon.
 
-This will terminate all sessions and disconnect all clients.`,
+This will stop all sessions and disconnect all clients.
+
+The command is synchronous: it returns only once the daemon has saved every
+session's state and removed its socket, so a new daemon can be started as soon
+as it returns. It fails if the daemon has not finished within 10 seconds.`,
 		Example: `  tuios kill-server`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runKillDaemon()

--- a/cmd/tuios/remote_commands.go
+++ b/cmd/tuios/remote_commands.go
@@ -15,94 +15,97 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// runSendKeys sends keystrokes to a running TUIOS session.
-func runSendKeys(sessionName, keys string, literal bool, raw bool, windowTarget string) error {
+// dialVerb connects to the daemon for a JSON verb-protocol call, or returns a
+// helpful error when the daemon is not running.
+func dialVerb() (*session.VerbClient, error) {
 	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
+		return nil, fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
 	}
+	client, err := session.DialVerbClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	return client, nil
+}
 
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
+// printVerbResult renders a verb result in the CLI's --json contract shape
+// (success/message plus the result fields), or a short human line otherwise.
+func printVerbResult(raw json.RawMessage, jsonOutput bool) error {
+	if !jsonOutput {
+		fmt.Println("Command executed successfully")
+		return nil
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	out := map[string]any{"success": true, "message": "command executed"}
+	for k, v := range fields {
+		if k == "type" {
+			continue
+		}
+		out[k] = v
+	}
+	outputJSON(out)
+	return nil
+}
 
-	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+// reportVerbError renders a failed verb call, honoring --json by printing a
+// {success:false,error} object and exiting non-zero.
+func reportVerbError(err error, jsonOutput bool) error {
+	if jsonOutput {
+		outputJSON(map[string]any{"success": false, "error": err.Error()})
+		os.Exit(1)
+	}
+	return err
+}
+
+// runSendKeys sends keystrokes to a running TUIOS session over the verb protocol.
+func runSendKeys(sessionName, keys string, literal bool, raw bool, windowTarget string) error {
+	client, err := dialVerb()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := uuid.New().String()
-
-	// Send the keys command
-	msg, err := session.NewMessage(session.MsgSendKeys, &session.SendKeysPayload{
-		SessionName:  sessionName,
-		Keys:         keys,
-		Literal:      literal,
-		Raw:          raw,
-		WindowTarget: windowTarget,
-		RequestID:    requestID,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create message: %w", err)
+	if _, err := client.Call("send-keys", map[string]any{
+		"session": sessionName,
+		"window":  windowTarget,
+		"keys":    keys,
+		"literal": literal,
+		"raw":     raw,
+	}); err != nil {
+		return fmt.Errorf("send-keys failed: %w", err)
 	}
-
-	if err := sendAndWaitForResult(client, msg, requestID); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // runCapturePane captures the content of a pane and prints to stdout.
 func runCapturePane(sessionName, windowTarget string, scrollback, ansi bool) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
-	}
-
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+	client, err := dialVerb()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := uuid.New().String()
-
-	msg, err := session.NewMessage(session.MsgCapturePane, &session.CapturePanePayload{
-		SessionName:  sessionName,
-		WindowTarget: windowTarget,
-		Scrollback:   scrollback,
-		ANSI:         ansi,
-		RequestID:    requestID,
+	raw, err := client.Call("capture-pane", map[string]any{
+		"session":    sessionName,
+		"window":     windowTarget,
+		"scrollback": scrollback,
+		"ansi":       ansi,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create message: %w", err)
+		return fmt.Errorf("capture failed: %w", err)
 	}
 
-	resp, err := client.SendControlMessage(msg)
-	if err != nil {
-		return fmt.Errorf("failed to send command: %w", err)
+	var res struct {
+		Content string `json:"content"`
 	}
-
-	switch resp.Type {
-	case session.MsgCommandResult:
-		var result session.CommandResultPayload
-		if err := resp.ParsePayloadWithCodec(&result, client.GetCodec()); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
-		}
-		if !result.Success {
-			return fmt.Errorf("capture failed: %s", result.Message)
-		}
-		if content, ok := result.Data["content"].(string); ok {
-			fmt.Print(content)
-		}
-		return nil
-	case session.MsgError:
-		return fmt.Errorf("server error: %s", string(resp.Payload))
-	default:
-		return fmt.Errorf("unexpected response type: %d", resp.Type)
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
 	}
+	fmt.Print(res.Content)
+	return nil
 }
 
 // runCommand executes a tape command in a running TUIOS session.
@@ -140,102 +143,78 @@ func runCommand(sessionName, command string, args []string, jsonOutput bool) err
 	return nil
 }
 
-// queryWindows queries window list directly from daemon (doesn't require TUI).
+// queryWindows queries the window list over the verb protocol (no TUI required).
 func queryWindows(sessionName string, jsonOutput bool) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
-	}
-
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+	client, err := dialVerb()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := uuid.New().String()
-
-	msg, err := session.NewMessage(session.MsgQueryWindows, &session.QueryWindowsPayload{
-		SessionName: sessionName,
-		RequestID:   requestID,
-	})
+	raw, err := client.Call("list-windows", map[string]any{"session": sessionName})
 	if err != nil {
-		return fmt.Errorf("failed to create message: %w", err)
+		return reportVerbError(fmt.Errorf("list-windows failed: %w", err), jsonOutput)
 	}
-
-	if err := sendAndWaitForResultWithFormat(client, msg, requestID, jsonOutput); err != nil {
-		return err
-	}
-
-	return nil
+	return printVerbResult(raw, jsonOutput)
 }
 
-// querySession queries session info directly from daemon (doesn't require TUI).
+// querySession queries session info over the verb protocol (no TUI required).
 func querySession(sessionName string, jsonOutput bool) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
-	}
-
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+	client, err := dialVerb()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := uuid.New().String()
-
-	msg, err := session.NewMessage(session.MsgQuerySession, &session.QuerySessionPayload{
-		SessionName: sessionName,
-		RequestID:   requestID,
-	})
+	raw, err := client.Call("session-info", map[string]any{"session": sessionName})
 	if err != nil {
-		return fmt.Errorf("failed to create message: %w", err)
+		return reportVerbError(fmt.Errorf("session-info failed: %w", err), jsonOutput)
 	}
+	return printVerbResult(raw, jsonOutput)
+}
 
-	if err := sendAndWaitForResultWithFormat(client, msg, requestID, jsonOutput); err != nil {
+// runSetConfig sets a session option over the verb protocol. The value is
+// recorded in daemon-owned state and, when a TUI is attached, applied live.
+func runSetConfig(sessionName, path, value string) error {
+	client, err := dialVerb()
+	if err != nil {
 		return err
 	}
+	defer func() { _ = client.Close() }()
 
+	if _, err := client.Call("set-option", map[string]any{
+		"session": sessionName,
+		"key":     path,
+		"value":   value,
+	}); err != nil {
+		return fmt.Errorf("set-option failed: %w", err)
+	}
+	fmt.Printf("Set %s = %s\n", path, value)
 	return nil
 }
 
-// runSetConfig sets a configuration option in a running TUIOS session.
-func runSetConfig(sessionName, path, value string) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
-	}
-
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+// runGetConfig reads a session option over the verb protocol.
+func runGetConfig(sessionName, path string) error {
+	client, err := dialVerb()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := uuid.New().String()
-
-	// Send the set config command
-	msg, err := session.NewMessage(session.MsgSetConfig, &session.SetConfigPayload{
-		SessionName: sessionName,
-		Path:        path,
-		Value:       value,
-		RequestID:   requestID,
+	raw, err := client.Call("get-option", map[string]any{
+		"session": sessionName,
+		"key":     path,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create message: %w", err)
+		return fmt.Errorf("get-option failed: %w", err)
 	}
-
-	if err := sendAndWaitForResult(client, msg, requestID); err != nil {
-		return err
+	var res struct {
+		Value string `json:"value"`
 	}
-
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	fmt.Println(res.Value)
 	return nil
 }
 

--- a/cmd/tuios/remote_commands.go
+++ b/cmd/tuios/remote_commands.go
@@ -15,17 +15,93 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// dialVerb connects to the daemon for a JSON verb-protocol call, or returns a
-// helpful error when the daemon is not running.
-func dialVerb() (*session.VerbClient, error) {
-	if !session.IsDaemonRunning() {
-		return nil, fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
-	}
-	client, err := session.DialVerbClient()
+// runListVerbs prints the control protocol's verb catalog. It is the discovery
+// entry point the daemon's own error hints point at, so it must work whenever
+// the daemon does, and say why when it does not.
+func runListVerbs(verb string, jsonOutput bool) error {
+	client, err := dialVerb()
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to daemon: %w", err)
+		return err
 	}
-	return client, nil
+	defer func() { _ = client.Close() }()
+
+	var params any
+	if verb != "" {
+		params = map[string]any{"verb": verb}
+	}
+	raw, err := client.Call("list-verbs", params)
+	if err != nil {
+		return explainVerbError("list-verbs", err)
+	}
+
+	if jsonOutput {
+		var pretty any
+		if err := json.Unmarshal(raw, &pretty); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+		outputJSON(pretty)
+		return nil
+	}
+
+	var catalog struct {
+		Version       int    `json:"version"`
+		MinVersion    int    `json:"min_version"`
+		DaemonVersion string `json:"daemon_version"`
+		Verbs         []struct {
+			Verb        string `json:"verb"`
+			Description string `json:"description"`
+			Params      []struct {
+				Name        string   `json:"name"`
+				Type        string   `json:"type"`
+				Required    bool     `json:"required"`
+				Description string   `json:"description"`
+				Accepted    []string `json:"accepted"`
+				Default     string   `json:"default"`
+			} `json:"params"`
+			Examples []string `json:"examples"`
+		} `json:"verbs"`
+		ErrorCodes []struct {
+			Code        string `json:"code"`
+			Description string `json:"description"`
+		} `json:"error_codes"`
+	}
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	fmt.Printf("Control protocol version %d (daemon %s, oldest supported %d)\n\n",
+		catalog.Version, catalog.DaemonVersion, catalog.MinVersion)
+
+	for _, v := range catalog.Verbs {
+		fmt.Printf("%s\n  %s\n", v.Verb, v.Description)
+		for _, p := range v.Params {
+			required := ""
+			if p.Required {
+				required = " (required)"
+			}
+			fmt.Printf("    %-10s %-8s%s %s\n", p.Name, p.Type, required, p.Description)
+			if len(p.Accepted) > 0 {
+				fmt.Printf("    %-10s %s\n", "", "one of: "+strings.Join(p.Accepted, ", "))
+			}
+			if p.Default != "" {
+				fmt.Printf("    %-10s %s\n", "", "default: "+p.Default)
+			}
+		}
+		for _, ex := range v.Examples {
+			fmt.Printf("    example: %s\n", ex)
+		}
+		fmt.Println()
+	}
+
+	// The error vocabulary only makes sense alongside the whole catalog, so it
+	// is omitted when a single verb was requested.
+	if verb == "" && len(catalog.ErrorCodes) > 0 {
+		fmt.Println("Error codes:")
+		for _, e := range catalog.ErrorCodes {
+			fmt.Printf("  %-18s %s\n", e.Code, e.Description)
+		}
+	}
+	return nil
 }
 
 // printVerbResult renders a verb result in the CLI's --json contract shape
@@ -75,7 +151,7 @@ func runSendKeys(sessionName, keys string, literal bool, raw bool, windowTarget 
 		"literal": literal,
 		"raw":     raw,
 	}); err != nil {
-		return fmt.Errorf("send-keys failed: %w", err)
+		return explainVerbError("send-keys", err)
 	}
 	return nil
 }
@@ -95,7 +171,7 @@ func runCapturePane(sessionName, windowTarget string, scrollback, ansi bool) err
 		"ansi":       ansi,
 	})
 	if err != nil {
-		return fmt.Errorf("capture failed: %w", err)
+		return explainVerbError("capture-pane", err)
 	}
 
 	var res struct {
@@ -110,8 +186,8 @@ func runCapturePane(sessionName, windowTarget string, scrollback, ansi bool) err
 
 // runCommand executes a tape command in a running TUIOS session.
 func runCommand(sessionName, command string, args []string, jsonOutput bool) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
+	if err := requireDaemon(); err != nil {
+		return err
 	}
 
 	client := session.NewClient(&session.ClientConfig{
@@ -119,7 +195,7 @@ func runCommand(sessionName, command string, args []string, jsonOutput bool) err
 	})
 
 	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	defer func() { _ = client.Close() }()
 
@@ -153,7 +229,7 @@ func queryWindows(sessionName string, jsonOutput bool) error {
 
 	raw, err := client.Call("list-windows", map[string]any{"session": sessionName})
 	if err != nil {
-		return reportVerbError(fmt.Errorf("list-windows failed: %w", err), jsonOutput)
+		return reportVerbError(explainVerbError("list-windows", err), jsonOutput)
 	}
 	return printVerbResult(raw, jsonOutput)
 }
@@ -168,7 +244,7 @@ func querySession(sessionName string, jsonOutput bool) error {
 
 	raw, err := client.Call("session-info", map[string]any{"session": sessionName})
 	if err != nil {
-		return reportVerbError(fmt.Errorf("session-info failed: %w", err), jsonOutput)
+		return reportVerbError(explainVerbError("session-info", err), jsonOutput)
 	}
 	return printVerbResult(raw, jsonOutput)
 }
@@ -187,7 +263,7 @@ func runSetConfig(sessionName, path, value string) error {
 		"key":     path,
 		"value":   value,
 	}); err != nil {
-		return fmt.Errorf("set-option failed: %w", err)
+		return explainVerbError("set-option", err)
 	}
 	fmt.Printf("Set %s = %s\n", path, value)
 	return nil
@@ -206,7 +282,7 @@ func runGetConfig(sessionName, path string) error {
 		"key":     path,
 	})
 	if err != nil {
-		return fmt.Errorf("get-option failed: %w", err)
+		return explainVerbError("get-option", err)
 	}
 	var res struct {
 		Value string `json:"value"`
@@ -220,8 +296,8 @@ func runGetConfig(sessionName, path string) error {
 
 // runTapeExec executes a tape file in a running TUIOS session.
 func runTapeExec(sessionName, filePath string) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running. Start a session first with 'tuios new'")
+	if err := requireDaemon(); err != nil {
+		return err
 	}
 
 	// Read the tape file
@@ -245,7 +321,7 @@ func runTapeExec(sessionName, filePath string) error {
 	})
 
 	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	defer func() { _ = client.Close() }()
 
@@ -625,8 +701,8 @@ func getConfigValueCompletions(path, _ string) []string {
 
 // runGetLogs retrieves and displays daemon logs.
 func runGetLogs(count int, clear bool, follow bool) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running")
+	if err := requireDaemon(); err != nil {
+		return err
 	}
 
 	client := session.NewClient(&session.ClientConfig{
@@ -634,7 +710,7 @@ func runGetLogs(count int, clear bool, follow bool) error {
 	})
 
 	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	defer func() { _ = client.Close() }()
 

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -60,6 +60,44 @@ func runNewSession(sessionName string) error {
 	return runDaemonSession(sessionName, true)
 }
 
+// runNewSessionDetached creates a headless session in the daemon and returns
+// without launching the TUI. The session holds an initial window, is usable by
+// control verbs immediately, and can be attached later with 'tuios attach'.
+func runNewSessionDetached(sessionName string) error {
+	if !session.IsDaemonRunning() {
+		fmt.Println("Starting TUIOS daemon...")
+		if err := startDaemonBackground(); err != nil {
+			return fmt.Errorf("failed to start daemon: %w", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	client := session.NewClient(&session.ClientConfig{Version: version})
+	if err := client.Connect(); err != nil {
+		return fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if sessionName == "" {
+		sessions, err := client.ListSessions()
+		if err != nil {
+			return fmt.Errorf("failed to list sessions: %w", err)
+		}
+		existing := make([]string, len(sessions))
+		for i, s := range sessions {
+			existing[i] = s.Name
+		}
+		sessionName = generateUniqueSessionName(existing)
+	}
+
+	if err := client.CreateDetachedSession(sessionName, 80, 24); err != nil {
+		return err
+	}
+
+	fmt.Printf("Created detached session '%s'. Attach with 'tuios attach %s'.\n", sessionName, sessionName)
+	return nil
+}
+
 func generateUniqueSessionName(existingNames []string) string {
 	existing := make(map[string]bool)
 	for _, name := range existingNames {

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -351,19 +351,23 @@ func runListSessions(jsonOutput bool) error {
 		return nil
 	}
 
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
+	client, err := session.DialVerbClient()
+	if err != nil {
 		return fmt.Errorf("failed to connect to daemon: %w", err)
 	}
 	defer func() { _ = client.Close() }()
 
-	sessions, err := client.ListSessions()
+	raw, err := client.Call("list-sessions", nil)
 	if err != nil {
 		return err
 	}
+	var listed struct {
+		Sessions []session.SessionInfo `json:"sessions"`
+	}
+	if err := json.Unmarshal(raw, &listed); err != nil {
+		return fmt.Errorf("failed to parse sessions: %w", err)
+	}
+	sessions := listed.Sessions
 
 	if jsonOutput {
 		data, err := json.MarshalIndent(sessions, "", "  ")
@@ -466,16 +470,13 @@ func runKillSession(sessionName string) error {
 		return fmt.Errorf("TUIOS daemon is not running")
 	}
 
-	client := session.NewClient(&session.ClientConfig{
-		Version: version,
-	})
-
-	if err := client.Connect(); err != nil {
+	client, err := session.DialVerbClient()
+	if err != nil {
 		return fmt.Errorf("failed to connect to daemon: %w", err)
 	}
 	defer func() { _ = client.Close() }()
 
-	if err := client.KillSession(sessionName); err != nil {
+	if _, err := client.Call("kill-session", map[string]any{"session": sessionName}); err != nil {
 		return err
 	}
 

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,26 +21,123 @@ import (
 )
 
 func runAttach(sessionName string, createIfMissing bool) error {
-	if !session.IsDaemonRunning() {
-		if createIfMissing {
-			fmt.Println("Starting TUIOS daemon...")
-			if err := startDaemonBackground(); err != nil {
-				return fmt.Errorf("failed to start daemon: %w", err)
-			}
-			time.Sleep(500 * time.Millisecond)
-		} else {
-			return fmt.Errorf("TUIOS daemon is not running. Use 'tuios new' to create a session")
+	// Check the terminal before anything else: a session that cannot be
+	// rendered is much harder to diagnose once the TUI has taken the screen.
+	if err := checkTerminal(); err != nil {
+		return err
+	}
+
+	diag := session.DiagnoseDaemon()
+	if !diag.Running() {
+		if !createIfMissing {
+			return explainAttachWithoutDaemon(sessionName, diag)
 		}
+		fmt.Println("Starting TUIOS daemon...")
+		if err := startDaemonBackground(); err != nil {
+			return &diagnosticError{
+				What:  fmt.Sprintf("The TUIOS daemon could not be started: %v.", err),
+				Cause: "the tuios binary could not be re-executed, or the socket directory is not writable.",
+				Fix:   "run 'tuios daemon' in another terminal to see why it fails to start.",
+				Err:   err,
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if err := ensureAttachTarget(sessionName, createIfMissing); err != nil {
+		return err
 	}
 
 	return runDaemonSession(sessionName, createIfMissing)
+}
+
+// explainAttachWithoutDaemon reports that attach found no daemon, and adds the
+// one thing a user in that state most wants to know: whether the session they
+// asked for is saved and can be brought back.
+func explainAttachWithoutDaemon(sessionName string, diag session.DaemonDiagnosis) error {
+	e := &diagnosticError{What: diag.Explain(), Err: diag.Err}
+
+	if sessionName == "" {
+		return e
+	}
+	infos, err := session.ListResurrectableInfos()
+	if err != nil {
+		return e
+	}
+	for _, info := range infos {
+		if info.Name == sessionName {
+			e.Extra = append(e.Extra, fmt.Sprintf("Session %q has saved state (%d window(s)) and can be restored.", sessionName, info.WindowCount))
+			e.Fix = fmt.Sprintf("run 'tuios resurrect %s' to restore it and attach.", sessionName)
+			return e
+		}
+	}
+	return e
+}
+
+// ensureAttachTarget verifies the named session exists before the TUI starts,
+// so a typo produces a list of real names instead of an empty screen or a
+// silently created session. It is a no-op when no name was given (attach picks
+// the most recent session) or when the caller asked to create the session.
+func ensureAttachTarget(sessionName string, createIfMissing bool) error {
+	if sessionName == "" || createIfMissing {
+		return nil
+	}
+
+	client, err := dialVerb()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	sessions, err := listSessionInfos(client)
+	if err != nil {
+		// Listing is a courtesy; if it fails, let the attach itself report.
+		return nil
+	}
+
+	names := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		names = append(names, s.Name)
+		if s.Name != sessionName {
+			continue
+		}
+		if s.Attached {
+			// Attaching to an already-attached session is supported, not an
+			// error, but the shared screen size surprises people who expect
+			// tmux's exclusive attach. Say so rather than letting them wonder
+			// why their window shrank.
+			fmt.Printf("Session %q already has a client attached; TUIOS shares it between clients and renders at the smallest client's size.\n", sessionName)
+		}
+		return nil
+	}
+	return explainMissingSession(sessionName, names)
+}
+
+// listSessionInfos returns the live sessions over the verb protocol.
+func listSessionInfos(client *session.VerbClient) ([]session.SessionInfo, error) {
+	raw, err := client.Call("list-sessions", nil)
+	if err != nil {
+		return nil, err
+	}
+	var listed struct {
+		Sessions []session.SessionInfo `json:"sessions"`
+	}
+	if err := json.Unmarshal(raw, &listed); err != nil {
+		return nil, err
+	}
+	return listed.Sessions, nil
 }
 
 func runNewSession(sessionName string) error {
 	if !session.IsDaemonRunning() {
 		fmt.Println("Starting TUIOS daemon...")
 		if err := startDaemonBackground(); err != nil {
-			return fmt.Errorf("failed to start daemon: %w", err)
+			return &diagnosticError{
+				What:  fmt.Sprintf("The TUIOS daemon could not be started: %v.", err),
+				Cause: "the tuios binary could not be re-executed, or the socket directory is not writable.",
+				Fix:   "run 'tuios daemon' in another terminal to see why it fails to start.",
+				Err:   err,
+			}
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
@@ -47,7 +145,7 @@ func runNewSession(sessionName string) error {
 	if sessionName == "" {
 		client := session.NewTUIClient()
 		if err := client.Connect(version, 80, 24); err != nil {
-			return fmt.Errorf("failed to connect to daemon: %w", err)
+			return explainDialError(err)
 		}
 
 		existingNames := client.AvailableSessionNames()
@@ -67,14 +165,19 @@ func runNewSessionDetached(sessionName string) error {
 	if !session.IsDaemonRunning() {
 		fmt.Println("Starting TUIOS daemon...")
 		if err := startDaemonBackground(); err != nil {
-			return fmt.Errorf("failed to start daemon: %w", err)
+			return &diagnosticError{
+				What:  fmt.Sprintf("The TUIOS daemon could not be started: %v.", err),
+				Cause: "the tuios binary could not be re-executed, or the socket directory is not writable.",
+				Fix:   "run 'tuios daemon' in another terminal to see why it fails to start.",
+				Err:   err,
+			}
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	client := session.NewClient(&session.ClientConfig{Version: version})
 	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	defer func() { _ = client.Close() }()
 
@@ -113,6 +216,12 @@ func generateUniqueSessionName(existingNames []string) string {
 }
 
 func runDaemonSession(sessionName string, createNew bool) error {
+	// Every path into the TUI funnels through here, so this is the one place
+	// that guarantees the terminal can host it before the screen is taken over.
+	if err := checkTerminal(); err != nil {
+		return err
+	}
+
 	if debugMode {
 		_ = os.Setenv("TUIOS_DEBUG_INTERNAL", "1")
 		fmt.Println("Debug mode enabled")
@@ -171,15 +280,24 @@ func runDaemonSession(sessionName string, createNew bool) error {
 	width, height := 80, 24
 
 	if err := client.ConnectWithCapabilities(version, width, height, clientCaps); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	log.Printf("[CLIENT] Connected to daemon")
 
 	log.Printf("[CLIENT] Attaching to session '%s' (createNew=%v)", sessionName, createNew)
 	state, err := client.AttachSession(sessionName, createNew, width, height)
 	if err != nil {
+		names := client.AvailableSessionNames()
 		_ = client.Close()
-		return fmt.Errorf("failed to attach to session: %w", err)
+		if !createNew && sessionName != "" {
+			return explainMissingSession(sessionName, names)
+		}
+		return &diagnosticError{
+			What:  fmt.Sprintf("Could not attach to session %q: %v.", sessionName, err),
+			Cause: "the daemon refused the attach, usually because the session was killed between listing and attaching.",
+			Fix:   "run 'tuios ls' to see live sessions, or 'tuios new' to create one.",
+			Err:   err,
+		}
 	}
 	log.Printf("[CLIENT] Attached to session, got state")
 
@@ -342,24 +460,25 @@ func runDaemonSession(sessionName string, createNew bool) error {
 }
 
 func runListSessions(jsonOutput bool) error {
-	if !session.IsDaemonRunning() {
+	diag := session.DiagnoseDaemon()
+	if !diag.Running() {
 		if jsonOutput {
 			fmt.Println("[]")
 		} else {
-			fmt.Println("TUIOS daemon is not running. No sessions available.")
+			fmt.Println(diag.Explain())
 		}
 		return nil
 	}
 
-	client, err := session.DialVerbClient()
+	client, err := dialVerb()
 	if err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
 	raw, err := client.Call("list-sessions", nil)
 	if err != nil {
-		return err
+		return explainVerbError("list-sessions", err)
 	}
 	var listed struct {
 		Sessions []session.SessionInfo `json:"sessions"`
@@ -379,7 +498,7 @@ func runListSessions(jsonOutput bool) error {
 	}
 
 	if len(sessions) == 0 {
-		fmt.Println("No sessions.")
+		fmt.Println("No sessions. Create one with 'tuios new', or run 'tuios resurrect' to see saved sessions.")
 		return nil
 	}
 
@@ -466,18 +585,14 @@ func formatTimeAgo(unixTime int64) string {
 }
 
 func runKillSession(sessionName string) error {
-	if !session.IsDaemonRunning() {
-		return fmt.Errorf("TUIOS daemon is not running")
-	}
-
-	client, err := session.DialVerbClient()
+	client, err := dialVerb()
 	if err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return err
 	}
 	defer func() { _ = client.Close() }()
 
 	if _, err := client.Call("kill-session", map[string]any{"session": sessionName}); err != nil {
-		return err
+		return explainVerbError("kill-session", err)
 	}
 
 	fmt.Printf("Killed session: %s\n", sessionName)
@@ -518,6 +633,66 @@ func runResurrect(sessionName string) error {
 	return runDaemonSession(sessionName, false)
 }
 
+// explainResurrectFailure turns a failed restore into a message that says which
+// of the several reasons applies: no saved state at all, or state that exists
+// but cannot be read by this build. The daemon archives unreadable state rather
+// than deleting it, so the message says where it went.
+func explainResurrectFailure(sessionName string, err error) error {
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, "was written by a newer TUIOS"):
+		return &diagnosticError{
+			What:  fmt.Sprintf("Session %q has saved state that this build of TUIOS cannot read.", sessionName),
+			Cause: "the state was written by a newer TUIOS, so its format is not understood here.",
+			Extra: []string{
+				"The state file was moved out of the way so it is not retried: " + session.ResurrectionArchiveDir(),
+				"Detail: " + msg,
+			},
+			Fix: "upgrade TUIOS to restore it, or run 'tuios new " + sessionName + "' to start fresh.",
+			Err: err,
+		}
+
+	case strings.Contains(msg, "is corrupt"):
+		return &diagnosticError{
+			What:  fmt.Sprintf("Session %q has saved state that is corrupt and cannot be restored.", sessionName),
+			Cause: "the state file was truncated or damaged, usually by an unclean shutdown or a full disk.",
+			Extra: []string{
+				"The damaged file was moved out of the way so it is not retried: " + session.ResurrectionArchiveDir(),
+				"Detail: " + msg,
+			},
+			Fix: "run 'tuios new " + sessionName + "' to start a fresh session.",
+			Err: err,
+		}
+
+	case strings.Contains(msg, "no resurrection data"):
+		e := &diagnosticError{
+			What:  fmt.Sprintf("Session %q has no saved state to restore.", sessionName),
+			Cause: "the name does not match any saved session. Sessions killed with 'tuios kill-session' are removed from saved state deliberately.",
+			Fix:   "run 'tuios resurrect' to list restorable sessions, or 'tuios new " + sessionName + "' to create it.",
+			Err:   err,
+		}
+		if infos, listErr := session.ListResurrectableInfos(); listErr == nil && len(infos) > 0 {
+			names := make([]string, 0, len(infos))
+			for _, info := range infos {
+				names = append(names, info.Name)
+			}
+			if closest := closestName(sessionName, names); closest != "" {
+				e.Extra = append(e.Extra, fmt.Sprintf("Did you mean %q?", closest))
+			}
+			e.Extra = append(e.Extra, "Restorable: "+strings.Join(truncateList(names, 12), ", ")+".")
+		}
+		return e
+	}
+
+	return &diagnosticError{
+		What:  fmt.Sprintf("Session %q could not be restored: %v.", sessionName, err),
+		Cause: "the daemon refused the restore.",
+		Fix:   "run 'tuios resurrect' to list restorable sessions.",
+		Err:   err,
+	}
+}
+
 // listResurrectableSessions prints the sessions that can be restored from saved
 // state on disk.
 func listResurrectableSessions() error {
@@ -543,6 +718,8 @@ func listResurrectableSessions() error {
 
 	if len(infos) == 0 {
 		fmt.Println("No resurrectable sessions.")
+		fmt.Printf("Saved state lives in %s; unreadable state is moved to %s.\n",
+			session.ResurrectionStateDir(), session.ResurrectionArchiveDir())
 		return nil
 	}
 
@@ -621,18 +798,42 @@ func runDaemon(foreground, disableAutoRestore bool) error {
 }
 
 func runKillDaemon() error {
-	if !session.IsDaemonRunning() {
+	diag := session.DiagnoseDaemon()
+
+	switch diag.State {
+	case session.DaemonRunning:
+		pid := diag.PID
+		if pid == 0 {
+			pid = session.GetDaemonPID()
+		}
+		if pid > 0 {
+			return killDaemonProcess(pid)
+		}
+		return &diagnosticError{
+			What:  "The TUIOS daemon is running but its process id could not be determined.",
+			Cause: "the pid file is missing or unreadable, which happens when the daemon was started by an older build or by another user.",
+			Fix:   fmt.Sprintf("find it with 'pgrep -f \"tuios daemon\"' and stop it with 'kill <pid>', or remove %s.", diag.SocketPath),
+		}
+
+	case session.DaemonStaleSocket:
+		// kill-server is the command every other message points at for this
+		// state, so it has to actually clear it rather than report "not
+		// running" and leave the socket in place.
+		if err := os.Remove(diag.SocketPath); err != nil && !os.IsNotExist(err) {
+			return &diagnosticError{
+				What:  fmt.Sprintf("A stale daemon socket at %s could not be removed: %v.", diag.SocketPath, err),
+				Cause: "the socket belongs to another user, or its directory is not writable.",
+				Fix:   fmt.Sprintf("remove it manually with 'rm %s'.", diag.SocketPath),
+				Err:   err,
+			}
+		}
+		fmt.Printf("TUIOS daemon was not running. Removed a stale socket at %s.\n", diag.SocketPath)
+		return nil
+
+	default:
 		fmt.Println("TUIOS daemon is not running.")
 		return nil
 	}
-
-	pid := session.GetDaemonPID()
-	if pid > 0 {
-		return killDaemonProcess(pid)
-	}
-
-	fmt.Println("Could not determine daemon PID. Try connecting to stop it.")
-	return nil
 }
 
 // startDaemonBackground is defined in platform-specific files:

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -660,11 +660,11 @@ func runResurrect(sessionName string) error {
 	// the daemon already auto-restored it on start.
 	client := session.NewClient(&session.ClientConfig{Version: version})
 	if err := client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to daemon: %w", err)
+		return explainDialError(err)
 	}
 	if err := client.ResurrectSession(sessionName); err != nil {
 		_ = client.Close()
-		return err
+		return explainResurrectFailure(sessionName, err)
 	}
 	_ = client.Close()
 

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -433,6 +433,14 @@ func runDaemonSession(sessionName string, createNew bool) error {
 		}()
 	})
 
+	// Handle the session being killed out from under this client. The session
+	// no longer exists, so the client must exit rather than sit in a dead UI.
+	client.OnSessionEnded(func(name, reason string) {
+		go func() {
+			p.Send(app.SessionEndedMsg{SessionName: name, Reason: reason})
+		}()
+	})
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
@@ -442,8 +450,16 @@ func runDaemonSession(sessionName string, createNew bool) error {
 
 	finalModel, err := p.Run()
 
+	reason := app.ExitNormal
 	if finalOS, ok := finalModel.(*app.OS); ok {
-		finalOS.SyncStateToDaemon()
+		reason = finalOS.ExitReason
+		// Syncing state back is meaningful only while the session still exists.
+		// After it was killed the daemon has no session to receive the state,
+		// and after the connection was lost the write cannot land, so skip it
+		// rather than block on a dead socket on the way out.
+		if reason == app.ExitNormal {
+			finalOS.SyncStateToDaemon()
+		}
 		finalOS.Cleanup()
 	}
 
@@ -455,8 +471,32 @@ func runDaemonSession(sessionName string, createNew bool) error {
 		return fmt.Errorf("program error: %w", err)
 	}
 
-	fmt.Printf("[detached from session '%s']\n", sessionName)
-	return nil
+	return reportSessionExit(sessionName, reason)
+}
+
+// reportSessionExit prints why the client stopped and returns an error for the
+// cases that are not a normal detach, so a script or an agent driving tuios sees
+// a non-zero status instead of a message that reads like success.
+func reportSessionExit(sessionName string, reason app.ExitReason) error {
+	switch reason {
+	case app.ExitSessionKilled:
+		return &diagnosticError{
+			What:  fmt.Sprintf("Session %q was terminated while you were attached.", sessionName),
+			Cause: "the session was killed from another client, from 'tuios kill-session', or over the control plane.",
+			Fix:   "run 'tuios ls' to see remaining sessions, or 'tuios new' to start another.",
+		}
+
+	case app.ExitDaemonLost:
+		return &diagnosticError{
+			What:  "The connection to the TUIOS daemon was lost.",
+			Cause: "the daemon exited, crashed, or was stopped while this client was attached.",
+			Fix:   "run 'tuios ls' to check the daemon, then 'tuios attach " + sessionName + "' to reconnect if the session survived.",
+		}
+
+	default:
+		fmt.Printf("[detached from session '%s']\n", sessionName)
+		return nil
+	}
 }
 
 func runListSessions(jsonOutput bool) error {

--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -847,7 +848,10 @@ func runKillDaemon() error {
 			pid = session.GetDaemonPID()
 		}
 		if pid > 0 {
-			return killDaemonProcess(pid)
+			if err := killDaemonProcess(pid); err != nil {
+				return err
+			}
+			return awaitDaemonShutdown(pid, diag.SocketPath)
 		}
 		return &diagnosticError{
 			What:  "The TUIOS daemon is running but its process id could not be determined.",
@@ -873,6 +877,42 @@ func runKillDaemon() error {
 	default:
 		fmt.Println("TUIOS daemon is not running.")
 		return nil
+	}
+}
+
+// killServerTimeout bounds how long kill-server waits for the daemon to finish
+// persisting and exit. A shutdown that is going to succeed takes milliseconds;
+// the slow case is Daemon.shutdown's own 5s cap on draining goroutines, so this
+// leaves headroom past that before declaring the daemon wedged.
+const killServerTimeout = 10 * time.Second
+
+// awaitDaemonShutdown blocks until the signalled daemon has finished writing its
+// resurrection state and removed its socket, so that kill-server returning means
+// the next command can safely start a fresh daemon. Reporting success while the
+// old daemon is still saving is what lets 'kill-server && start-server' race:
+// the new daemon reads state the old one has not finished writing, or the old
+// one's final write lands on top of the new one's.
+func awaitDaemonShutdown(pid int, socketPath string) error {
+	err := session.WaitForDaemonShutdown(killServerTimeout)
+	if err == nil {
+		fmt.Println("TUIOS daemon stopped. Session state was saved.")
+		return nil
+	}
+	if !errors.Is(err, session.ErrShutdownTimeout) {
+		return &diagnosticError{
+			What:  fmt.Sprintf("Could not confirm the TUIOS daemon (PID %d) shut down: %v.", pid, err),
+			Cause: "the daemon socket path could not be resolved, so there is no signal to wait on.",
+			Fix:   fmt.Sprintf("check the daemon exited with 'ps -p %d', then retry.", pid),
+			Err:   err,
+		}
+	}
+	return &diagnosticError{
+		What: fmt.Sprintf("The TUIOS daemon (PID %d) was asked to stop but had not finished after %s.",
+			pid, killServerTimeout),
+		Cause: "the daemon is wedged, or a session is taking an unusually long time to write its saved state.",
+		Fix: fmt.Sprintf("wait and run 'tuios kill-server' again to re-check. If it stays stuck, force it with 'kill -9 %d' and remove %s; note that force killing loses any session state that had not been written.",
+			pid, socketPath),
+		Err: err,
 	}
 }
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -24,6 +24,7 @@ This document provides a complete reference for TUIOS command-line interface.
 - [Global Flags](#global-flags)
 - [Common Usage Examples](#common-usage-examples)
 - [Environment Variables](#environment-variables)
+- [When Something Goes Wrong](#when-something-goes-wrong)
 - [Exit Codes](#exit-codes)
 - [Version Information](#version-information)
 - [Command Migration Guide](#command-migration-guide)
@@ -513,6 +514,33 @@ tuios set-config -s mysession dockbar_position bottom
 Query the state of a running TUIOS session. These commands are designed for scripting and return structured data about windows and session state.
 
 **Note:** These commands query the daemon's stored state directly and work even when no TUI client is attached to the session. This makes them ideal for background scripting and monitoring.
+
+### `tuios list-verbs`
+
+Print the control protocol's verb catalog: every verb with its parameter schema,
+accepted values, and example requests, plus the protocol version and the stable
+error codes.
+
+```bash
+tuios list-verbs [verb] [--json]
+```
+
+This is the discovery entry point for scripting and for agents driving TUIOS. It
+needs no documentation to interpret: the schema, the value sets, and the error
+vocabulary are all in the output.
+
+**Examples:**
+
+```bash
+# Every verb with its parameters
+tuios list-verbs
+
+# Just one verb
+tuios list-verbs capture-pane
+
+# Machine-readable
+tuios list-verbs --json | jq '.verbs[].verb'
+```
 
 ### `tuios list-windows`
 
@@ -1353,10 +1381,101 @@ export COLORTERM=truecolor
 
 ---
 
+## When Something Goes Wrong
+
+Every failure `tuios` reports answers three questions in order: what failed, the
+most likely cause, and the exact command that fixes it. If you meet a message
+that does not, it is a bug worth reporting.
+
+### The daemon is not running
+
+There are three distinct versions of this, and they have different fixes:
+
+| Message says | What it means | Fix |
+| --- | --- | --- |
+| "is not running" | No socket exists. The daemon has never run, or was stopped. | `tuios new` |
+| "a stale socket is left over at ..." | The daemon crashed without cleaning up. | `tuios kill-server`, which removes it |
+| "Permission denied ... socket" | The socket belongs to another user, or its mode changed. | Check `ls -l` on the path; set `XDG_RUNTIME_DIR` to a directory you own |
+
+### The daemon is older than the CLI
+
+After upgrading TUIOS, the old daemon keeps running and serving the socket. It
+cannot speak the control protocol the new CLI uses, so commands fail:
+
+```
+The running TUIOS daemon does not speak this CLI's control protocol (daemon 0.9.0, CLI 1.4.0).
+Most likely cause: TUIOS was upgraded while the daemon kept running, so the old daemon is still serving the socket.
+Fix: run 'tuios kill-server', then run this command again.
+```
+
+Run `tuios kill-server`. Sessions are saved before the daemon exits and restored
+when it next starts; `tuios resurrect` lists what is restorable.
+
+### A session name is not found
+
+The message lists the sessions that do exist and suggests the closest name:
+
+```
+Session "wrok" was not found.
+Most likely cause: the name does not match any live session.
+Did you mean "work"?
+Sessions: notes, work.
+Fix: run 'tuios ls' to list sessions, or 'tuios new wrok' to create this one.
+```
+
+A session killed with `tuios kill-session` is gone for good: killing is a
+deliberate teardown, so its saved state is removed too. A session that merely
+outlived its daemon is still restorable with `tuios resurrect`.
+
+### A saved session will not restore
+
+`tuios resurrect <name>` distinguishes three cases: no saved state at all, state
+that is corrupt, and state written by a newer TUIOS. Unreadable state is moved
+into an archive directory rather than deleted, and the message names that
+directory so you can inspect or recover the file.
+
+### The terminal cannot host the interface
+
+`tuios attach`, `tuios new`, and `tuios resurrect` check the terminal before
+taking over the screen, and refuse with an explanation when it is too small
+(minimum 40x12), when `TERM` is unset or `dumb`, or when stdout is not a
+terminal at all. For non-interactive use, drive a session with `tuios send-keys`
+and `tuios capture-pane` instead of attaching.
+
+### A session was killed while you were attached
+
+The client exits with a non-zero status and says so, rather than leaving you in a
+dead UI:
+
+```
+Session "work" was terminated while you were attached.
+```
+
+The same applies when the daemon itself goes away, which reports a lost
+connection instead.
+
+### Discovering the control protocol
+
+`tuios list-verbs` prints every verb the daemon supports with its parameters,
+accepted values, and runnable examples, plus the stable error codes. It is the
+discovery entry point that the error hints point at, and `--json` makes it
+machine-readable for an agent or a script.
+
+```bash
+tuios list-verbs                 # everything
+tuios list-verbs capture-pane    # one verb
+tuios list-verbs --json          # for scripting
+```
+
+---
+
 ## Exit Codes
 
 - `0` - Success
 - `1` - Error (configuration error, network error, file not found, etc.)
+
+A `tuios attach` that ends because its session was killed, or because the daemon
+was lost, exits `1`. A normal detach exits `0`.
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -306,12 +306,34 @@ tuios kill-session mysession   # Kill session named "mysession"
 
 ### `tuios kill-server`
 
-Stop the TUIOS daemon process. This kills all sessions.
+Stop the TUIOS daemon process. This stops all sessions.
 
 **Usage:**
 ```bash
 tuios kill-server
 ```
+
+**Contract:** the command is synchronous. It returns only once the daemon has
+written every session's resurrection state and removed its socket, so a script
+may start a new daemon as soon as it returns:
+
+```bash
+tuios kill-server && tuios start-server   # safe: no race
+```
+
+The daemon unlinks its socket last, after the final saves, and that unlink is
+what this command waits for. A refused connection is not the same signal: the
+daemon closes its listener at the start of shutdown, while state is still
+unsaved, so polling the socket for connectivity can report "stopped" before
+anything has been persisted.
+
+If the daemon has not finished within 10 seconds the command fails, naming the
+pid and the socket, rather than returning success while the old process is still
+running. Re-running it re-checks. Force killing with `kill -9` skips the final
+save and loses any state written since the last periodic save.
+
+When no daemon is running, the command reports that and removes a stale socket
+if one is present. It exits 0 in that case.
 
 ### `tuios daemon`
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -405,16 +405,64 @@ Event types:
 
 | Type | Meaning | Notable fields |
 | --- | --- | --- |
-| `window-created` | A daemon owned window was created. | `session`, `window`, `pty_id`, `title` |
-| `window-closed` | A daemon owned window was removed. | `session`, `window`, `pty_id` |
+| `window-created` | A window was created. | `session`, `window`, `pty_id`, `title` |
+| `window-closed` | A window was removed. | `session`, `window`, `pty_id` |
 | `window-exit` | A window's shell process exited. | `session`, `window`, `pty_id` |
 | `window-retitled` | A window's title or name changed. | `session`, `window`, `title` |
+| `window-focused` | A window became the focused window. | `session`, `window`, `pty_id` |
+| `window-moved` | A window moved to another workspace. | `session`, `window`, `pty_id`, `workspace` |
+| `window-minimized` | A window was minimized. | `session`, `window`, `pty_id` |
+| `window-restored` | A minimized window was restored. | `session`, `window`, `pty_id` |
+| `workspace-switched` | The session's current workspace changed. | `session`, `workspace` |
 | `output` | A window produced output (activity signal only; the raw bytes still flow over the binary stream). | `session`, `window`, `pty_id`, `bytes` |
 | `bell` | A window rang the terminal bell. | `session`, `window`, `pty_id` |
 | `mode-changed` | A terminal mode toggled (for example alt-screen). | `session`, `window`, `mode`, `enabled` |
 | `session-created` | A session was created. | `session` |
 | `session-closed` | A session was terminated. | `session` |
 | `gap` | Slow-subscriber marker: `dropped` events were dropped for this connection. | `dropped` |
+
+### What fires when
+
+A mutation reaches the daemon's canonical state by one of two routes. With no
+TUI client attached the daemon mutates its own state. With a TUI attached the
+daemon routes the command to it, the TUI performs the mutation, and it syncs the
+result back. Both routes converge on the same state, and the window lifecycle
+events are derived from that convergence by diffing the state before and after
+it, so:
+
+- Every window lifecycle event fires **exactly once** per mutation, with the same
+  payload fields and the same relative ordering, whether or not a client is
+  attached. There is no separate "headless only" set of events.
+- Lifecycle events fire for mutations a **human drives from the TUI**, not just
+  for ones a control-plane verb requested. Creating a window with the keyboard
+  raises `window-created` exactly as `new-window` does.
+- The PTY-driven events (`output`, `bell`, `mode-changed`, `window-exit`) hang
+  off the PTY rather than off window state, so they have always fired on both
+  routes and are unaffected.
+
+Ordering within a single mutation is stable: closes, then creates, then
+per-window changes (`window-retitled`, `window-moved`,
+`window-minimized`/`window-restored`), then `workspace-switched`, then
+`window-focused`. Focus comes last because it is usually a consequence of an
+earlier event in the same batch, so a consumer building a model from the stream
+already knows about the window being focused by the time it is told to focus it.
+
+Two cases are worth stating plainly because they are easy to guess wrong:
+
+- `window-retitled` fires for an **explicit rename** (the `rename-window` verb or
+  the TUI's rename) and, separately, when the **shell changes its own title** via
+  an OSC escape sequence. The shell-driven case is reported by the PTY, not by
+  the state diff, so a shell retitling itself raises the event once, not twice.
+- A change that is not a lifecycle change raises nothing. Window geometry,
+  z-order, and alt-screen flags move constantly as a TUI renders and re-tiles;
+  none of them produce events, so an attached client does not flood the stream.
+
+Restoring a session (daemon cold start, or the `resurrect` verb) raises
+`session-created` followed by a `window-created` for each restored window, since
+from a subscriber's point of view those windows come into existence at that
+moment. A subscriber that connects afterwards sees no backfill: the stream
+carries what happens from the subscription onward, and the ack's `seq` is the
+baseline. Use `list-windows` to establish initial state, then follow the stream.
 
 ### subscribe
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -45,12 +45,43 @@ A success response carries a `result` object:
 {"id": 1, "result": {"type": "window_list", "total": 2, "windows": [ ... ]}}
 ```
 
-An error response carries an `error` object with a stable string `code` and a
-human readable `message`:
+An error response carries an `error` object with a stable string `code`, a human
+readable `message`, and usually a structured `hint` naming what resolves the
+failure:
 
 ```json
-{"id": 1, "error": {"code": "session_not_found", "message": "session work not found"}}
+{"id": 1, "error": {
+  "code": "session_not_found",
+  "message": "session wrok not found",
+  "hint": {
+    "param": "session",
+    "command": "tuios ls",
+    "did_you_mean": "work",
+    "available": ["notes", "work"],
+    "detail": "the name matches no live session. ..."
+  }
+}}
 ```
+
+### The hint object
+
+`hint` exists so a caller never has to guess what to do next, and never has to
+make a second call just to learn what values are legal. Every field is optional
+and omitted when empty, so a consumer that reads only `code` and `message` is
+unaffected.
+
+| Field | Meaning |
+| --- | --- |
+| `verb` | The verb that resolves or explains the failure, e.g. `list-verbs` for an unknown verb. |
+| `command` | The exact CLI command that resolves it, written to be run as-is. Placeholders are in `<angle brackets>`. |
+| `param` | The offending parameter, for `invalid_params` and anything that failed on one input. |
+| `accepted` | The values `param` will take, when that set is closed. |
+| `did_you_mean` | The closest match to what the caller asked for, when one is close enough to suggest. |
+| `available` | What does exist: session names, addressable windows, verb names, option keys. |
+| `detail` | One sentence of context that does not fit the fields above. |
+
+A hint is advisory. Acting on `command` or `did_you_mean` is always optional, and
+the absence of a hint never changes what `code` means.
 
 Every `result` carries a `type` discriminator string so a generic client can
 dispatch on the result shape without tracking which verb it sent.
@@ -62,7 +93,54 @@ resolves to the most recently active session.
 
 The protocol carries a version integer. Bump it only on an incompatible change
 to the envelope or to an existing verb; adding a new verb is backward compatible
-and does not bump it. Read the version and the full verb list with `list-verbs`:
+and does not bump it.
+
+### The hello handshake
+
+`hello` is the first call a client should make. It reports the protocol range the
+daemon serves and identifies the daemon, so a version mismatch is reported as a
+`protocol_mismatch` error rather than surfacing later as a decode failure or a
+dropped connection.
+
+Request:
+
+```json
+{"id": 1, "verb": "hello", "params": {"client": "tuios", "version": "1.4.0", "protocol": 1}}
+```
+
+Result:
+
+```json
+{"id": 1, "result": {
+  "type": "hello",
+  "protocol": 1,
+  "min_protocol": 1,
+  "daemon_version": "1.4.0",
+  "pid": 4242,
+  "sessions": 2
+}}
+```
+
+The handshake is optional, not a gate: a daemon serves every other verb whether
+or not `hello` was called, and a daemon older than the handshake answers
+`unknown_verb`, which a client should treat as "older but usable" rather than as
+a failure.
+
+There is one case the handshake cannot answer on this protocol, because the
+daemon predates the protocol entirely. Such a daemon reads the leading `{` of a
+request line as the high byte of a binary length prefix, fails its frame check,
+and closes the connection. A client that sees the connection die with no response
+line should read that as a version mismatch, not as a transport fault; the
+`tuios` CLI confirms it by asking over the older binary handshake, which every
+daemon has always answered, and reports both versions along with the
+`tuios kill-server` command that resolves it.
+
+### list-verbs
+
+`list-verbs` is the discovery entry point. It returns every verb with its full
+parameter schema and runnable examples, the protocol range, the error-code
+catalog, and the envelope shapes, which together are enough to drive the control
+plane without reading this document.
 
 Request:
 
@@ -70,18 +148,38 @@ Request:
 {"id": 1, "verb": "list-verbs"}
 ```
 
-Response:
+Response (abridged):
 
 ```json
 {"id": 1, "result": {
   "type": "verb_list",
   "version": 1,
+  "min_version": 1,
+  "daemon_version": "1.4.0",
   "verbs": [
-    {"verb": "capture-pane", "description": "Capture a pane's content ..."},
-    {"verb": "close-window", "description": "Close a window ..."}
-  ]
+    {
+      "verb": "capture-pane",
+      "description": "Capture a pane's content.",
+      "params": [
+        {"name": "session", "type": "string", "description": "Session name. Omit to target the most recently active session."},
+        {"name": "source", "type": "string", "description": "Which buffer to capture.",
+         "accepted": ["visible", "recent", "recent-unwrapped"], "default": "visible"}
+      ],
+      "examples": ["{\"id\":1,\"verb\":\"capture-pane\",\"params\":{\"session\":\"work\",\"source\":\"recent\"}}"]
+    }
+  ],
+  "error_codes": [{"code": "session_not_found", "description": "The named session does not exist. ..."}],
+  "envelope": {"request": "{\"id\":<any>,\"verb\":\"<name>\",\"params\":{...}}", "...": "..."}
 }}
 ```
+
+Pass a `verb` param to describe only that verb. Each parameter carries its
+`name`, `type` (`string`, `int`, `bool`, or `[]string`), `description`, and
+optionally `required`, `accepted`, and `default`. The `accepted` lists are the
+same lists the handlers enforce, so they cannot drift from the implementation.
+
+From the shell, `tuios list-verbs` and `tuios list-verbs --json` render the same
+catalog.
 
 ## Error codes
 
@@ -98,7 +196,13 @@ Response:
 | `option_not_found` | A get-option key was never set. |
 | `command_failed` | A verb routed to the attached client came back failed or timed out. |
 | `timeout` | A wait-for condition did not match before its timeout elapsed. |
+| `protocol_mismatch` | The caller's protocol version is outside the range this daemon serves. Only `hello` produces it. |
 | `internal` | An unexpected server side failure. |
+
+Codes are stable and additive: existing codes never change meaning, and a new
+code is only ever introduced for a condition that previously had none. A client
+should treat an unrecognized code as a generic failure and fall back to
+`message`. The live catalog with descriptions is in the `list-verbs` result.
 
 ## How verbs interact with an attached client
 
@@ -112,11 +216,27 @@ Structural verbs that a live renderer must own to stay in sync (`new-window`,
 the attached TUI when one is present and act on daemon owned state otherwise. The
 routing is transparent to the caller: it is still one request and one response.
 
+A verb that genuinely cannot run without a renderer (tiling geometry, animation,
+theming) fails with `needs_client`, whose hint names the `tuios attach` command
+for that session. Everything else works headless.
+
+`kill-session` destroys the session for every client, not just the caller. Each
+attached client is told the session ended and exits with a non-zero status, so a
+script that kills a session does not leave a user staring at a dead UI. The
+`session-closed` event fires on the event stream at the same time.
+
 ## Verbs
+
+### hello
+
+Handshake: report the protocol range this daemon serves. Params: `client`,
+`version`, `protocol`. Result type: `hello`. See the versioning section above.
 
 ### list-verbs
 
-List every supported verb and the protocol version. No params.
+List every verb with its parameter schema and examples, plus the protocol range,
+the error-code catalog, and the envelope shapes. Params: `verb` (optional, to
+describe just one).
 
 Request:
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -97,6 +97,7 @@ Response:
 | `needs_client` | The verb needs a live renderer that is not attached. |
 | `option_not_found` | A get-option key was never set. |
 | `command_failed` | A verb routed to the attached client came back failed or timed out. |
+| `timeout` | A wait-for condition did not match before its timeout elapsed. |
 | `internal` | An unexpected server side failure. |
 
 ## How verbs interact with an attached client
@@ -392,6 +393,120 @@ Response:
 
 A key that was never set returns an `option_not_found` error.
 
+## Event stream
+
+The daemon can push events instead of a caller polling. A connection that issues
+the `subscribe` verb is turned into a long-lived event stream; every other
+connection never receives events. Each event is one JSON line carrying a
+daemon-global monotonic `seq`, a `type`, and the fields relevant to that type.
+Two subscribers always see the same `seq` for the same event.
+
+Event types:
+
+| Type | Meaning | Notable fields |
+| --- | --- | --- |
+| `window-created` | A daemon owned window was created. | `session`, `window`, `pty_id`, `title` |
+| `window-closed` | A daemon owned window was removed. | `session`, `window`, `pty_id` |
+| `window-exit` | A window's shell process exited. | `session`, `window`, `pty_id` |
+| `window-retitled` | A window's title or name changed. | `session`, `window`, `title` |
+| `output` | A window produced output (activity signal only; the raw bytes still flow over the binary stream). | `session`, `window`, `pty_id`, `bytes` |
+| `bell` | A window rang the terminal bell. | `session`, `window`, `pty_id` |
+| `mode-changed` | A terminal mode toggled (for example alt-screen). | `session`, `window`, `mode`, `enabled` |
+| `session-created` | A session was created. | `session` |
+| `session-closed` | A session was terminated. | `session` |
+| `gap` | Slow-subscriber marker: `dropped` events were dropped for this connection. | `dropped` |
+
+### subscribe
+
+Open the event stream on this connection.
+
+Params: `session` (optional filter), `window` (optional filter), `types`
+(optional list of event types to include; empty means all), `queue` (optional
+per-connection queue size; defaults to 256).
+
+Request:
+
+```json
+{"id": 1, "verb": "subscribe", "params": {"session": "work", "types": ["output", "bell"]}}
+```
+
+Ack response (the stream begins after this line):
+
+```json
+{"id": 1, "result": {"type": "subscribed", "seq": 42}}
+```
+
+Subsequent lines are events, for example:
+
+```json
+{"seq": 43, "type": "output", "session": "work", "window": "1f3c...", "pty_id": "9ab2...", "bytes": 64, "time": 1737200000000000000}
+```
+
+A second `subscribe` on the same connection is rejected with `invalid_request`.
+
+### Slow subscriber policy
+
+Each subscribed connection has a bounded queue. When it is full the daemon drops
+the event and counts the drop rather than blocking; the next event delivered to
+that connection is preceded by a gap marker:
+
+```json
+{"type": "gap", "dropped": 12}
+```
+
+so the connection learns it fell behind (the `seq` values also jump). One slow
+reader never stalls the daemon or any other subscriber.
+
+### unsubscribe
+
+Close this connection's event stream. Params: none.
+
+```json
+{"verb": "unsubscribe"}
+```
+
+Response: `{"result": {"type": "unsubscribed"}}`. Closing the connection also
+tears the stream down.
+
+### wait-for
+
+Block until a condition matches, then return a `wait_result`; return a `timeout`
+error if the condition does not match in time. This is sugar over a short-lived
+subscription and replaces a caller's capture-pane poll loop.
+
+Params: `condition` (required), `session`, `window`, `pattern` (regex, for
+`window-output`), `source` (`visible` or the default recent/scrollback content,
+for `window-output`), `idle` (quiet-period milliseconds, for `window-idle`;
+default 500), `timeout` (milliseconds; default 30000).
+
+Conditions:
+
+- `window-output` matches `pattern` against the target window's captured
+  content. Checked once immediately, then re-checked as the window produces
+  output.
+- `window-exit` resolves when the target window's shell process exits.
+- `window-idle` resolves after the target window produces no output for `idle`
+  milliseconds.
+- `session-exists` resolves when a session named `session` exists.
+
+Request:
+
+```json
+{"id": 1, "verb": "wait-for", "params": {"condition": "window-output", "session": "work", "pattern": "build succeeded", "timeout": 60000}}
+```
+
+Response on match:
+
+```json
+{"id": 1, "result": {"type": "wait_result", "condition": "window-output", "matched": true, "window": "", "pattern": "build succeeded"}}
+```
+
+Response on timeout:
+
+```json
+{"id": 1, "error": {"code": "timeout", "message": "timed out waiting for output matching build succeeded"}}
+```
+
 ## Examples from a shell
 
 Create a detached session, drive it, and read it back:
@@ -406,6 +521,14 @@ printf '{"id":1,"verb":"list-windows"}\n' | socat - "UNIX-CONNECT:$SOCK" | jq .
 printf '{"verb":"send-text","params":{"text":"date\n"}}\n' | socat - "UNIX-CONNECT:$SOCK"
 printf '{"verb":"capture-pane","params":{"source":"recent","lines":5}}\n' \
   | socat - "UNIX-CONNECT:$SOCK" | jq -r .result.content
+
+# Block until a build finishes instead of polling capture-pane.
+printf '{"verb":"wait-for","params":{"condition":"window-output","pattern":"build succeeded","timeout":120000}}\n' \
+  | socat - "UNIX-CONNECT:$SOCK" | jq .
+
+# Watch every window's activity as newline-delimited events.
+printf '{"verb":"subscribe","params":{"types":["output","bell","window-exit"]}}\n' \
+  | socat - "UNIX-CONNECT:$SOCK" | jq -c .
 ```
 
 The tuios CLI speaks this protocol directly. `tuios ls`, `tuios kill-session`,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -163,7 +163,7 @@ Response (abridged):
       "params": [
         {"name": "session", "type": "string", "description": "Session name. Omit to target the most recently active session."},
         {"name": "source", "type": "string", "description": "Which buffer to capture.",
-         "accepted": ["visible", "recent", "recent-unwrapped"], "default": "visible"}
+         "accepted": ["visible", "recent"], "default": "visible"}
       ],
       "examples": ["{\"id\":1,\"verb\":\"capture-pane\",\"params\":{\"session\":\"work\",\"source\":\"recent\"}}"]
     }
@@ -411,9 +411,9 @@ Capture a pane's content, rendered from the daemon side terminal emulator.
 Params:
 
 - `session` (optional), `window` (optional).
-- `source` (optional): `visible` (the viewport, the default), `recent`
-  (viewport plus scrollback), or `recent-unwrapped` (reserved; currently
-  identical to `recent`).
+- `source` (optional): `visible` (the viewport, the default) or `recent`
+  (viewport plus scrollback). Any other value is rejected with
+  `invalid_params`; the hint names the accepted set.
 - `styled` (optional bool): include ANSI styling escape sequences. Default is
   plain text.
 - `scrollback` (optional bool): alias for `source: "recent"`.
@@ -434,6 +434,15 @@ Response:
 ```json
 {"result": {"type": "pane_content", "source": "recent", "styled": false, "content": "..."}}
 ```
+
+Content is physical rows, not logical lines: a line longer than the pane width
+was wrapped by the emulator and comes back as several rows, so `lines`, `start`
+and `end` count wrapped rows. There is no unwrapped capture. Earlier builds
+documented a reserved `recent-unwrapped` source that was accepted but behaved
+exactly like `recent`; it is now rejected rather than silently ignored, because
+the emulator does not record which rows are continuations and unwrapping them
+would mean guessing. A caller that needs logical lines should widen the pane
+with `resize` before capturing.
 
 ### resize
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,414 @@
+# TUIOS JSON verb protocol
+
+The TUIOS daemon speaks a typed, line-delimited JSON control protocol over the
+same unix socket the interactive client uses. It is layered additively on top of
+the existing binary framing: a connection is classified as JSON or binary from
+its very first byte, so older clients (older tuios binaries, the SSH server, the
+web build) keep working unchanged while new tooling can drive the daemon with
+one JSON object per line.
+
+This is the stable, language agnostic surface for scripting, CI, and test
+harnesses. You can talk to it from a shell with a here-string and read replies
+with jq, no client library required.
+
+## Transport and framing
+
+- One request is one line of JSON terminated by a newline.
+- One response is one line of JSON terminated by a newline.
+- The daemon detects the protocol from the first byte of the connection. A JSON
+  client's first byte is `{` (or leading whitespace); a binary client's first
+  byte is the high byte of a length prefix, which is always `0x00` or `0x01` for
+  frames under the 16MB cap, so the two never collide.
+- A single request line is capped at 16MB. Requests are processed in order on a
+  connection; issue one request, read one response, then send the next. Run
+  independent requests concurrently by opening more than one connection.
+- The socket is protected by filesystem permissions (mode 0700). There is no
+  application level auth token; use SSH for remote access.
+
+## Request envelope
+
+```json
+{"id": 1, "verb": "list-windows", "params": {"session": "work"}}
+```
+
+- `id` is opaque and optional. It may be a number or a string. The daemon echoes
+  it back verbatim on the matching response. Omit it and the response omits it.
+- `verb` is the verb name (required).
+- `params` is a verb specific object. It may be omitted when a verb takes no
+  parameters.
+
+## Response envelope
+
+A success response carries a `result` object:
+
+```json
+{"id": 1, "result": {"type": "window_list", "total": 2, "windows": [ ... ]}}
+```
+
+An error response carries an `error` object with a stable string `code` and a
+human readable `message`:
+
+```json
+{"id": 1, "error": {"code": "session_not_found", "message": "session work not found"}}
+```
+
+Every `result` carries a `type` discriminator string so a generic client can
+dispatch on the result shape without tracking which verb it sent.
+
+Most verbs that name a session accept an empty or omitted `session`, which
+resolves to the most recently active session.
+
+## Versioning and introspection
+
+The protocol carries a version integer. Bump it only on an incompatible change
+to the envelope or to an existing verb; adding a new verb is backward compatible
+and does not bump it. Read the version and the full verb list with `list-verbs`:
+
+Request:
+
+```json
+{"id": 1, "verb": "list-verbs"}
+```
+
+Response:
+
+```json
+{"id": 1, "result": {
+  "type": "verb_list",
+  "version": 1,
+  "verbs": [
+    {"verb": "capture-pane", "description": "Capture a pane's content ..."},
+    {"verb": "close-window", "description": "Close a window ..."}
+  ]
+}}
+```
+
+## Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `invalid_request` | The line was not a valid request envelope (bad JSON, or missing verb). |
+| `unknown_verb` | No verb by that name. |
+| `invalid_params` | The params failed to decode, or a required field was missing. |
+| `session_not_found` | The named session does not exist (or no sessions exist). |
+| `window_not_found` | The window target did not resolve to a window. |
+| `no_windows` | The session has no windows to act on. |
+| `pty_not_found` | The target window has no live PTY. |
+| `needs_client` | The verb needs a live renderer that is not attached. |
+| `option_not_found` | A get-option key was never set. |
+| `command_failed` | A verb routed to the attached client came back failed or timed out. |
+| `internal` | An unexpected server side failure. |
+
+## How verbs interact with an attached client
+
+Read verbs (`list-sessions`, `session-info`, `list-windows`, `get-option`) and
+input verbs (`send-text`, `capture-pane`, `resize`) always answer from daemon
+owned state and the daemon owned PTYs, so they work with or without an attached
+TUI.
+
+Structural verbs that a live renderer must own to stay in sync (`new-window`,
+`close-window`, `send-keys`, and the live apply half of `set-option`) route to
+the attached TUI when one is present and act on daemon owned state otherwise. The
+routing is transparent to the caller: it is still one request and one response.
+
+## Verbs
+
+### list-verbs
+
+List every supported verb and the protocol version. No params.
+
+Request:
+
+```json
+{"verb": "list-verbs"}
+```
+
+Result type: `verb_list`. See the introspection section above.
+
+### list-sessions
+
+List all sessions the daemon holds. No params.
+
+Request:
+
+```json
+{"verb": "list-sessions"}
+```
+
+Response:
+
+```json
+{"result": {"type": "session_list", "sessions": [
+  {"name": "work", "id": "5f...", "window_count": 3, "attached": true, "width": 120, "height": 40}
+]}}
+```
+
+### session-info
+
+Report details about one session.
+
+Params: `session` (optional).
+
+Request:
+
+```json
+{"verb": "session-info", "params": {"session": "work"}}
+```
+
+Response:
+
+```json
+{"result": {
+  "type": "session_info",
+  "session_name": "work",
+  "session_id": "5f...",
+  "current_workspace": 1,
+  "window_count": 3,
+  "tiling_mode": "tiling",
+  "width": 120,
+  "height": 40,
+  "tui_attached": true
+}}
+```
+
+### list-windows
+
+List the windows in a session.
+
+Params: `session` (optional).
+
+Request:
+
+```json
+{"verb": "list-windows", "params": {"session": "work"}}
+```
+
+Response:
+
+```json
+{"result": {
+  "type": "window_list",
+  "total": 2,
+  "focused_index": 0,
+  "focused_window_id": "7e02...",
+  "current_workspace": 1,
+  "workspace_windows": [2, 0, 0, 0, 0, 0, 0, 0, 0],
+  "windows": [
+    {"window_id": "7e02...", "index": 0, "title": "zsh", "display_name": "editor",
+     "workspace": 1, "focused": true, "minimized": false, "x": 0, "y": 0,
+     "width": 80, "height": 24, "pty_id": "4bff..."}
+  ]
+}}
+```
+
+### new-window
+
+Create a new window in a session.
+
+Params: `session` (optional), `name` (optional window name).
+
+Request:
+
+```json
+{"verb": "new-window", "params": {"session": "work", "name": "build"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "window_created", "window_id": "9a3c...", "name": "build"}}
+```
+
+### close-window
+
+Close a window.
+
+Params: `session` (optional), `window` (optional target; defaults to the focused
+window). A window target matches, in order, an exact window ID, a unique ID
+prefix, an exact custom name, then an exact title.
+
+Request:
+
+```json
+{"verb": "close-window", "params": {"session": "work", "window": "build"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "ok"}}
+```
+
+### send-keys
+
+Send parsed key tokens to a window. Tokens are split on spaces and commas and
+each is mapped to its terminal byte sequence (named keys such as `enter` and
+`tab`, `ctrl+x`, `alt+x`, function keys, or a literal character). With a TUI
+attached the keys route to it so window manager keys such as the prefix are
+honored; otherwise the parsed bytes go straight to the target PTY.
+
+Params: `session` (optional), `window` (optional), `keys` (required), `literal`
+(optional bool, send the text through unchanged), `raw` (optional bool, treat
+each character as its own key).
+
+Request:
+
+```json
+{"verb": "send-keys", "params": {"session": "work", "keys": "ctrl+c"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "ok"}}
+```
+
+### send-text
+
+Send literal text to a window's PTY. Unlike send-keys the text is written to the
+PTY verbatim with no key parsing, so it is always safe and always goes straight
+to the daemon owned PTY. Include a trailing newline to submit a line.
+
+Params: `session` (optional), `window` (optional), `text` (required).
+
+Request:
+
+```json
+{"verb": "send-text", "params": {"session": "work", "text": "echo hello\n"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "ok"}}
+```
+
+### capture-pane
+
+Capture a pane's content, rendered from the daemon side terminal emulator.
+
+Params:
+
+- `session` (optional), `window` (optional).
+- `source` (optional): `visible` (the viewport, the default), `recent`
+  (viewport plus scrollback), or `recent-unwrapped` (reserved; currently
+  identical to `recent`).
+- `styled` (optional bool): include ANSI styling escape sequences. Default is
+  plain text.
+- `scrollback` (optional bool): alias for `source: "recent"`.
+- `ansi` (optional bool): alias for `styled`.
+- `lines` (optional int): when greater than zero and no region is given, keep
+  only the last N lines.
+- `start`, `end` (optional ints): a 1 based inclusive line region. When set, the
+  region wins over `lines`.
+
+Request:
+
+```json
+{"verb": "capture-pane", "params": {"session": "work", "source": "recent", "lines": 20}}
+```
+
+Response:
+
+```json
+{"result": {"type": "pane_content", "source": "recent", "styled": false, "content": "..."}}
+```
+
+### resize
+
+Resize a window's PTY.
+
+Params: `session` (optional), `window` (optional), `width` (required, positive),
+`height` (required, positive).
+
+Request:
+
+```json
+{"verb": "resize", "params": {"session": "work", "width": 100, "height": 40}}
+```
+
+Response:
+
+```json
+{"result": {"type": "resized", "width": 100, "height": 40}}
+```
+
+### kill-session
+
+Terminate a session and everything in it.
+
+Params: `session` (required).
+
+Request:
+
+```json
+{"verb": "kill-session", "params": {"session": "work"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "ok"}}
+```
+
+### set-option
+
+Set a session option. The value is recorded in daemon owned session state so a
+later get-option reads it back, and works with no client attached. When a TUI is
+attached the change is also routed to it so options it understands apply to the
+live renderer; `applied` reports whether that live apply succeeded.
+
+Params: `session` (optional), `key` (required), `value` (optional).
+
+Request:
+
+```json
+{"verb": "set-option", "params": {"session": "work", "key": "border_style", "value": "rounded"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "option_set", "key": "border_style", "value": "rounded", "applied": true}}
+```
+
+### get-option
+
+Read a session option previously set with set-option.
+
+Params: `session` (optional), `key` (required).
+
+Request:
+
+```json
+{"verb": "get-option", "params": {"session": "work", "key": "border_style"}}
+```
+
+Response:
+
+```json
+{"result": {"type": "option", "key": "border_style", "value": "rounded"}}
+```
+
+A key that was never set returns an `option_not_found` error.
+
+## Examples from a shell
+
+Create a detached session, drive it, and read it back:
+
+```sh
+SOCK="${XDG_RUNTIME_DIR:-/tmp/tuios-$(id -u)}/tuios/tuios.sock"
+
+# List windows in the most recently active session.
+printf '{"id":1,"verb":"list-windows"}\n' | socat - "UNIX-CONNECT:$SOCK" | jq .
+
+# Run a command in a pane and read the output.
+printf '{"verb":"send-text","params":{"text":"date\n"}}\n' | socat - "UNIX-CONNECT:$SOCK"
+printf '{"verb":"capture-pane","params":{"source":"recent","lines":5}}\n' \
+  | socat - "UNIX-CONNECT:$SOCK" | jq -r .result.content
+```
+
+The tuios CLI speaks this protocol directly. `tuios ls`, `tuios kill-session`,
+`tuios send-keys`, `tuios capture-pane`, `tuios list-windows`,
+`tuios session-info`, `tuios set-config`, and `tuios get-config` are all verb
+protocol clients.

--- a/e2e/control_plane_test.go
+++ b/e2e/control_plane_test.go
@@ -133,11 +133,12 @@ func (e *env) mustRun(args ...string) string {
 
 // killServer stops the isolated daemon and waits for it to actually exit.
 //
-// kill-server only sends SIGTERM and returns immediately, while the daemon then
-// writes its final resurrection state into XDG_STATE_HOME. Returning before it
-// finishes would race t.TempDir cleanup, which deletes that directory out from
-// under the still-running daemon. Errors are ignored: this runs as cleanup and
-// the server may already be gone.
+// kill-server is itself synchronous, so the waits below are belt and braces for
+// teardown: they also cover the case where kill-server failed or timed out and
+// the daemon is still writing its final resurrection state into XDG_STATE_HOME.
+// Returning while that is in flight would race t.TempDir cleanup, which deletes
+// the directory out from under the daemon. Errors are ignored: this runs as
+// cleanup and the server may already be gone.
 func (e *env) killServer() {
 	_, _ = e.run("kill-server")
 	e.awaitDaemonGone(10 * time.Second)
@@ -146,13 +147,15 @@ func (e *env) killServer() {
 
 // awaitStateSettled waits until the resurrection state directory stops changing.
 //
-// Socket removal is not quite the last write a shutting-down daemon makes: a
-// session created moments earlier can still be saved after the socket is gone,
-// and a save writes a temp file before renaming it. Removing the test's TempDir
-// during that window fails with "directory not empty", which shows up as a
-// cleanup error on whichever short test happened to race it. Waiting for two
-// identical readings makes teardown deterministic instead. Best effort: it
-// returns on timeout, since callers use it during cleanup.
+// Daemon.shutdown now unlinks the socket last, after every final save, so on the
+// normal path awaitDaemonGone already implies the state directory is quiet. This
+// remains as teardown insurance for the one path where that does not hold:
+// shutdown caps draining goroutines at 5s and proceeds regardless, so a wedged
+// session can still write after the unlink. A save writes a temp file before
+// renaming it, and removing the test's TempDir during that window fails with
+// "directory not empty", which surfaces as a cleanup error on whichever short
+// test raced it. Waiting for two identical readings keeps teardown deterministic.
+// Best effort: it returns on timeout, since callers use it during cleanup.
 func (e *env) awaitStateSettled(timeout time.Duration) {
 	dir := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions")
 
@@ -184,10 +187,12 @@ func (e *env) awaitStateSettled(timeout time.Duration) {
 // awaitDaemonGone blocks until the daemon has fully finished shutting down.
 //
 // It waits for the socket FILE to be removed, not merely for connections to be
-// refused. The daemon closes its listener before saving resurrection state and
-// only unlinks the socket afterwards (see Daemon.shutdown), so an unconnectable
-// socket does not yet mean state has been persisted. Best effort: it returns on
-// timeout rather than failing, since callers use it during cleanup.
+// refused. The daemon closes its listener at the top of shutdown and only unlinks
+// the socket at the very end, after the final resurrection saves (see
+// Daemon.shutdown), so an unconnectable socket does not yet mean state has been
+// persisted while a removed one does. This is the same signal 'tuios kill-server'
+// waits on. Best effort: it returns on timeout rather than failing, since callers
+// use it during cleanup.
 func (e *env) awaitDaemonGone(timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -199,8 +204,10 @@ func (e *env) awaitDaemonGone(timeout time.Duration) {
 }
 
 // waitForStateFile blocks until a session's resurrection state lands on disk.
-// State is persisted by a periodic saver and by the final save during shutdown,
-// so it appears asynchronously after kill-server returns.
+// State is persisted by a periodic saver and by the final save during shutdown.
+// After a completed kill-server the final save has already happened, so this
+// returns at once; the wait is for callers that have not stopped the daemon and
+// are waiting on the periodic saver.
 func (e *env) waitForStateFile(session string, timeout time.Duration) string {
 	e.t.Helper()
 	path := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions", session+".json")
@@ -459,6 +466,60 @@ func TestUnknownVerbDoesNotKillConnection(t *testing.T) {
 	}
 }
 
+// TestKillServerIsSynchronous proves the contract scripts depend on: when
+// kill-server returns, the daemon has finished. Session state is already on
+// disk and the socket is already gone, with no polling in between.
+//
+// The old behaviour was fire and forget: kill-server sent SIGTERM and returned
+// while the daemon was still saving, so 'kill-server && start-server' could
+// start a new daemon that read state the old one had not finished writing.
+func TestKillServerIsSynchronous(t *testing.T) {
+	e := newEnv(t)
+
+	e.mustRun("new", "--detach", "synckill")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+	c.result(1, "new-window", map[string]any{"session": "synckill", "name": "durable"}, 10*time.Second)
+
+	// Delete anything the periodic saver has already written, so a state file
+	// seen after kill-server can only have been written by the shutdown path.
+	stateDir := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions")
+	statePath := filepath.Join(stateDir, "synckill.json")
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("clearing pre-shutdown state: %v", err)
+	}
+
+	e.mustRun("kill-server")
+
+	// No waiting: the point of the contract is that these hold on return.
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("kill-server returned before session state was saved: %v", err)
+	}
+	if _, err := os.Stat(e.socket); !os.IsNotExist(err) {
+		t.Errorf("kill-server returned while the socket was still present: %v", err)
+	}
+
+	// The saved state must be complete, not a partial write caught mid-flight.
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("reading state: %v", err)
+	}
+	var saved map[string]any
+	if err := json.Unmarshal(raw, &saved); err != nil {
+		t.Fatalf("state written by shutdown is not valid JSON (%d bytes): %v", len(raw), err)
+	}
+	if !strings.Contains(string(raw), "durable") {
+		t.Errorf("saved state is missing the window created before shutdown: %s", raw)
+	}
+
+	// Running it again with no daemon left must succeed rather than report a
+	// failure to stop something that is already stopped.
+	if out, err := e.run("kill-server"); err != nil {
+		t.Errorf("second kill-server failed: %v (%s)", err, out)
+	}
+}
+
 // TestResurrectionAcrossDaemonRestart proves the cold start path: a session's
 // windows come back after the daemon process dies, with live PTYs that still
 // respond to control verbs. This is the resurrection feature's real contract,
@@ -477,9 +538,7 @@ func TestResurrectionAcrossDaemonRestart(t *testing.T) {
 	wantTotal := int(before["total"].(float64))
 
 	// Resurrection state is written by a periodic saver and on shutdown; the
-	// clean kill-server path performs the final save. kill-server only sends
-	// SIGTERM and returns before that save completes, so both the state file
-	// and the socket teardown have to be waited for.
+	// clean kill-server path performs the final save before returning.
 	e.mustRun("kill-server")
 
 	// The state file must actually exist, otherwise the restore below would be

--- a/e2e/control_plane_test.go
+++ b/e2e/control_plane_test.go
@@ -497,3 +497,220 @@ func TestResurrectionAcrossDaemonRestart(t *testing.T) {
 		}
 	}
 }
+
+// TestUnknownVerbHintsAtTheRightOne extends the robustness test above: a bad
+// verb must not only be answered with a typed error, it must tell the caller how
+// to recover. This is what lets an agent correct itself without a human.
+func TestUnknownVerbHintsAtTheRightOne(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "hints")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+
+	resp := c.call(1, "list-window", nil, 5*time.Second)
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("unknown verb returned success: %v", resp)
+	}
+	hint, ok := errObj["hint"].(map[string]any)
+	if !ok {
+		t.Fatalf("unknown verb carried no hint: %v", errObj)
+	}
+	if got, _ := hint["did_you_mean"].(string); got != "list-windows" {
+		t.Errorf("did_you_mean = %q, want list-windows", got)
+	}
+	if got, _ := hint["verb"].(string); got != "list-verbs" {
+		t.Errorf("hint verb = %q, want list-verbs", got)
+	}
+
+	// Following the hint must actually work.
+	suggested, _ := hint["did_you_mean"].(string)
+	if _, ok := c.result(2, suggested, map[string]any{"session": "hints"}, 5*time.Second)["windows"]; !ok {
+		t.Fatal("the suggested verb did not work")
+	}
+}
+
+// TestSessionNotFoundListsWhatExists proves the most common agent mistake, a
+// wrong session name, comes back with the live names and the closest match.
+func TestSessionNotFoundListsWhatExists(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "alpha")
+	e.mustRun("new", "--detach", "beta")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+	resp := c.call(1, "list-windows", map[string]any{"session": "alfa"}, 5*time.Second)
+
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an error for an unknown session: %v", resp)
+	}
+	if code, _ := errObj["code"].(string); code != "session_not_found" {
+		t.Fatalf("code = %v, want session_not_found", errObj["code"])
+	}
+	hint, ok := errObj["hint"].(map[string]any)
+	if !ok {
+		t.Fatalf("session_not_found carried no hint: %v", errObj)
+	}
+	if got, _ := hint["did_you_mean"].(string); got != "alpha" {
+		t.Errorf("did_you_mean = %q, want alpha", got)
+	}
+
+	available, _ := hint["available"].([]any)
+	found := map[string]bool{}
+	for _, v := range available {
+		if s, ok := v.(string); ok {
+			found[s] = true
+		}
+	}
+	if !found["alpha"] || !found["beta"] {
+		t.Errorf("available = %v, want both live sessions", available)
+	}
+}
+
+// TestHelloReportsTheProtocolRange exercises the handshake over the real socket,
+// which is what a client uses to tell a usable daemon from one left over across
+// an upgrade.
+func TestHelloReportsTheProtocolRange(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "hello")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+	res := c.result(1, "hello", map[string]any{
+		"client":   "e2e",
+		"version":  "test",
+		"protocol": 1,
+	}, 5*time.Second)
+
+	if res["type"] != "hello" {
+		t.Errorf("type = %v, want hello", res["type"])
+	}
+	protocol, _ := res["protocol"].(float64)
+	if protocol < 1 {
+		t.Errorf("protocol = %v, want at least 1", res["protocol"])
+	}
+	minProtocol, _ := res["min_protocol"].(float64)
+	if minProtocol > protocol {
+		t.Errorf("min_protocol %v exceeds protocol %v", minProtocol, protocol)
+	}
+	if pid, _ := res["pid"].(float64); pid <= 0 {
+		t.Errorf("pid = %v, want the daemon's process id", res["pid"])
+	}
+
+	// A client claiming a protocol this daemon cannot serve is refused with the
+	// typed code rather than being allowed to proceed.
+	resp := c.call(2, "hello", map[string]any{"version": "9.9.9", "protocol": 9999}, 5*time.Second)
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("a future protocol was accepted: %v", resp)
+	}
+	if code, _ := errObj["code"].(string); code != "protocol_mismatch" {
+		t.Errorf("code = %v, want protocol_mismatch", errObj["code"])
+	}
+	hint, _ := errObj["hint"].(map[string]any)
+	if cmd, _ := hint["command"].(string); cmd != "tuios kill-server" {
+		t.Errorf("hint command = %v, want tuios kill-server", hint["command"])
+	}
+}
+
+// TestListVerbsIsSelfDescribing proves an agent can learn the whole control
+// surface from one call: every verb documented, with parameters typed and
+// examples that parse.
+func TestListVerbsIsSelfDescribing(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "introspect")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+	res := c.result(1, "list-verbs", nil, 5*time.Second)
+
+	verbs, ok := res["verbs"].([]any)
+	if !ok || len(verbs) == 0 {
+		t.Fatalf("list-verbs returned no verbs: %v", res)
+	}
+	if _, ok := res["error_codes"].([]any); !ok {
+		t.Error("list-verbs returned no error-code catalog")
+	}
+	if _, ok := res["envelope"].(map[string]any); !ok {
+		t.Error("list-verbs returned no envelope documentation")
+	}
+
+	seen := map[string]bool{}
+	for _, raw := range verbs {
+		v, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("verb entry is not an object: %v", raw)
+		}
+		name, _ := v["verb"].(string)
+		seen[name] = true
+
+		if desc, _ := v["description"].(string); desc == "" {
+			t.Errorf("verb %q has no description", name)
+		}
+		if _, ok := v["params"].([]any); !ok {
+			t.Errorf("verb %q has no params list", name)
+		}
+		// Every example must be a parseable request for this verb.
+		examples, _ := v["examples"].([]any)
+		for _, rawEx := range examples {
+			ex, _ := rawEx.(string)
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(ex), &parsed); err != nil {
+				t.Errorf("verb %q has an unparseable example %q: %v", name, ex, err)
+				continue
+			}
+			if parsed["verb"] != name {
+				t.Errorf("verb %q has an example for %v", name, parsed["verb"])
+			}
+		}
+	}
+
+	// The verbs a scripting client depends on must all be present.
+	for _, want := range []string{
+		"hello", "list-verbs", "list-sessions", "list-windows", "new-window",
+		"close-window", "send-keys", "send-text", "capture-pane", "kill-session",
+		"subscribe", "wait-for",
+	} {
+		if !seen[want] {
+			t.Errorf("list-verbs omitted %q", want)
+		}
+	}
+}
+
+// TestCLIExplainsAMissingDaemon covers the CLI half over a real process: with no
+// daemon running, the message must name the fix rather than leaking a socket
+// error.
+func TestCLIExplainsAMissingDaemon(t *testing.T) {
+	e := newEnv(t)
+
+	// No daemon has been started in this hermetic environment.
+	out, err := e.run("list-windows")
+	if err == nil {
+		t.Fatalf("expected list-windows to fail with no daemon, got: %s", out)
+	}
+	for _, want := range []string{"daemon is not running", "Most likely cause", "Fix:", "tuios new"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestCLIExplainsAMissingSession covers the other most common CLI mistake: a
+// session name that does not exist must list the ones that do.
+func TestCLIExplainsAMissingSession(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "real")
+	e.waitForSocket(10 * time.Second)
+
+	out, err := e.run("list-windows", "--session", "reel")
+	if err == nil {
+		t.Fatalf("expected a failure for an unknown session, got: %s", out)
+	}
+	for _, want := range []string{"reel", "Did you mean", "real", "Fix:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/e2e/control_plane_test.go
+++ b/e2e/control_plane_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -140,6 +141,44 @@ func (e *env) mustRun(args ...string) string {
 func (e *env) killServer() {
 	_, _ = e.run("kill-server")
 	e.awaitDaemonGone(10 * time.Second)
+	e.awaitStateSettled(3 * time.Second)
+}
+
+// awaitStateSettled waits until the resurrection state directory stops changing.
+//
+// Socket removal is not quite the last write a shutting-down daemon makes: a
+// session created moments earlier can still be saved after the socket is gone,
+// and a save writes a temp file before renaming it. Removing the test's TempDir
+// during that window fails with "directory not empty", which shows up as a
+// cleanup error on whichever short test happened to race it. Waiting for two
+// identical readings makes teardown deterministic instead. Best effort: it
+// returns on timeout, since callers use it during cleanup.
+func (e *env) awaitStateSettled(timeout time.Duration) {
+	dir := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions")
+
+	read := func() string {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return "<none>"
+		}
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		sort.Strings(names)
+		return strings.Join(names, ",")
+	}
+
+	deadline := time.Now().Add(timeout)
+	previous := read()
+	for time.Now().Before(deadline) {
+		time.Sleep(150 * time.Millisecond)
+		current := read()
+		if current == previous {
+			return
+		}
+		previous = current
+	}
 }
 
 // awaitDaemonGone blocks until the daemon has fully finished shutting down.

--- a/e2e/control_plane_test.go
+++ b/e2e/control_plane_test.go
@@ -1,0 +1,499 @@
+//go:build e2e
+
+// Package e2e drives a real tuios daemon end to end over its unix socket,
+// exercising the JSON verb control plane and session resurrection the way an
+// external scripting client would: raw socket writes, no in-process shortcuts.
+//
+// These tests are behind the "e2e" build tag because they spawn real daemons
+// and real shells. Run them with:
+//
+//	go build -o /tmp/tuios ./cmd/tuios
+//	TUIOS_BIN=/tmp/tuios go test -tags e2e ./e2e/...
+//
+// When TUIOS_BIN is unset the tests build the binary themselves into a temp
+// directory, so a bare "go test -tags e2e ./e2e/..." also works.
+//
+// Every test runs in a hermetic environment: XDG_RUNTIME_DIR (which holds the
+// daemon socket and pid file) and XDG_STATE_HOME (which holds resurrection
+// state) are redirected into the test's TempDir, so the developer's real
+// daemon, sessions, and saved state are never touched.
+package e2e
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+// env is one isolated tuios installation: a binary plus a private set of XDG
+// directories. Everything a test does routes through it.
+type env struct {
+	t      *testing.T
+	bin    string
+	dirs   map[string]string
+	socket string
+}
+
+// newEnv locates or builds the tuios binary and prepares isolated XDG dirs.
+func newEnv(t *testing.T) *env {
+	t.Helper()
+
+	bin := os.Getenv("TUIOS_BIN")
+	if bin == "" {
+		bin = buildTuios(t)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		t.Skipf("tuios binary not usable at %q: %v", bin, err)
+	}
+
+	base := t.TempDir()
+	dirs := map[string]string{}
+	for _, key := range []string{
+		"XDG_RUNTIME_DIR", "XDG_CONFIG_HOME", "XDG_STATE_HOME",
+		"XDG_CACHE_HOME", "XDG_DATA_HOME",
+	} {
+		dir := filepath.Join(base, key)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", key, err)
+		}
+		dirs[key] = dir
+	}
+
+	e := &env{
+		t:    t,
+		bin:  bin,
+		dirs: dirs,
+		// The daemon socket path is derived from XDG_RUNTIME_DIR.
+		socket: filepath.Join(dirs["XDG_RUNTIME_DIR"], "tuios", "tuios.sock"),
+	}
+	t.Cleanup(e.killServer)
+	return e
+}
+
+// buildTuios compiles the binary under test once per test that needs it.
+func buildTuios(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "tuios")
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/tuios")
+	cmd.Dir = ".."
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building tuios: %v\n%s", err, b)
+	}
+	return out
+}
+
+// environ returns the isolated environment for a tuios subprocess.
+func (e *env) environ() []string {
+	out := append([]string{}, os.Environ()...)
+	// Drop any inherited XDG vars so ours are authoritative.
+	filtered := out[:0]
+	for _, kv := range out {
+		if _, isOverridden := e.dirs[strings.SplitN(kv, "=", 2)[0]]; !isOverridden {
+			filtered = append(filtered, kv)
+		}
+	}
+	out = filtered
+	for k, v := range e.dirs {
+		out = append(out, k+"="+v)
+	}
+	// A deterministic POSIX shell keeps pane content predictable.
+	return append(out, "SHELL=/bin/sh", "TERM=xterm-256color")
+}
+
+// run executes a tuios subcommand and returns its combined output.
+func (e *env) run(args ...string) (string, error) {
+	e.t.Helper()
+	cmd := exec.Command(e.bin, args...)
+	cmd.Env = e.environ()
+	b, err := cmd.CombinedOutput()
+	return string(b), err
+}
+
+// mustRun executes a tuios subcommand and fails the test if it errors.
+func (e *env) mustRun(args ...string) string {
+	e.t.Helper()
+	out, err := e.run(args...)
+	if err != nil {
+		e.t.Fatalf("tuios %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+// killServer stops the isolated daemon and waits for it to actually exit.
+//
+// kill-server only sends SIGTERM and returns immediately, while the daemon then
+// writes its final resurrection state into XDG_STATE_HOME. Returning before it
+// finishes would race t.TempDir cleanup, which deletes that directory out from
+// under the still-running daemon. Errors are ignored: this runs as cleanup and
+// the server may already be gone.
+func (e *env) killServer() {
+	_, _ = e.run("kill-server")
+	e.awaitDaemonGone(10 * time.Second)
+}
+
+// awaitDaemonGone blocks until the daemon has fully finished shutting down.
+//
+// It waits for the socket FILE to be removed, not merely for connections to be
+// refused. The daemon closes its listener before saving resurrection state and
+// only unlinks the socket afterwards (see Daemon.shutdown), so an unconnectable
+// socket does not yet mean state has been persisted. Best effort: it returns on
+// timeout rather than failing, since callers use it during cleanup.
+func (e *env) awaitDaemonGone(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(e.socket); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitForStateFile blocks until a session's resurrection state lands on disk.
+// State is persisted by a periodic saver and by the final save during shutdown,
+// so it appears asynchronously after kill-server returns.
+func (e *env) waitForStateFile(session string, timeout time.Duration) string {
+	e.t.Helper()
+	path := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions", session+".json")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	e.t.Fatalf("resurrection state %s never appeared", path)
+	return ""
+}
+
+// waitForSocket blocks until the daemon socket accepts a connection.
+func (e *env) waitForSocket(timeout time.Duration) {
+	e.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", e.socket, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	e.t.Fatalf("daemon socket %s never became connectable", e.socket)
+}
+
+// ---------------------------------------------------------------------------
+// raw JSON verb client
+// ---------------------------------------------------------------------------
+
+// verbConn speaks the line delimited JSON verb protocol over a raw socket,
+// deliberately without using the in-repo client, so these tests exercise the
+// real wire format an external tool would have to speak.
+type verbConn struct {
+	t    *testing.T
+	conn net.Conn
+	r    *bufio.Reader
+}
+
+func (e *env) dial() *verbConn {
+	e.t.Helper()
+	conn, err := net.DialTimeout("unix", e.socket, 5*time.Second)
+	if err != nil {
+		e.t.Fatalf("dial %s: %v", e.socket, err)
+	}
+	e.t.Cleanup(func() { _ = conn.Close() })
+	return &verbConn{t: e.t, conn: conn, r: bufio.NewReader(conn)}
+}
+
+// call sends one request and returns the decoded response envelope. timeout
+// bounds the read, so a wait-for that never resolves fails the test instead of
+// hanging the suite.
+func (c *verbConn) call(id int, verb string, params map[string]any, timeout time.Duration) map[string]any {
+	c.t.Helper()
+
+	req := map[string]any{"id": id, "verb": verb}
+	if params != nil {
+		req["params"] = params
+	}
+	line, err := json.Marshal(req)
+	if err != nil {
+		c.t.Fatalf("marshal request: %v", err)
+	}
+
+	_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, err := c.conn.Write(append(line, '\n')); err != nil {
+		c.t.Fatalf("write %s: %v", verb, err)
+	}
+
+	_ = c.conn.SetReadDeadline(time.Now().Add(timeout))
+	raw, err := c.r.ReadBytes('\n')
+	if err != nil {
+		c.t.Fatalf("read response to %s: %v", verb, err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		c.t.Fatalf("decode response to %s: %v\nraw: %s", verb, err, raw)
+	}
+	if gotID, ok := resp["id"]; ok {
+		if int(gotID.(float64)) != id {
+			c.t.Fatalf("%s: response id = %v, want %d", verb, gotID, id)
+		}
+	}
+	return resp
+}
+
+// result asserts the response carried a result (not an error) and returns it.
+func (c *verbConn) result(id int, verb string, params map[string]any, timeout time.Duration) map[string]any {
+	c.t.Helper()
+	resp := c.call(id, verb, params, timeout)
+	if e, ok := resp["error"]; ok {
+		c.t.Fatalf("%s returned error: %v", verb, e)
+	}
+	res, ok := resp["result"].(map[string]any)
+	if !ok {
+		c.t.Fatalf("%s: response has no result object: %v", verb, resp)
+	}
+	return res
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+// TestHeadlessControlPlane is the core dogfood: create a detached session with
+// no client ever attached, then drive it entirely over the JSON verb protocol.
+// It proves the daemon owns window state and pane content on its own, which is
+// the whole point of the control plane.
+func TestHeadlessControlPlane(t *testing.T) {
+	e := newEnv(t)
+
+	// 1. Create a headless session. --detach means no TUI is ever attached, so
+	//    everything below is served from daemon owned state.
+	e.mustRun("new", "--detach", "ctl")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+
+	// 2. list-verbs doubles as a protocol handshake and version check.
+	verbs := c.result(1, "list-verbs", nil, 5*time.Second)
+	if _, ok := verbs["version"]; !ok {
+		t.Fatalf("list-verbs did not report a protocol version: %v", verbs)
+	}
+
+	// 3. The detached session must already have its initial window, otherwise
+	//    control verbs would have no target and the session would be unusable
+	//    until someone attached.
+	wl := c.result(2, "list-windows", map[string]any{"session": "ctl"}, 5*time.Second)
+	initial := int(wl["total"].(float64))
+	if initial < 1 {
+		t.Fatalf("detached session has %d windows, want at least 1", initial)
+	}
+
+	// 4. Create a second window headlessly and confirm the count moved.
+	created := c.result(3, "new-window", map[string]any{"session": "ctl", "name": "worker"}, 10*time.Second)
+	winID, _ := created["window_id"].(string)
+	if winID == "" {
+		t.Fatalf("new-window returned no window_id: %v", created)
+	}
+
+	wl = c.result(4, "list-windows", map[string]any{"session": "ctl"}, 5*time.Second)
+	if got := int(wl["total"].(float64)); got != initial+1 {
+		t.Fatalf("after new-window: %d windows, want %d", got, initial+1)
+	}
+	if !strings.Contains(fmt.Sprint(wl["windows"]), "worker") {
+		t.Fatalf("new window not listed by name: %v", wl["windows"])
+	}
+
+	// 5. Run a real command in the new window. The marker is computed by the
+	//    shell ($((21*2)) -> 42), so seeing "marker-42" proves the shell
+	//    actually executed it rather than our bytes merely being echoed.
+	c.result(5, "send-text", map[string]any{
+		"session": "ctl",
+		"window":  winID,
+		"text":    "echo marker-$((21*2))\n",
+	}, 5*time.Second)
+
+	// 6. wait-for is the scripting primitive that replaces a capture-pane poll
+	//    loop. Blocking here proves the event stream actually fires on output.
+	wr := c.result(6, "wait-for", map[string]any{
+		"condition": "window-output",
+		"session":   "ctl",
+		"window":    winID,
+		"pattern":   "marker-42",
+		"timeout":   20000,
+	}, 30*time.Second)
+	if matched, _ := wr["matched"].(bool); !matched {
+		t.Fatalf("wait-for did not match: %v", wr)
+	}
+
+	// 7. capture-pane must independently show the same result, rendered from
+	//    the daemon side terminal emulator.
+	pane := c.result(7, "capture-pane", map[string]any{
+		"session": "ctl",
+		"window":  winID,
+		"source":  "recent",
+	}, 10*time.Second)
+	content, _ := pane["content"].(string)
+	if !strings.Contains(content, "marker-42") {
+		t.Fatalf("capture-pane missing command output.\n--- pane ---\n%s", content)
+	}
+
+	// 8. Options round trip through the daemon owned store.
+	c.result(8, "set-option", map[string]any{"session": "ctl", "key": "mouse", "value": "on"}, 5*time.Second)
+	opt := c.result(9, "get-option", map[string]any{"session": "ctl", "key": "mouse"}, 5*time.Second)
+	if got, _ := opt["value"].(string); got != "on" {
+		t.Fatalf("get-option = %q, want \"on\"", got)
+	}
+
+	// 9. close-window brings the count back down.
+	c.result(10, "close-window", map[string]any{"session": "ctl", "window": winID}, 10*time.Second)
+	wl = c.result(11, "list-windows", map[string]any{"session": "ctl"}, 5*time.Second)
+	if got := int(wl["total"].(float64)); got != initial {
+		t.Fatalf("after close-window: %d windows, want %d", got, initial)
+	}
+
+	// 10. kill-session tears it down and it disappears from the listing.
+	c.result(12, "kill-session", map[string]any{"session": "ctl"}, 10*time.Second)
+	sessions := c.result(13, "list-sessions", nil, 5*time.Second)
+	if strings.Contains(fmt.Sprint(sessions["sessions"]), "\"ctl\"") {
+		t.Fatalf("killed session still listed: %v", sessions["sessions"])
+	}
+}
+
+// TestWaitForTimeoutIsTyped pins the failure contract a script depends on: a
+// condition that never matches must come back as a typed "timeout" error
+// rather than hanging or returning a generic failure.
+func TestWaitForTimeoutIsTyped(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "tmo")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+	resp := c.call(1, "wait-for", map[string]any{
+		"condition": "window-output",
+		"session":   "tmo",
+		"pattern":   "this-never-appears-anywhere",
+		"timeout":   1000,
+	}, 15*time.Second)
+
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("wait-for on an unmatchable pattern returned success: %v", resp)
+	}
+	if code, _ := errObj["code"].(string); code != "timeout" {
+		t.Fatalf("error code = %q, want \"timeout\"", code)
+	}
+}
+
+// TestUnknownVerbDoesNotKillConnection proves the dispatch loop is robust: a
+// bad request is answered with a typed error and the same connection stays
+// usable, which is what keeps a long lived scripting client alive.
+func TestUnknownVerbDoesNotKillConnection(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun("new", "--detach", "rbst")
+	e.waitForSocket(10 * time.Second)
+
+	c := e.dial()
+
+	resp := c.call(1, "no-such-verb", nil, 5*time.Second)
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("unknown verb returned success: %v", resp)
+	}
+	if code, _ := errObj["code"].(string); code != "unknown_verb" {
+		t.Fatalf("error code = %q, want \"unknown_verb\"", code)
+	}
+
+	// The connection must still serve a good request afterwards.
+	if _, ok := c.result(2, "list-sessions", nil, 5*time.Second)["sessions"]; !ok {
+		t.Fatal("connection unusable after an unknown verb")
+	}
+}
+
+// TestResurrectionAcrossDaemonRestart proves the cold start path: a session's
+// windows come back after the daemon process dies, with live PTYs that still
+// respond to control verbs. This is the resurrection feature's real contract,
+// exercised across an actual process boundary rather than in process.
+func TestResurrectionAcrossDaemonRestart(t *testing.T) {
+	e := newEnv(t)
+
+	e.mustRun("new", "--detach", "revive")
+	e.waitForSocket(10 * time.Second)
+
+	// Add a distinctively named window so we can prove identity survives, not
+	// merely that some window count matched.
+	c := e.dial()
+	c.result(1, "new-window", map[string]any{"session": "revive", "name": "phoenix"}, 10*time.Second)
+	before := c.result(2, "list-windows", map[string]any{"session": "revive"}, 5*time.Second)
+	wantTotal := int(before["total"].(float64))
+
+	// Resurrection state is written by a periodic saver and on shutdown; the
+	// clean kill-server path performs the final save. kill-server only sends
+	// SIGTERM and returns before that save completes, so both the state file
+	// and the socket teardown have to be waited for.
+	e.mustRun("kill-server")
+
+	// The state file must actually exist, otherwise the restore below would be
+	// vacuously true.
+	stateDir := filepath.Join(e.dirs["XDG_STATE_HOME"], "tuios", "sessions")
+	e.awaitDaemonGone(15 * time.Second)
+	e.waitForStateFile("revive", 15*time.Second)
+
+	// Start a fresh daemon process. It restores sessions before accepting
+	// clients, so the very first verb call must already see them.
+	daemon := exec.Command(e.bin, "daemon")
+	daemon.Env = e.environ()
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("starting daemon: %v", err)
+	}
+	t.Cleanup(func() { _ = daemon.Process.Kill() })
+	e.waitForSocket(15 * time.Second)
+
+	c2 := e.dial()
+	after := c2.result(1, "list-windows", map[string]any{"session": "revive"}, 10*time.Second)
+	if got := int(after["total"].(float64)); got != wantTotal {
+		t.Fatalf("after restart: %d windows, want %d", got, wantTotal)
+	}
+	if !strings.Contains(fmt.Sprint(after["windows"]), "phoenix") {
+		t.Fatalf("named window did not survive restart: %v", after["windows"])
+	}
+
+	// The restored windows must have *live* shells, not just replayed metadata.
+	// Running a command through a restored PTY is the only convincing proof.
+	c2.result(2, "send-text", map[string]any{
+		"session": "revive",
+		"text":    "echo revived-$((6*7))\n",
+	}, 5*time.Second)
+	wr := c2.result(3, "wait-for", map[string]any{
+		"condition": "window-output",
+		"session":   "revive",
+		"pattern":   "revived-42",
+		"timeout":   20000,
+	}, 30*time.Second)
+	if matched, _ := wr["matched"].(bool); !matched {
+		t.Fatalf("restored window's shell is not live: %v", wr)
+	}
+
+	// An explicit kill must make a session non resurrectable, otherwise killed
+	// sessions would come back from the dead on the next daemon start.
+	c2.result(4, "kill-session", map[string]any{"session": "revive"}, 10*time.Second)
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		t.Fatalf("reading state dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == "revive.json" {
+			t.Fatal("killed session left resurrection state behind")
+		}
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -183,6 +183,10 @@ type OS struct {
 	SessionName       string             // Name of the daemon session (if attached)
 	RestoredFromState bool               // True after RestoreFromState, cleared after first resize
 	SubscribedPTYs    map[string]bool    // Tracks which PTY IDs are currently subscribed (for visibility optimization)
+	// ExitReason records why the program stopped, for the caller to report and
+	// to pick an exit status. Empty means the user quit or detached normally.
+	// It is written only on the Bubble Tea goroutine, in Update.
+	ExitReason ExitReason
 	// Multi-client effective size (min of all clients in session)
 	EffectiveWidth  int // Effective width for rendering (min of all clients, 0 = use terminal size)
 	EffectiveHeight int // Effective height for rendering (min of all clients, 0 = use terminal size)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -154,6 +154,31 @@ type DaemonDisconnectedMsg struct {
 	Err error
 }
 
+// SessionEndedMsg is sent when the daemon reports that the attached session was
+// terminated (killed from another client, from the CLI, or over the control
+// plane). The session no longer exists, so there is nothing to detach from and
+// nothing to reconnect to: the client must exit.
+type SessionEndedMsg struct {
+	// SessionName is the session that ended, as the daemon named it.
+	SessionName string
+	// Reason is the daemon's short explanation, when it gave one.
+	Reason string
+}
+
+// ExitReason explains why the program stopped, so the caller can print an
+// accurate message and choose an exit status. A client that quits because its
+// session was destroyed must not report a normal detach.
+type ExitReason int
+
+const (
+	// ExitNormal is a user-initiated quit or detach.
+	ExitNormal ExitReason = iota
+	// ExitSessionKilled means the attached session was terminated.
+	ExitSessionKilled
+	// ExitDaemonLost means the daemon connection was lost unrecoverably.
+	ExitDaemonLost
+)
+
 // InputHandler is a function type that handles input messages.
 // This allows the Update method to delegate to the input package without creating a circular dependency.
 type InputHandler func(msg tea.Msg, o *OS) (tea.Model, tea.Cmd)
@@ -813,6 +838,15 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 	case DaemonDisconnectedMsg:
 		// The daemon connection was lost and cannot be recovered; quit cleanly
 		// so the user is not left staring at a frozen, unresponsive session.
+		m.ExitReason = ExitDaemonLost
+		return m, tea.Quit
+
+	case SessionEndedMsg:
+		// The session was destroyed underneath this client. Its windows are
+		// gone and its PTYs are closed, so there is nothing left to render and
+		// nothing to sync back. Record why and quit; the caller reports it and
+		// exits non-zero.
+		m.ExitReason = ExitSessionKilled
 		return m, tea.Quit
 
 	case ConfigReloadedMsg:

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -148,6 +148,45 @@ func (c *Client) KillSession(name string) error {
 	}
 }
 
+// CreateDetachedSession asks the daemon to create a headless session (with an
+// initial window) and no attached client. name may be empty to let the daemon
+// generate one. It returns an error if the name is already taken.
+func (c *Client) CreateDetachedSession(name string, width, height int) error {
+	msg, err := NewMessageWithCodec(MsgNew, &NewPayload{
+		SessionName: name,
+		Width:       width,
+		Height:      height,
+		Detach:      true,
+	}, c.codec)
+	if err != nil {
+		return err
+	}
+
+	if err := c.send(msg); err != nil {
+		return err
+	}
+
+	resp, err := c.recv()
+	if err != nil {
+		return err
+	}
+
+	switch resp.Type {
+	case MsgSessionList:
+		return nil // Success
+
+	case MsgError:
+		var errPayload ErrorPayload
+		if err := resp.ParsePayloadWithCodec(&errPayload, c.codec); err != nil {
+			return fmt.Errorf("create failed")
+		}
+		return fmt.Errorf("create failed: %s", errPayload.Message)
+
+	default:
+		return fmt.Errorf("unexpected response type: %d", resp.Type)
+	}
+}
+
 // ResurrectSession asks the daemon to restore a saved session on demand. It is
 // a no-op (success) if the session is already live.
 func (c *Client) ResurrectSession(name string) error {

--- a/internal/session/codec.go
+++ b/internal/session/codec.go
@@ -138,6 +138,7 @@ func init() {
 	gob.Register(SessionInfo{})
 	gob.Register(SessionListPayload{})
 	gob.Register(KillPayload{})
+	gob.Register(SessionEndedPayload{})
 	gob.Register(ResizePayload{})
 	gob.Register(ErrorPayload{})
 	gob.Register(PTYInfo{})

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -158,14 +158,15 @@ func (d *Daemon) onSessionCreated(s *Session) {
 	name := s.Name
 	s.SetEventSink(func(ev SessionEvent) {
 		d.events.publish(streamEvent{
-			Type:    ev.Type,
-			Session: name,
-			Window:  ev.Window,
-			PTYID:   ev.PTYID,
-			Title:   ev.Title,
-			Bytes:   ev.Bytes,
-			Mode:    ev.Mode,
-			Enabled: ev.Enabled,
+			Type:      ev.Type,
+			Session:   name,
+			Window:    ev.Window,
+			PTYID:     ev.PTYID,
+			Title:     ev.Title,
+			Bytes:     ev.Bytes,
+			Mode:      ev.Mode,
+			Enabled:   ev.Enabled,
+			Workspace: ev.Workspace,
 		})
 	})
 	d.events.publish(streamEvent{Type: EventSessionCreated, Session: name})

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -32,6 +32,10 @@ type Daemon struct {
 	pendingRequests   map[string]*pendingRequest
 	pendingRequestsMu sync.RWMutex
 
+	// events is the control-plane event hub backing the subscribe verb's event
+	// stream and the wait-for verb's blocking waits.
+	events *eventHub
+
 	// Goroutine tracking for clean shutdown
 	wg sync.WaitGroup
 
@@ -83,6 +87,15 @@ type connState struct {
 	sessionID        string // Session they're attached to
 	ptySubscriptions map[string]struct{}
 
+	// Event stream state (JSON verb protocol). eventSub is the hub subscription
+	// once this connection has issued a subscribe verb; streaming guards against a
+	// second subscribe on the same connection; pendingStream hands the fresh
+	// subscription from the subscribe handler to the dispatch loop, which starts
+	// the streamer only after the ack response has been written.
+	eventSub      *eventSub
+	pendingStream *eventSub
+	streaming     bool
+
 	// isTUIClient indicates this is a full TUI client (vs a control client)
 	// TUI clients can receive and execute remote commands
 	isTUIClient bool
@@ -122,6 +135,7 @@ func NewDaemon(cfg *DaemonConfig) *Daemon {
 		cancel:             cancel,
 		clients:            make(map[string]*connState),
 		pendingRequests:    make(map[string]*pendingRequest),
+		events:             newEventHub(),
 		version:            cfg.Version,
 		disableAutoRestore: cfg.DisableAutoRestore,
 	}
@@ -130,7 +144,37 @@ func NewDaemon(cfg *DaemonConfig) *Daemon {
 		d.manager.SetSocketPath(cfg.SocketPath)
 	}
 
+	// Wire session lifecycle to the event hub: every session created through the
+	// manager gets an event sink that publishes to the hub, and creation/deletion
+	// raise session lifecycle events.
+	d.manager.SetSessionHooks(d.onSessionCreated, d.onSessionDeleted)
+
 	return d
+}
+
+// onSessionCreated installs a session's event sink and publishes a
+// session-created event. It runs on the manager's create hook.
+func (d *Daemon) onSessionCreated(s *Session) {
+	name := s.Name
+	s.SetEventSink(func(ev SessionEvent) {
+		d.events.publish(streamEvent{
+			Type:    ev.Type,
+			Session: name,
+			Window:  ev.Window,
+			PTYID:   ev.PTYID,
+			Title:   ev.Title,
+			Bytes:   ev.Bytes,
+			Mode:    ev.Mode,
+			Enabled: ev.Enabled,
+		})
+	})
+	d.events.publish(streamEvent{Type: EventSessionCreated, Session: name})
+}
+
+// onSessionDeleted publishes a session-closed event. It runs on the manager's
+// delete hook.
+func (d *Daemon) onSessionDeleted(s *Session) {
+	d.events.publish(streamEvent{Type: EventSessionClosed, Session: s.Name})
 }
 
 // Start starts the daemon.
@@ -317,6 +361,18 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 
 	defer func() {
 		LogBasic("Client %s disconnected", clientID)
+
+		// Wake any per-connection background goroutines (the event streamer) so
+		// they observe the disconnect and unwind, and release a lingering event
+		// subscription if the streamer never started (e.g. the ack write failed).
+		cs.closeDone()
+		cs.mu.Lock()
+		sub := cs.eventSub
+		cs.eventSub = nil
+		cs.mu.Unlock()
+		if sub != nil {
+			d.events.unsubscribe(sub)
+		}
 
 		d.clientsMu.Lock()
 		delete(d.clients, clientID)

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -296,15 +296,24 @@ func (d *Daemon) shutdown() error {
 			log.Println("Warning: goroutine shutdown timed out after 5s, forcing shutdown")
 		}
 
+		// Stopping the manager stops every session, and each session's Stop
+		// writes its final resurrection state synchronously. When this returns,
+		// everything that will be persisted has been persisted.
 		d.manager.Shutdown()
 
-		socketPath := d.manager.SocketPath()
-		_ = os.Remove(socketPath)
-
+		// Unlinking the socket is deliberately the last thing the daemon does,
+		// after the final resurrection saves and after the pid file. It is the
+		// signal 'tuios kill-server' waits on, so anything ordered after it
+		// would make that signal a lie: a caller could observe the socket gone,
+		// start a new daemon, and race a write from the old one. Closing the
+		// listener is not a usable signal for the same reason, since it happens
+		// at the top of shutdown while state is still unsaved.
 		pidPath, err := GetPidFilePath()
 		if err == nil {
 			_ = os.Remove(pidPath)
 		}
+
+		_ = os.Remove(d.manager.SocketPath())
 
 		log.Println("Daemon shutdown complete")
 	})

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -48,8 +49,15 @@ type Daemon struct {
 
 // pendingRequest tracks a routed command awaiting its result, with the time it
 // was created so cleanupLoop can expire stale entries.
+//
+// A request is delivered one of two ways when the TUI replies:
+//   - requester != nil: the result is forwarded to that connection as a normal
+//     MsgCommandResult (the binary control path).
+//   - resultCh != nil: the result is handed to a goroutine blocked in
+//     routeToTUISync (the JSON verb path), which then writes the JSON response.
 type pendingRequest struct {
 	requester *connState
+	resultCh  chan *CommandResultPayload
 	created   time.Time
 }
 
@@ -347,6 +355,17 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		_ = conn.Close()
 	}()
 
+	// Wrap the connection so the first byte can be inspected without consuming
+	// it from the binary read path. A JSON verb-protocol client sends a line
+	// starting with '{' (or leading whitespace); a binary client's first byte is
+	// the high byte of a big-endian length prefix, which is 0x00 or 0x01 for any
+	// frame under the 16MB cap and so never collides with '{' or whitespace.
+	br := bufio.NewReaderSize(conn, 64*1024)
+	if d.detectJSONClient(cs, br) {
+		d.handleJSONConnection(cs, br)
+		return
+	}
+
 	lastHeartbeat := time.Now()
 	for {
 		select {
@@ -360,7 +379,7 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		// Short deadline only detects the message boundary (for done/ctx
 		// checks); the body gets a longer deadline so a large payload cannot be
 		// cut mid-frame and desync framing.
-		msg, codecType, err := ReadMessageConn(conn, 100*time.Millisecond, 30*time.Second)
+		msg, codecType, err := ReadMessageBuffered(conn, br, 100*time.Millisecond, 30*time.Second)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -172,10 +172,20 @@ func (d *Daemon) onSessionCreated(s *Session) {
 	d.events.publish(streamEvent{Type: EventSessionCreated, Session: name})
 }
 
-// onSessionDeleted publishes a session-closed event. It runs on the manager's
-// delete hook.
+// onSessionDeleted publishes a session-closed event and tells every client
+// attached to the session that it is gone. It runs on the manager's delete hook,
+// so every deletion path (the kill-session verb, the legacy kill message, and
+// any internal teardown) notifies clients through one place.
+//
+// Without this a killed session leaves its clients attached to nothing: their
+// PTYs are closed and their windows are gone, but the socket stays open, so the
+// client sits in a dead session with no way to learn what happened.
 func (d *Daemon) onSessionDeleted(s *Session) {
 	d.events.publish(streamEvent{Type: EventSessionClosed, Session: s.Name})
+	d.broadcastToSession(s.ID, MsgSessionEnded, &SessionEndedPayload{
+		SessionName: s.Name,
+		Reason:      "the session was terminated",
+	}, "")
 }
 
 // Start starts the daemon.

--- a/internal/session/daemon_command.go
+++ b/internal/session/daemon_command.go
@@ -282,6 +282,10 @@ func (d *Daemon) handleCommandResult(cs *connState, msg *Message) error {
 // still returns a single request/response over the JSON connection. requestID
 // must be unique per in-flight call.
 func (d *Daemon) routeToTUISync(tui *connState, requestID string, cmd *RemoteCommandPayload, timeout time.Duration) (*CommandResultPayload, error) {
+	// Stamp the request ID onto the outgoing command so the TUI echoes it back on
+	// its result and handleCommandResult can match it to this pending waiter.
+	cmd.RequestID = requestID
+
 	ch := make(chan *CommandResultPayload, 1)
 
 	d.pendingRequestsMu.Lock()

--- a/internal/session/daemon_command.go
+++ b/internal/session/daemon_command.go
@@ -23,11 +23,26 @@ func (d *Daemon) handleExecuteCommand(cs *connState, msg *Message) error {
 	}
 	LogBasic("Execute command: found session %s (ID=%s)", session.Name, session.ID)
 
-	// Find the TUI client attached to this session
+	// Find the TUI client attached to this session. When one is present the
+	// command is routed to it (unchanged behavior). With no client attached,
+	// structural verbs execute directly against daemon-owned state.
 	tuiClient := d.findTUIClient(session.ID)
 	if tuiClient == nil {
-		LogBasic("Execute command: no TUI client found for session %s", session.ID)
-		return d.sendCommandResult(cs, payload.RequestID, false, "no TUI client attached to session")
+		if payload.TapeScript != "" {
+			return d.sendCommandResult(cs, payload.RequestID, false,
+				"tape scripts require an attached client (the headless daemon has no renderer)")
+		}
+		onExit := func(ptyID string) { d.notifyPTYClosed(session.ID, ptyID) }
+		data, err := d.executeDaemonCommand(session, payload.CommandType, payload.Args, onExit)
+		if err != nil {
+			return d.sendCommandResult(cs, payload.RequestID, false, err.Error())
+		}
+		return d.sendMessage(cs, MsgCommandResult, &CommandResultPayload{
+			RequestID: payload.RequestID,
+			Success:   true,
+			Message:   "command executed",
+			Data:      data,
+		})
 	}
 	LogBasic("Execute command: found TUI client %s", tuiClient.clientID)
 
@@ -78,10 +93,13 @@ func (d *Daemon) handleSendKeys(cs *connState, msg *Message) error {
 		return d.sendCommandResult(cs, payload.RequestID, false, "session not found")
 	}
 
-	// Find the TUI client attached to this session
+	// With no client attached, deliver the keys straight to the target PTY.
 	tuiClient := d.findTUIClient(session.ID)
 	if tuiClient == nil {
-		return d.sendCommandResult(cs, payload.RequestID, false, "no TUI client attached to session")
+		if err := d.sendKeysDaemonSide(session, &payload); err != nil {
+			return d.sendCommandResult(cs, payload.RequestID, false, err.Error())
+		}
+		return d.sendCommandResult(cs, payload.RequestID, true, "keys sent")
 	}
 
 	// Forward the command to the TUI client
@@ -121,9 +139,19 @@ func (d *Daemon) handleCapturePane(cs *connState, msg *Message) error {
 		return d.sendCommandResult(cs, payload.RequestID, false, "session not found")
 	}
 
+	// With no client attached, render the pane from the daemon-side VT emulator.
 	tuiClient := d.findTUIClient(session.ID)
 	if tuiClient == nil {
-		return d.sendCommandResult(cs, payload.RequestID, false, "no TUI client attached to session")
+		content, err := d.capturePaneDaemonSide(session, &payload)
+		if err != nil {
+			return d.sendCommandResult(cs, payload.RequestID, false, err.Error())
+		}
+		return d.sendMessage(cs, MsgCommandResult, &CommandResultPayload{
+			RequestID: payload.RequestID,
+			Success:   true,
+			Message:   "captured",
+			Data:      map[string]any{"content": content},
+		})
 	}
 
 	remoteCmd := &RemoteCommandPayload{
@@ -169,10 +197,13 @@ func (d *Daemon) handleSetConfig(cs *connState, msg *Message) error {
 		return d.sendCommandResult(cs, payload.RequestID, false, "session not found")
 	}
 
-	// Find the TUI client attached to this session
+	// Find the TUI client attached to this session. set_config changes live
+	// appearance, which only a renderer can apply, so headless it is refused
+	// with a clear message rather than silently dropped.
 	tuiClient := d.findTUIClient(session.ID)
 	if tuiClient == nil {
-		return d.sendCommandResult(cs, payload.RequestID, false, "no TUI client attached to session")
+		return d.sendCommandResult(cs, payload.RequestID, false,
+			"set-config requires an attached client (appearance changes need a renderer)")
 	}
 
 	// Forward the command to the TUI client
@@ -316,61 +347,8 @@ func (d *Daemon) handleQueryWindows(cs *connState, msg *Message) error {
 		return d.sendError(cs, ErrCodeSessionNotFound, "session not found")
 	}
 
-	// Get state from session (daemon stores this)
-	state := session.GetState()
-
-	// Build window list from state
-	windows := make([]map[string]any, 0, len(state.Windows))
-	for i, w := range state.Windows {
-		displayName := w.Title
-		if w.CustomName != "" {
-			displayName = w.CustomName
-		}
-
-		winInfo := map[string]any{
-			"window_id":    w.ID,
-			"index":        i,
-			"title":        w.Title,
-			"display_name": displayName,
-			"workspace":    w.Workspace,
-			"minimized":    w.Minimized,
-			"focused":      w.ID == state.FocusedWindowID,
-			"x":            w.X,
-			"y":            w.Y,
-			"width":        w.Width,
-			"height":       w.Height,
-		}
-		if w.CustomName != "" {
-			winInfo["custom_name"] = w.CustomName
-		}
-		windows = append(windows, winInfo)
-	}
-
-	// Count windows per workspace
-	workspaceWindows := make([]int, 9) // Assume 9 workspaces
-	for _, w := range state.Windows {
-		if w.Workspace >= 1 && w.Workspace <= 9 {
-			workspaceWindows[w.Workspace-1]++
-		}
-	}
-
-	// Find focused index
-	focusedIndex := -1
-	for i, w := range state.Windows {
-		if w.ID == state.FocusedWindowID {
-			focusedIndex = i
-			break
-		}
-	}
-
-	resultData := map[string]any{
-		"windows":           windows,
-		"total":             len(state.Windows),
-		"focused_index":     focusedIndex,
-		"focused_window_id": state.FocusedWindowID,
-		"current_workspace": state.CurrentWorkspace,
-		"workspace_windows": workspaceWindows,
-	}
+	// Get state from session (daemon stores this) and build the window list.
+	resultData := buildWindowListData(session.GetState())
 
 	return d.sendMessage(cs, MsgCommandResult, &CommandResultPayload{
 		RequestID: payload.RequestID,
@@ -394,32 +372,9 @@ func (d *Daemon) handleQuerySession(cs *connState, msg *Message) error {
 		return d.sendError(cs, ErrCodeSessionNotFound, "session not found")
 	}
 
-	// Get state from session
-	state := session.GetState()
-
-	// Check if TUI is attached
-	tuiClient := d.findTUIClient(session.ID)
-	hasClient := tuiClient != nil
-
-	// Build session info from state
-	tilingMode := "floating"
-	if state.AutoTiling {
-		tilingMode = "tiling"
-	}
-
-	resultData := map[string]any{
-		"session_name":      state.Name,
-		"session_id":        session.ID,
-		"mode":              "unknown", // Can't know mode without TUI
-		"current_workspace": state.CurrentWorkspace,
-		"num_workspaces":    9, // Default
-		"window_count":      len(state.Windows),
-		"tiling_mode":       tilingMode,
-		"master_ratio":      state.MasterRatio,
-		"width":             state.Width,
-		"height":            state.Height,
-		"tui_attached":      hasClient,
-	}
+	// Build session info from state, noting whether a TUI is attached.
+	hasClient := d.findTUIClient(session.ID) != nil
+	resultData := buildSessionInfoData(session, session.GetState(), hasClient)
 
 	return d.sendMessage(cs, MsgCommandResult, &CommandResultPayload{
 		RequestID: payload.RequestID,

--- a/internal/session/daemon_command.go
+++ b/internal/session/daemon_command.go
@@ -254,6 +254,17 @@ func (d *Daemon) handleCommandResult(cs *connState, msg *Message) error {
 	}
 	d.pendingRequestsMu.Unlock()
 
+	// Deliver to a JSON verb handler blocked in routeToTUISync, if any.
+	if found && pending != nil && pending.resultCh != nil {
+		result := payload
+		select {
+		case pending.resultCh <- &result:
+		default:
+			// The waiter already gave up (timeout/disconnect); drop the result.
+		}
+		return nil
+	}
+
 	// Forward the result to the original requester
 	if found && pending != nil && pending.requester != nil {
 		requester := pending.requester
@@ -262,6 +273,42 @@ func (d *Daemon) handleCommandResult(cs *connState, msg *Message) error {
 	}
 
 	return nil
+}
+
+// routeToTUISync sends a remote command to an attached TUI and blocks until the
+// TUI replies with its result, a timeout elapses, or the daemon shuts down. It
+// is the synchronous bridge the JSON verb front-end uses so a control verb that
+// must be handled by the live renderer (WM keys, structural changes, live config)
+// still returns a single request/response over the JSON connection. requestID
+// must be unique per in-flight call.
+func (d *Daemon) routeToTUISync(tui *connState, requestID string, cmd *RemoteCommandPayload, timeout time.Duration) (*CommandResultPayload, error) {
+	ch := make(chan *CommandResultPayload, 1)
+
+	d.pendingRequestsMu.Lock()
+	d.pendingRequests[requestID] = &pendingRequest{resultCh: ch, created: time.Now()}
+	d.pendingRequestsMu.Unlock()
+
+	clearPending := func() {
+		d.pendingRequestsMu.Lock()
+		delete(d.pendingRequests, requestID)
+		d.pendingRequestsMu.Unlock()
+	}
+
+	if err := d.sendMessage(tui, MsgRemoteCommand, cmd); err != nil {
+		clearPending()
+		return nil, fmt.Errorf("failed to reach the attached client: %w", err)
+	}
+
+	select {
+	case res := <-ch:
+		return res, nil
+	case <-time.After(timeout):
+		clearPending()
+		return nil, fmt.Errorf("timed out waiting for the attached client")
+	case <-d.ctx.Done():
+		clearPending()
+		return nil, fmt.Errorf("daemon shutting down")
+	}
 }
 
 // findTargetSession finds a session by name, or returns the most recently active session.

--- a/internal/session/daemon_diagnose.go
+++ b/internal/session/daemon_diagnose.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// This file answers one question precisely: why can this process not talk to a
+// daemon? "Not running" covers several genuinely different states, and each one
+// has a different fix, so collapsing them into a single message is what leaves a
+// user stuck.
+
+// DaemonState classifies the daemon socket's condition.
+type DaemonState int
+
+const (
+	// DaemonRunning means a process accepted a connection on the socket.
+	DaemonRunning DaemonState = iota
+	// DaemonAbsent means no socket file exists: the daemon has never run, or
+	// was shut down cleanly.
+	DaemonAbsent
+	// DaemonStaleSocket means the socket file exists but nothing is listening
+	// on it, which is what a crashed or SIGKILLed daemon leaves behind.
+	DaemonStaleSocket
+	// DaemonPermissionDenied means the socket exists but this user may not
+	// connect to it, typically another user's socket or a bad mode.
+	DaemonPermissionDenied
+	// DaemonUnreachable is any other connection failure.
+	DaemonUnreachable
+)
+
+// DaemonDiagnosis describes the daemon socket's condition, with enough detail
+// for a caller to write a message that names the fix.
+type DaemonDiagnosis struct {
+	State DaemonState
+	// SocketPath is the socket that was probed, empty only when the path itself
+	// could not be resolved.
+	SocketPath string
+	// PID is the daemon's process id when it is running and left a pid file.
+	PID int
+	// Err is the underlying failure, when there was one.
+	Err error
+}
+
+// Running reports whether a daemon is actually accepting connections.
+func (d DaemonDiagnosis) Running() bool { return d.State == DaemonRunning }
+
+// DiagnoseDaemon probes the daemon socket and classifies what it finds.
+//
+// It is deliberately more informative than IsDaemonRunning, which answers only
+// yes or no: a stale socket and a permission-denied socket both read as "not
+// running" there, yet one is fixed by starting a session and the other is not
+// fixed by anything the user would think to try.
+func DiagnoseDaemon() DaemonDiagnosis {
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		return DaemonDiagnosis{State: DaemonUnreachable, Err: err}
+	}
+
+	d := DaemonDiagnosis{SocketPath: socketPath}
+
+	if _, statErr := os.Stat(socketPath); statErr != nil {
+		if errors.Is(statErr, fs.ErrNotExist) {
+			d.State = DaemonAbsent
+			return d
+		}
+		if errors.Is(statErr, fs.ErrPermission) {
+			d.State = DaemonPermissionDenied
+			d.Err = statErr
+			return d
+		}
+		d.State = DaemonUnreachable
+		d.Err = statErr
+		return d
+	}
+
+	conn, dialErr := net.DialTimeout("unix", socketPath, time.Second)
+	if dialErr == nil {
+		_ = conn.Close()
+		d.State = DaemonRunning
+		d.PID = GetDaemonPID()
+		return d
+	}
+
+	d.Err = dialErr
+	switch {
+	case errors.Is(dialErr, syscall.ECONNREFUSED), errors.Is(dialErr, syscall.ENOENT):
+		// The file is there but no process is behind it: a crashed daemon.
+		d.State = DaemonStaleSocket
+	case errors.Is(dialErr, fs.ErrPermission), errors.Is(dialErr, syscall.EACCES):
+		d.State = DaemonPermissionDenied
+	default:
+		d.State = DaemonUnreachable
+	}
+	return d
+}
+
+// Explain renders the diagnosis as a message that states what failed, the most
+// likely cause, and the exact command that resolves it. It returns an empty
+// string when the daemon is running, so a caller can use it as a guard.
+func (d DaemonDiagnosis) Explain() string {
+	switch d.State {
+	case DaemonRunning:
+		return ""
+
+	case DaemonAbsent:
+		return "The TUIOS daemon is not running.\n" +
+			"Most likely cause: no session has been started yet, or the daemon was shut down.\n" +
+			"Fix: run 'tuios new' to start a session, or 'tuios start-server' for a daemon with no session."
+
+	case DaemonStaleSocket:
+		return fmt.Sprintf("The TUIOS daemon is not running, but a stale socket is left over at %s.\n"+
+			"Most likely cause: the daemon crashed or was killed without cleaning up.\n"+
+			"Fix: run 'tuios kill-server' to clear it, then 'tuios new' to start a session.", d.SocketPath)
+
+	case DaemonPermissionDenied:
+		return fmt.Sprintf("Permission denied connecting to the TUIOS daemon socket at %s.\n"+
+			"Most likely cause: the socket belongs to another user, or its directory permissions changed.\n"+
+			"Fix: check 'ls -l %s'. If it belongs to another user, set XDG_RUNTIME_DIR to a directory you own; if it is yours, remove it and run 'tuios new'.",
+			d.SocketPath, d.SocketPath)
+
+	default:
+		reason := "unknown error"
+		if d.Err != nil {
+			reason = d.Err.Error()
+		}
+		return fmt.Sprintf("Could not reach the TUIOS daemon at %s: %s.\n"+
+			"Most likely cause: the socket path is unusable (a full or read-only XDG_RUNTIME_DIR, or a leftover file that is not a socket).\n"+
+			"Fix: run 'tuios kill-server', then 'tuios new'. If that fails, remove %s and try again.",
+			d.SocketPath, reason, d.SocketPath)
+	}
+}

--- a/internal/session/daemon_diagnose.go
+++ b/internal/session/daemon_diagnose.go
@@ -100,6 +100,41 @@ func DiagnoseDaemon() DaemonDiagnosis {
 	return d
 }
 
+// ErrShutdownTimeout reports that a daemon was asked to stop but did not
+// finish within the caller's deadline. It is distinct from a failure to signal
+// the daemon: the request was delivered, the confirmation never arrived.
+var ErrShutdownTimeout = errors.New("timed out waiting for the daemon to finish shutting down")
+
+// WaitForDaemonShutdown blocks until a daemon that was asked to stop has
+// finished, or until timeout elapses.
+//
+// The completion signal is the socket file being unlinked, which Daemon.shutdown
+// does last, after every session has written its final resurrection state. That
+// makes this a persistence guarantee and not merely a liveness one: a refused
+// connection would prove neither, because the listener closes at the top of
+// shutdown while state is still unsaved.
+//
+// It returns ErrShutdownTimeout if the deadline passes with the socket still in
+// place, so a caller can say that the daemon is wedged rather than reporting
+// success and letting a subsequent start race the old process.
+func WaitForDaemonShutdown(timeout time.Duration) error {
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, statErr := os.Stat(socketPath); errors.Is(statErr, fs.ErrNotExist) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return ErrShutdownTimeout
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // Explain renders the diagnosis as a message that states what failed, the most
 // likely cause, and the exact command that resolves it. It returns an empty
 // string when the daemon is running, so a caller can use it as a guard.

--- a/internal/session/daemon_events.go
+++ b/internal/session/daemon_events.go
@@ -1,0 +1,185 @@
+package session
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// This file implements the daemon's event hub: the fan-out that backs the
+// subscribe verb's long-lived event stream and the wait-for verb's blocking
+// waits. Event sources (PTY output/bell/mode changes, window and session
+// lifecycle) publish typed events to the hub, which stamps each with a
+// daemon-global monotonic sequence number and delivers it to every matching
+// subscriber. Subscribers have a bounded queue: a slow subscriber's events are
+// dropped and a gap marker is delivered rather than blocking the daemon (the
+// same slow-client discipline used by daemon_stream.go for raw PTY output).
+
+// Event type discriminators carried in a stream event's "type" field. These are
+// part of the public protocol surface; keep the string values stable.
+const (
+	EventWindowCreated  = "window-created"  // a daemon-owned window was created
+	EventWindowClosed   = "window-closed"   // a daemon-owned window was closed/removed
+	EventWindowExit     = "window-exit"     // a window's shell process exited
+	EventWindowRetitled = "window-retitled" // a window's title/name changed
+	EventOutput         = "output"          // a window produced output (activity)
+	EventBell           = "bell"            // a window rang the terminal bell
+	EventModeChanged    = "mode-changed"    // a terminal mode toggled (e.g. alt-screen)
+	EventSessionCreated = "session-created" // a session was created
+	EventSessionClosed  = "session-closed"  // a session was terminated
+	EventGap            = "gap"             // slow-subscriber marker: N events were dropped
+	EventSubscribed     = "subscribed"      // subscribe ack result type
+)
+
+// defaultEventQueue bounds a subscriber's per-connection event queue. When it is
+// full the hub drops the event and records the drop as a gap rather than blocking
+// the publisher (and thus the daemon).
+const defaultEventQueue = 256
+
+// streamEvent is one event as delivered on the wire (a JSON line). Seq is the
+// daemon-global monotonic sequence number; every subscriber sees the same Seq for
+// the same event. Zero-value fields are omitted so a bell event is not padded
+// with an empty title, byte count, and so on.
+type streamEvent struct {
+	Seq     uint64 `json:"seq,omitempty"`
+	Type    string `json:"type"`
+	Session string `json:"session,omitempty"`
+	Window  string `json:"window,omitempty"`
+	PTYID   string `json:"pty_id,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Bytes   int    `json:"bytes,omitempty"`
+	Mode    string `json:"mode,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+	Dropped uint64 `json:"dropped,omitempty"`
+	Time    int64  `json:"time,omitempty"`
+}
+
+// SessionEvent is the source-side event a Session emits through its event sink.
+// The daemon's sink wrapper adds the session name, sequence number, and time
+// before publishing to the hub. Window/PTYID are filled in by the per-PTY emitter
+// or the window op that raises the event.
+type SessionEvent struct {
+	Type    string
+	Window  string
+	PTYID   string
+	Title   string
+	Bytes   int
+	Mode    string
+	Enabled bool
+}
+
+// eventFilter selects which events a subscriber receives. A zero value matches
+// everything. An empty types set matches all event types.
+type eventFilter struct {
+	session string
+	window  string
+	ptyID   string
+	types   map[string]bool
+}
+
+func (f eventFilter) match(ev streamEvent) bool {
+	if f.session != "" && ev.Session != f.session {
+		return false
+	}
+	if f.window != "" && ev.Window != f.window {
+		return false
+	}
+	if f.ptyID != "" && ev.PTYID != f.ptyID {
+		return false
+	}
+	if len(f.types) > 0 && !f.types[ev.Type] {
+		return false
+	}
+	return true
+}
+
+// eventSub is one subscription: a bounded delivery channel, its filter, and a
+// dropped-since-last-delivered counter driving the gap marker. stop lets an
+// explicit unsubscribe wake the streamer.
+type eventSub struct {
+	ch       chan streamEvent
+	filter   eventFilter
+	dropped  atomic.Uint64
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// close signals the subscription's streamer (if any) to exit. Safe to call more
+// than once.
+func (s *eventSub) close() {
+	s.stopOnce.Do(func() { close(s.stop) })
+}
+
+// eventHub fans typed events out to every matching subscriber, assigning each a
+// daemon-global monotonic sequence number.
+type eventHub struct {
+	mu   sync.Mutex
+	seq  uint64
+	subs map[*eventSub]struct{}
+}
+
+func newEventHub() *eventHub {
+	return &eventHub{subs: make(map[*eventSub]struct{})}
+}
+
+// subscribe registers a new subscription with the given filter and queue size
+// (bufSize <= 0 uses the default). The returned sub must be released with
+// unsubscribe.
+func (h *eventHub) subscribe(filter eventFilter, bufSize int) *eventSub {
+	if bufSize <= 0 {
+		bufSize = defaultEventQueue
+	}
+	sub := &eventSub{
+		ch:     make(chan streamEvent, bufSize),
+		filter: filter,
+		stop:   make(chan struct{}),
+	}
+	h.mu.Lock()
+	h.subs[sub] = struct{}{}
+	h.mu.Unlock()
+	return sub
+}
+
+// unsubscribe removes a subscription and signals its streamer to stop. Idempotent.
+func (h *eventHub) unsubscribe(sub *eventSub) {
+	if sub == nil {
+		return
+	}
+	h.mu.Lock()
+	delete(h.subs, sub)
+	h.mu.Unlock()
+	sub.close()
+}
+
+// currentSeq returns the last assigned sequence number, so a fresh subscriber can
+// learn the baseline from which its stream begins.
+func (h *eventHub) currentSeq() uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.seq
+}
+
+// publish stamps ev with the next global sequence number and a timestamp, then
+// delivers it to every matching subscriber. Delivery is non-blocking: a
+// subscriber whose queue is full has the event dropped and its drop counter
+// incremented (surfaced later as a gap marker), so one slow subscriber can never
+// stall the publisher or any other subscriber.
+func (h *eventHub) publish(ev streamEvent) {
+	h.mu.Lock()
+	h.seq++
+	ev.Seq = h.seq
+	if ev.Time == 0 {
+		ev.Time = time.Now().UnixNano()
+	}
+	for sub := range h.subs {
+		if !sub.filter.match(ev) {
+			continue
+		}
+		select {
+		case sub.ch <- ev:
+		default:
+			sub.dropped.Add(1)
+		}
+	}
+	h.mu.Unlock()
+}

--- a/internal/session/daemon_events.go
+++ b/internal/session/daemon_events.go
@@ -18,17 +18,22 @@ import (
 // Event type discriminators carried in a stream event's "type" field. These are
 // part of the public protocol surface; keep the string values stable.
 const (
-	EventWindowCreated  = "window-created"  // a daemon-owned window was created
-	EventWindowClosed   = "window-closed"   // a daemon-owned window was closed/removed
-	EventWindowExit     = "window-exit"     // a window's shell process exited
-	EventWindowRetitled = "window-retitled" // a window's title/name changed
-	EventOutput         = "output"          // a window produced output (activity)
-	EventBell           = "bell"            // a window rang the terminal bell
-	EventModeChanged    = "mode-changed"    // a terminal mode toggled (e.g. alt-screen)
-	EventSessionCreated = "session-created" // a session was created
-	EventSessionClosed  = "session-closed"  // a session was terminated
-	EventGap            = "gap"             // slow-subscriber marker: N events were dropped
-	EventSubscribed     = "subscribed"      // subscribe ack result type
+	EventWindowCreated     = "window-created"     // a window was created
+	EventWindowClosed      = "window-closed"      // a window was closed/removed
+	EventWindowExit        = "window-exit"        // a window's shell process exited
+	EventWindowRetitled    = "window-retitled"    // a window's title/name changed
+	EventWindowFocused     = "window-focused"     // a window became the focused window
+	EventWindowMoved       = "window-moved"       // a window moved to another workspace
+	EventWindowMinimized   = "window-minimized"   // a window was minimized
+	EventWindowRestored    = "window-restored"    // a minimized window was restored
+	EventWorkspaceSwitched = "workspace-switched" // the session's current workspace changed
+	EventOutput            = "output"             // a window produced output (activity)
+	EventBell              = "bell"               // a window rang the terminal bell
+	EventModeChanged       = "mode-changed"       // a terminal mode toggled (e.g. alt-screen)
+	EventSessionCreated    = "session-created"    // a session was created
+	EventSessionClosed     = "session-closed"     // a session was terminated
+	EventGap               = "gap"                // slow-subscriber marker: N events were dropped
+	EventSubscribed        = "subscribed"         // subscribe ack result type
 )
 
 // defaultEventQueue bounds a subscriber's per-connection event queue. When it is
@@ -50,8 +55,12 @@ type streamEvent struct {
 	Bytes   int    `json:"bytes,omitempty"`
 	Mode    string `json:"mode,omitempty"`
 	Enabled bool   `json:"enabled,omitempty"`
-	Dropped uint64 `json:"dropped,omitempty"`
-	Time    int64  `json:"time,omitempty"`
+	// Workspace carries the workspace a window moved to (window-moved) or the
+	// workspace that became current (workspace-switched). Workspaces are 1-based,
+	// so a zero value is always "not applicable" and is omitted.
+	Workspace int    `json:"workspace,omitempty"`
+	Dropped   uint64 `json:"dropped,omitempty"`
+	Time      int64  `json:"time,omitempty"`
 }
 
 // SessionEvent is the source-side event a Session emits through its event sink.
@@ -59,13 +68,14 @@ type streamEvent struct {
 // before publishing to the hub. Window/PTYID are filled in by the per-PTY emitter
 // or the window op that raises the event.
 type SessionEvent struct {
-	Type    string
-	Window  string
-	PTYID   string
-	Title   string
-	Bytes   int
-	Mode    string
-	Enabled bool
+	Type      string
+	Window    string
+	PTYID     string
+	Title     string
+	Bytes     int
+	Mode      string
+	Enabled   bool
+	Workspace int
 }
 
 // eventFilter selects which events a subscriber receives. A zero value matches

--- a/internal/session/daemon_events_test.go
+++ b/internal/session/daemon_events_test.go
@@ -1,0 +1,135 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestEventHubTwoSubscribersSameSequence verifies that two subscribers see the
+// same monotonic sequence number for each published event.
+func TestEventHubTwoSubscribersSameSequence(t *testing.T) {
+	h := newEventHub()
+	a := h.subscribe(eventFilter{}, 64)
+	b := h.subscribe(eventFilter{}, 64)
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		h.publish(streamEvent{Type: EventOutput})
+	}
+
+	for i := 0; i < n; i++ {
+		ea := <-a.ch
+		eb := <-b.ch
+		if ea.Seq != eb.Seq {
+			t.Fatalf("event %d: subscriber seqs differ: a=%d b=%d", i, ea.Seq, eb.Seq)
+		}
+		if ea.Seq != uint64(i+1) {
+			t.Fatalf("event %d: seq = %d, want %d", i, ea.Seq, i+1)
+		}
+	}
+}
+
+// TestEventHubDropsWhenQueueFull verifies the slow-subscriber policy: once the
+// bounded queue is full, further events are dropped and counted rather than
+// blocking the publisher, and the surviving events are the earliest ones.
+func TestEventHubDropsWhenQueueFull(t *testing.T) {
+	h := newEventHub()
+	sub := h.subscribe(eventFilter{}, 4)
+
+	for i := 0; i < 10; i++ {
+		h.publish(streamEvent{Type: EventOutput})
+	}
+
+	// 4 buffered, 6 dropped.
+	if got := sub.dropped.Load(); got != 6 {
+		t.Fatalf("dropped = %d, want 6", got)
+	}
+	first := <-sub.ch
+	if first.Seq != 1 {
+		t.Fatalf("first surviving event seq = %d, want 1 (earliest kept)", first.Seq)
+	}
+}
+
+// TestEventHubFilters verifies session/type filtering: a subscriber only receives
+// events matching its filter, and non-matching events are neither delivered nor
+// counted as drops.
+func TestEventHubFilters(t *testing.T) {
+	h := newEventHub()
+	sub := h.subscribe(eventFilter{session: "work", types: map[string]bool{EventBell: true}}, 16)
+
+	h.publish(streamEvent{Type: EventOutput, Session: "work"}) // wrong type
+	h.publish(streamEvent{Type: EventBell, Session: "other"})  // wrong session
+	h.publish(streamEvent{Type: EventBell, Session: "work"})   // match
+
+	ev := <-sub.ch
+	if ev.Type != EventBell || ev.Session != "work" {
+		t.Fatalf("got %+v, want a work/bell event", ev)
+	}
+	if sub.dropped.Load() != 0 {
+		t.Fatalf("filtered-out events must not count as drops, got %d", sub.dropped.Load())
+	}
+	select {
+	case extra := <-sub.ch:
+		t.Fatalf("unexpected extra event: %+v", extra)
+	default:
+	}
+}
+
+// TestStreamEventsEmitsGapMarker verifies the streamer surfaces dropped events as
+// a gap marker written just before the next surviving event. Events are published
+// before the streamer starts (modeling an infinitely slow reader during the
+// burst) so drops accumulate deterministically through the real hub.
+func TestStreamEventsEmitsGapMarker(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{})
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close(); _ = client.Close() })
+
+	cs := &connState{
+		conn:             client,
+		clientID:         "gap-client",
+		done:             make(chan struct{}),
+		codec:            DefaultCodec(),
+		ptySubscriptions: make(map[string]struct{}),
+	}
+
+	sub := d.events.subscribe(eventFilter{}, 2)
+	// Burst 5 events with no streamer draining: seq 1,2 buffer; 3,4,5 drop.
+	for i := 0; i < 5; i++ {
+		d.events.publish(streamEvent{Type: EventOutput})
+	}
+	if got := sub.dropped.Load(); got != 3 {
+		t.Fatalf("dropped = %d, want 3", got)
+	}
+
+	go d.streamEvents(cs, sub)
+	t.Cleanup(func() { close(cs.done) })
+
+	r := bufio.NewReader(server)
+	read := func() streamEvent {
+		t.Helper()
+		_ = server.SetReadDeadline(time.Now().Add(3 * time.Second))
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("decode %q: %v", string(line), err)
+		}
+		return ev
+	}
+
+	// The gap marker precedes the next surviving event.
+	if gap := read(); gap.Type != EventGap || gap.Dropped != 3 {
+		t.Fatalf("first line = %+v, want gap with dropped=3", gap)
+	}
+	if e1 := read(); e1.Seq != 1 {
+		t.Fatalf("second line seq = %d, want 1", e1.Seq)
+	}
+	if e2 := read(); e2.Seq != 2 {
+		t.Fatalf("third line seq = %d, want 2", e2.Seq)
+	}
+}

--- a/internal/session/daemon_handlers.go
+++ b/internal/session/daemon_handlers.go
@@ -204,12 +204,25 @@ func (d *Daemon) handleNew(cs *connState, msg *Message) error {
 		name = d.manager.GenerateSessionName()
 	}
 
-	_, err := d.manager.CreateSession(name, cfg, payload.Width, payload.Height)
+	sess, err := d.manager.CreateSession(name, cfg, payload.Width, payload.Height)
 	if err != nil {
 		if err.Error() == fmt.Sprintf("session '%s' already exists", name) {
 			return d.sendError(cs, ErrCodeSessionExists, err.Error())
 		}
 		return fmt.Errorf("failed to create session: %w", err)
+	}
+
+	// A detached session has no client to create its first window, so spawn one
+	// daemon-side. This makes the session immediately usable by control verbs
+	// and gives a later 'tuios attach' a window to restore. Non-detach creation
+	// keeps its historical behavior of an empty session the TUI populates.
+	if payload.Detach {
+		sessionID := sess.ID
+		onExit := func(ptyID string) { d.notifyPTYClosed(sessionID, ptyID) }
+		if _, err := sess.AddDaemonWindow("Window", onExit); err != nil {
+			return d.sendError(cs, ErrCodeInternal, fmt.Sprintf("failed to create initial window: %v", err))
+		}
+		log.Printf("Created detached session %q with an initial window", name)
 	}
 
 	return d.handleList(cs)

--- a/internal/session/daemon_native.go
+++ b/internal/session/daemon_native.go
@@ -1,0 +1,424 @@
+package session
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// This file implements the headless execution path for the mutating control
+// verbs. When a session has a TUI client attached the daemon keeps routing verbs
+// to it (unchanged behavior); when none is attached these functions act directly
+// on the daemon-owned canonical state so control works with no client.
+
+// errNeedsClient is returned for verbs that genuinely require a live renderer
+// (tiling geometry, animations, theming) and so cannot run headless.
+type errNeedsClient struct{ verb string }
+
+func (e errNeedsClient) Error() string {
+	return fmt.Sprintf("command %q requires an attached client (the headless daemon has no renderer)", e.verb)
+}
+
+// focusedWindowID returns the focused window's ID, falling back to the first
+// window on the current workspace, or an error when the session has no windows.
+func focusedWindowID(state *SessionState) (string, error) {
+	if state.FocusedWindowID != "" {
+		return state.FocusedWindowID, nil
+	}
+	for i := range state.Windows {
+		if state.Windows[i].Workspace == state.CurrentWorkspace {
+			return state.Windows[i].ID, nil
+		}
+	}
+	if len(state.Windows) > 0 {
+		return state.Windows[0].ID, nil
+	}
+	return "", fmt.Errorf("session has no windows")
+}
+
+// executeDaemonCommand runs a structural tape command against daemon-owned
+// session state with no TUI client. onExit is wired into any PTY it spawns so
+// the daemon can notify clients when that shell exits. It returns result data
+// (for read verbs and NewWindow) or an error. Rendering-dependent verbs return
+// errNeedsClient.
+func (d *Daemon) executeDaemonCommand(sess *Session, commandType string, args []string, onExit func(ptyID string)) (map[string]any, error) {
+	switch commandType {
+	case "NewWindow":
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+		win, err := sess.AddDaemonWindow("Window", onExit)
+		if err != nil {
+			return nil, err
+		}
+		displayName := win.Title
+		if name != "" {
+			if err := sess.RenameDaemonWindow(win.ID, name); err != nil {
+				return nil, err
+			}
+			displayName = name
+		}
+		return map[string]any{"window_id": win.ID, "name": displayName}, nil
+
+	case "CloseWindow":
+		target := ""
+		if len(args) > 0 {
+			target = args[0]
+		} else {
+			id, err := focusedWindowID(sess.GetState())
+			if err != nil {
+				return nil, err
+			}
+			target = id
+		}
+		if _, err := sess.CloseDaemonWindow(target); err != nil {
+			return nil, err
+		}
+		return nil, nil
+
+	case "NextWindow":
+		return nil, sess.CycleDaemonFocus(1)
+
+	case "PrevWindow":
+		return nil, sess.CycleDaemonFocus(-1)
+
+	case "FocusWindow":
+		if len(args) < 1 {
+			return nil, fmt.Errorf("FocusWindow requires a window name or ID")
+		}
+		return nil, sess.FocusDaemonWindow(args[0])
+
+	case "RenameWindow":
+		switch len(args) {
+		case 1:
+			id, err := focusedWindowID(sess.GetState())
+			if err != nil {
+				return nil, err
+			}
+			return nil, sess.RenameDaemonWindow(id, args[0])
+		case 2:
+			return nil, sess.RenameDaemonWindow(args[0], args[1])
+		default:
+			return nil, fmt.Errorf("RenameWindow requires <new-name> or <target> <new-name>")
+		}
+
+	case "MinimizeWindow", "RestoreWindow":
+		minimize := commandType == "MinimizeWindow"
+		target := ""
+		if len(args) > 0 {
+			target = args[0]
+		} else {
+			id, err := focusedWindowID(sess.GetState())
+			if err != nil {
+				return nil, err
+			}
+			target = id
+		}
+		return nil, sess.SetDaemonWindowMinimized(target, minimize)
+
+	case "SwitchWorkspace":
+		ws, err := parseWorkspaceArg(args)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sess.SwitchDaemonWorkspace(ws)
+
+	case "MoveToWorkspace", "MoveAndFollowWorkspace":
+		ws, err := parseWorkspaceArg(args)
+		if err != nil {
+			return nil, err
+		}
+		id, err := focusedWindowID(sess.GetState())
+		if err != nil {
+			return nil, err
+		}
+		if err := sess.MoveDaemonWindowToWorkspace(id, ws); err != nil {
+			return nil, err
+		}
+		if commandType == "MoveAndFollowWorkspace" {
+			return nil, sess.SwitchDaemonWorkspace(ws)
+		}
+		return nil, nil
+
+	// Read-only verbs answerable from state without a client.
+	case "ListWindows":
+		return buildWindowListData(sess.GetState()), nil
+	case "GetSessionInfo":
+		return buildSessionInfoData(sess, sess.GetState(), false), nil
+	case "GetWindow":
+		state := sess.GetState()
+		target := ""
+		if len(args) > 0 {
+			target = args[0]
+		} else {
+			id, err := focusedWindowID(state)
+			if err != nil {
+				return nil, err
+			}
+			target = id
+		}
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return nil, err
+		}
+		return windowStateToData(state, idx), nil
+
+	default:
+		return nil, errNeedsClient{verb: commandType}
+	}
+}
+
+// parseWorkspaceArg extracts a 1-9 workspace number from a command's args.
+func parseWorkspaceArg(args []string) (int, error) {
+	if len(args) < 1 {
+		return 0, fmt.Errorf("workspace number required")
+	}
+	ws, err := strconv.Atoi(strings.TrimSpace(args[0]))
+	if err != nil {
+		return 0, fmt.Errorf("invalid workspace number %q", args[0])
+	}
+	return ws, nil
+}
+
+// keysToBytes translates a send-keys request into the raw bytes to write to a
+// PTY. literal or raw modes pass the text through unchanged. Otherwise the input
+// is split on spaces/commas and each token is mapped to its terminal byte
+// sequence (named keys, ctrl+X, alt+X, or a literal character). WM-level tokens
+// (the prefix) have no headless meaning and produce an error.
+func keysToBytes(keys string, literal, raw bool) ([]byte, error) {
+	if literal || raw {
+		return []byte(keys), nil
+	}
+
+	normalized := strings.ReplaceAll(keys, ",", " ")
+	tokens := strings.Fields(normalized)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no valid keys in sequence: %s", keys)
+	}
+
+	var out []byte
+	for _, tok := range tokens {
+		b, err := keyTokenToBytes(tok)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, b...)
+	}
+	return out, nil
+}
+
+// namedKeyBytes maps a special key name (case-insensitive) to its byte sequence.
+var namedKeyBytes = map[string]string{
+	"enter":     "\r",
+	"return":    "\r",
+	"space":     " ",
+	"tab":       "\t",
+	"escape":    "\x1b",
+	"esc":       "\x1b",
+	"backspace": "\x7f",
+	"delete":    "\x1b[3~",
+	"del":       "\x1b[3~",
+	"up":        "\x1b[A",
+	"down":      "\x1b[B",
+	"right":     "\x1b[C",
+	"left":      "\x1b[D",
+	"home":      "\x1b[H",
+	"end":       "\x1b[F",
+	"pageup":    "\x1b[5~",
+	"pagedown":  "\x1b[6~",
+	"insert":    "\x1b[2~",
+	"f1":        "\x1bOP",
+	"f2":        "\x1bOQ",
+	"f3":        "\x1bOR",
+	"f4":        "\x1bOS",
+	"f5":        "\x1b[15~",
+	"f6":        "\x1b[17~",
+	"f7":        "\x1b[18~",
+	"f8":        "\x1b[19~",
+	"f9":        "\x1b[20~",
+	"f10":       "\x1b[21~",
+	"f11":       "\x1b[23~",
+	"f12":       "\x1b[24~",
+}
+
+// keyTokenToBytes converts one send-keys token to its terminal byte sequence.
+func keyTokenToBytes(tok string) ([]byte, error) {
+	lower := strings.ToLower(tok)
+
+	if tok == "PREFIX" || tok == "$PREFIX" {
+		return nil, fmt.Errorf("the prefix key is a window-manager concept and has no meaning headless; attach a client")
+	}
+
+	if b, ok := namedKeyBytes[lower]; ok {
+		return []byte(b), nil
+	}
+
+	// ctrl+X: control byte for letters, and common punctuation.
+	if after, ok := strings.CutPrefix(lower, "ctrl+"); ok {
+		if len(after) == 1 {
+			c := after[0]
+			switch {
+			case c >= 'a' && c <= 'z':
+				return []byte{c & 0x1f}, nil
+			case c == ' ' || c == '@':
+				return []byte{0x00}, nil
+			case c == '[':
+				return []byte{0x1b}, nil
+			case c == '\\':
+				return []byte{0x1c}, nil
+			case c == ']':
+				return []byte{0x1d}, nil
+			}
+		}
+		return nil, fmt.Errorf("unsupported ctrl combination %q", tok)
+	}
+
+	// alt+X: ESC followed by the key/character.
+	if after, ok := strings.CutPrefix(lower, "alt+"); ok {
+		if b, ok := namedKeyBytes[after]; ok {
+			return append([]byte{0x1b}, []byte(b)...), nil
+		}
+		if len(after) >= 1 {
+			return append([]byte{0x1b}, []byte(after)...), nil
+		}
+		return nil, fmt.Errorf("unsupported alt combination %q", tok)
+	}
+
+	// Any other single-token string is sent as literal characters.
+	return []byte(tok), nil
+}
+
+// resolvePTYForTarget resolves a window target (name/ID, or empty for the
+// focused window) to its live PTY within the session.
+func (d *Daemon) resolvePTYForTarget(sess *Session, target string) (*PTY, error) {
+	state := sess.GetState()
+	if target == "" {
+		id, err := focusedWindowID(state)
+		if err != nil {
+			return nil, err
+		}
+		target = id
+	}
+	idx, err := findWindowStateIndex(state.Windows, target)
+	if err != nil {
+		return nil, err
+	}
+	ptyID := state.Windows[idx].PTYID
+	if ptyID == "" {
+		return nil, fmt.Errorf("window %q has no PTY", target)
+	}
+	pty := sess.GetPTY(ptyID)
+	if pty == nil {
+		return nil, fmt.Errorf("PTY for window %q is gone", target)
+	}
+	return pty, nil
+}
+
+// sendKeysDaemonSide writes a send-keys request straight to the target window's
+// PTY, with no TUI client involved.
+func (d *Daemon) sendKeysDaemonSide(sess *Session, payload *SendKeysPayload) error {
+	pty, err := d.resolvePTYForTarget(sess, payload.WindowTarget)
+	if err != nil {
+		return err
+	}
+	data, err := keysToBytes(payload.Keys, payload.Literal, payload.Raw)
+	if err != nil {
+		return err
+	}
+	_, err = pty.Write(data)
+	return err
+}
+
+// capturePaneDaemonSide renders the target pane from the daemon-side VT
+// emulator, with no TUI client involved.
+func (d *Daemon) capturePaneDaemonSide(sess *Session, payload *CapturePanePayload) (string, error) {
+	pty, err := d.resolvePTYForTarget(sess, payload.WindowTarget)
+	if err != nil {
+		return "", err
+	}
+	return pty.CaptureContent(payload.Scrollback, payload.ANSI), nil
+}
+
+// buildWindowListData builds the window-list result map from session state. It
+// is shared by handleQueryWindows and the headless ListWindows verb.
+func buildWindowListData(state *SessionState) map[string]any {
+	windows := make([]map[string]any, 0, len(state.Windows))
+	for i := range state.Windows {
+		windows = append(windows, windowStateToData(state, i))
+	}
+
+	workspaceWindows := make([]int, maxDaemonWorkspaces)
+	for i := range state.Windows {
+		ws := state.Windows[i].Workspace
+		if ws >= 1 && ws <= maxDaemonWorkspaces {
+			workspaceWindows[ws-1]++
+		}
+	}
+
+	focusedIndex := -1
+	for i := range state.Windows {
+		if state.Windows[i].ID == state.FocusedWindowID {
+			focusedIndex = i
+			break
+		}
+	}
+
+	return map[string]any{
+		"windows":           windows,
+		"total":             len(state.Windows),
+		"focused_index":     focusedIndex,
+		"focused_window_id": state.FocusedWindowID,
+		"current_workspace": state.CurrentWorkspace,
+		"workspace_windows": workspaceWindows,
+	}
+}
+
+// windowStateToData renders one window (by index) to a result map.
+func windowStateToData(state *SessionState, idx int) map[string]any {
+	w := state.Windows[idx]
+	displayName := w.Title
+	if w.CustomName != "" {
+		displayName = w.CustomName
+	}
+	info := map[string]any{
+		"window_id":    w.ID,
+		"index":        idx,
+		"title":        w.Title,
+		"display_name": displayName,
+		"workspace":    w.Workspace,
+		"minimized":    w.Minimized,
+		"focused":      w.ID == state.FocusedWindowID,
+		"x":            w.X,
+		"y":            w.Y,
+		"width":        w.Width,
+		"height":       w.Height,
+		"pty_id":       w.PTYID,
+	}
+	if w.CustomName != "" {
+		info["custom_name"] = w.CustomName
+	}
+	return info
+}
+
+// buildSessionInfoData builds the session-info result map from session state.
+// It is shared by handleQuerySession and the headless GetSessionInfo verb.
+func buildSessionInfoData(sess *Session, state *SessionState, hasClient bool) map[string]any {
+	tilingMode := "floating"
+	if state.AutoTiling {
+		tilingMode = "tiling"
+	}
+	return map[string]any{
+		"session_name":      state.Name,
+		"session_id":        sess.ID,
+		"mode":              "unknown",
+		"current_workspace": state.CurrentWorkspace,
+		"num_workspaces":    maxDaemonWorkspaces,
+		"window_count":      len(state.Windows),
+		"tiling_mode":       tilingMode,
+		"master_ratio":      state.MasterRatio,
+		"width":             state.Width,
+		"height":            state.Height,
+		"tui_attached":      hasClient,
+	}
+}

--- a/internal/session/daemon_native_test.go
+++ b/internal/session/daemon_native_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKeysToBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		keys    string
+		literal bool
+		raw     bool
+		want    []byte
+		wantErr bool
+	}{
+		{name: "literal text", keys: "echo hi", literal: true, want: []byte("echo hi")},
+		{name: "raw text", keys: "a b", raw: true, want: []byte("a b")},
+		{name: "enter", keys: "Enter", want: []byte("\r")},
+		{name: "named sequence", keys: "h i Enter", want: []byte("hi\r")},
+		{name: "comma separated", keys: "Escape,Tab", want: []byte("\x1b\t")},
+		{name: "ctrl-c", keys: "ctrl+c", want: []byte{0x03}},
+		{name: "ctrl-a", keys: "ctrl+a", want: []byte{0x01}},
+		{name: "alt-x", keys: "alt+x", want: []byte{0x1b, 'x'}},
+		{name: "arrow up", keys: "Up", want: []byte("\x1b[A")},
+		{name: "prefix rejected", keys: "PREFIX", wantErr: true},
+		{name: "bad ctrl", keys: "ctrl+shift", wantErr: true},
+		{name: "empty", keys: "   ", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := keysToBytes(tc.keys, tc.literal, tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("keysToBytes(%q) = %v, want %v", tc.keys, got, tc.want)
+			}
+		})
+	}
+}
+
+// newTestDaemonSession builds a daemon with one detached (no-client) session.
+func newTestDaemonSession(t *testing.T) (*Daemon, *Session) {
+	t.Helper()
+	d := NewDaemon(&DaemonConfig{})
+	sess, err := d.manager.CreateSession("headless", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	t.Cleanup(d.manager.Shutdown)
+	return d, sess
+}
+
+func TestExecuteDaemonCommandLifecycle(t *testing.T) {
+	d, sess := newTestDaemonSession(t)
+	noExit := func(string) {}
+
+	// NewWindow returns an ID and spawns a live PTY.
+	data, err := d.executeDaemonCommand(sess, "NewWindow", []string{"build"}, noExit)
+	if err != nil {
+		t.Fatalf("NewWindow failed: %v", err)
+	}
+	winID, _ := data["window_id"].(string)
+	if winID == "" {
+		t.Fatal("NewWindow returned no window_id")
+	}
+	if name, _ := data["name"].(string); name != "build" {
+		t.Errorf("NewWindow name = %q, want build", name)
+	}
+
+	// A second window, then Next/Prev focus cycling.
+	if _, err := d.executeDaemonCommand(sess, "NewWindow", nil, noExit); err != nil {
+		t.Fatalf("second NewWindow failed: %v", err)
+	}
+	if len(sess.GetState().Windows) != 2 {
+		t.Fatalf("window count = %d, want 2", len(sess.GetState().Windows))
+	}
+	if _, err := d.executeDaemonCommand(sess, "PrevWindow", nil, noExit); err != nil {
+		t.Fatalf("PrevWindow failed: %v", err)
+	}
+	if sess.GetState().FocusedWindowID != winID {
+		t.Errorf("focus after PrevWindow = %q, want %q", sess.GetState().FocusedWindowID, winID)
+	}
+
+	// ListWindows read verb works headless.
+	list, err := d.executeDaemonCommand(sess, "ListWindows", nil, noExit)
+	if err != nil {
+		t.Fatalf("ListWindows failed: %v", err)
+	}
+	if total, _ := list["total"].(int); total != 2 {
+		t.Errorf("ListWindows total = %v, want 2", list["total"])
+	}
+
+	// CloseWindow by name removes it.
+	if _, err := d.executeDaemonCommand(sess, "CloseWindow", []string{"build"}, noExit); err != nil {
+		t.Fatalf("CloseWindow failed: %v", err)
+	}
+	if len(sess.GetState().Windows) != 1 {
+		t.Errorf("window count after close = %d, want 1", len(sess.GetState().Windows))
+	}
+
+	// A rendering-dependent verb is refused headless.
+	if _, err := d.executeDaemonCommand(sess, "Split", []string{"horizontal"}, noExit); err == nil {
+		t.Error("expected Split to be refused headless")
+	}
+}
+
+func TestSendKeysAndCaptureDaemonSide(t *testing.T) {
+	d, sess := newTestDaemonSession(t)
+
+	if _, err := sess.AddDaemonWindow("shell", nil); err != nil {
+		t.Fatalf("AddDaemonWindow failed: %v", err)
+	}
+
+	// Type a command with a distinctive marker into the focused pane's PTY.
+	const marker = "tuios-headless-marker"
+	err := d.sendKeysDaemonSide(sess, &SendKeysPayload{
+		Keys:    "echo " + marker + "\n",
+		Literal: true,
+	})
+	if err != nil {
+		t.Fatalf("sendKeysDaemonSide failed: %v", err)
+	}
+
+	// Poll the daemon-side capture until the marker's echoed output appears.
+	deadline := time.Now().Add(5 * time.Second)
+	var content string
+	for time.Now().Before(deadline) {
+		content, err = d.capturePaneDaemonSide(sess, &CapturePanePayload{})
+		if err != nil {
+			t.Fatalf("capturePaneDaemonSide failed: %v", err)
+		}
+		if strings.Contains(content, marker) {
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("capture never showed marker %q; last content:\n%s", marker, content)
+}
+
+func TestSendKeysDaemonSideNoWindows(t *testing.T) {
+	d, sess := newTestDaemonSession(t)
+	err := d.sendKeysDaemonSide(sess, &SendKeysPayload{Keys: "Enter"})
+	if err == nil {
+		t.Error("expected error sending keys to a session with no windows")
+	}
+}

--- a/internal/session/daemon_new_test.go
+++ b/internal/session/daemon_new_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// runHandleNew drives handleNew over a pipe, draining the SessionList response
+// the handler writes so the send does not block.
+func runHandleNew(t *testing.T, d *Daemon, payload *NewPayload) error {
+	t.Helper()
+	server, clientConn := net.Pipe()
+	cs := &connState{
+		conn:             clientConn,
+		clientID:         "test-client",
+		done:             make(chan struct{}),
+		codec:            DefaultCodec(),
+		ptySubscriptions: make(map[string]struct{}),
+	}
+
+	// Drain whatever the handler sends back.
+	go func() {
+		_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, _, _ = ReadMessageWithCodec(server)
+		_ = server.Close()
+	}()
+
+	msg, err := NewMessageWithCodec(MsgNew, payload, cs.codec)
+	if err != nil {
+		t.Fatalf("NewMessageWithCodec failed: %v", err)
+	}
+	err = d.handleNew(cs, msg)
+	_ = clientConn.Close()
+	return err
+}
+
+// TestHandleNewDetachSpawnsWindow verifies a detached session is created with an
+// initial live window, so it is usable headless right away.
+func TestHandleNewDetachSpawnsWindow(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{})
+	defer d.manager.Shutdown()
+
+	if err := runHandleNew(t, d, &NewPayload{SessionName: "detached", Width: 80, Height: 24, Detach: true}); err != nil {
+		t.Fatalf("handleNew(detach) failed: %v", err)
+	}
+
+	sess := d.manager.GetSession("detached")
+	if sess == nil {
+		t.Fatal("detached session was not created")
+	}
+	state := sess.GetState()
+	if len(state.Windows) != 1 {
+		t.Fatalf("detached session window count = %d, want 1", len(state.Windows))
+	}
+	if state.FocusedWindowID == "" {
+		t.Error("detached session has no focused window")
+	}
+	if pty := sess.GetPTY(state.Windows[0].PTYID); pty == nil {
+		t.Error("detached session's initial window has no live PTY")
+	}
+}
+
+// TestHandleNewWithoutDetachIsEmpty verifies the historical behavior is
+// unchanged: a plain 'new' creates an empty session the TUI later populates.
+func TestHandleNewWithoutDetachIsEmpty(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{})
+	defer d.manager.Shutdown()
+
+	if err := runHandleNew(t, d, &NewPayload{SessionName: "plain", Width: 80, Height: 24}); err != nil {
+		t.Fatalf("handleNew failed: %v", err)
+	}
+
+	sess := d.manager.GetSession("plain")
+	if sess == nil {
+		t.Fatal("session was not created")
+	}
+	if len(sess.GetState().Windows) != 0 {
+		t.Errorf("plain session window count = %d, want 0", len(sess.GetState().Windows))
+	}
+}

--- a/internal/session/daemon_resurrect_test.go
+++ b/internal/session/daemon_resurrect_test.go
@@ -13,8 +13,7 @@ import (
 // window's saved cwd, clearly marked as restored.
 func TestDaemonRestartRestoresWindows(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	cwd1 := t.TempDir()
 	cwd2 := t.TempDir()
@@ -93,8 +92,7 @@ func TestDaemonRestartRestoresWindows(t *testing.T) {
 // session that is already live.
 func TestDaemonRestoreSkipsLiveSession(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	d := NewDaemon(&DaemonConfig{})
 	defer d.manager.Shutdown()
@@ -154,8 +152,7 @@ func TestResurrectionStateCapturesCwd(t *testing.T) {
 // state so the session is not resurrectable afterwards.
 func TestKillRemovesResurrectionState(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	mgr := NewManager()
 	if _, err := mgr.CreateSession("doomed", &SessionConfig{}, 80, 24); err != nil {

--- a/internal/session/daemon_shutdown_test.go
+++ b/internal/session/daemon_shutdown_test.go
@@ -1,0 +1,125 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// startShutdownTestDaemon starts a daemon like startTestDaemon but hands back
+// the resurrection directory too, so a test can watch what has been written at
+// the moment shutdown reports itself complete. It deliberately does not register
+// a Stop cleanup, because these tests drive shutdown themselves.
+func startShutdownTestDaemon(t *testing.T) (*Daemon, string, string) {
+	t.Helper()
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	stateDir := t.TempDir()
+	t.Cleanup(useResurrectionDir(stateDir))
+
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	if err := d.Start(); err != nil {
+		t.Fatalf("daemon Start: %v", err)
+	}
+	t.Cleanup(d.Stop)
+
+	sp, err := GetSocketPath()
+	if err != nil {
+		t.Fatalf("GetSocketPath: %v", err)
+	}
+	return d, sp, stateDir
+}
+
+// TestSocketRemovalMeansStateIsPersisted pins the ordering contract that
+// WaitForDaemonShutdown depends on: by the time the socket is gone, every
+// session's final resurrection state is on disk.
+//
+// This is what makes 'tuios kill-server' followed by a fresh start safe. If the
+// unlink were ordered before the saves, the socket could vanish while a session
+// was still being written, and the next daemon would restore a truncated or
+// missing file.
+func TestSocketRemovalMeansStateIsPersisted(t *testing.T) {
+	d, socketPath, stateDir := startShutdownTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	statePath := filepath.Join(stateDir, "work.json")
+	// Remove any state the periodic saver may already have written, so the file
+	// observed below can only have come from the shutdown path.
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("clearing pre-shutdown state: %v", err)
+	}
+
+	go d.Stop()
+
+	if err := WaitForDaemonShutdown(10 * time.Second); err != nil {
+		t.Fatalf("WaitForDaemonShutdown: %v", err)
+	}
+
+	// Check immediately, with no polling: the wait is only meaningful if the
+	// state is already durable the instant it returns.
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("socket was removed before the session's state was saved: %v", err)
+	}
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Errorf("wait returned but the socket is still present: %v", err)
+	}
+}
+
+// TestWaitForDaemonShutdownReturnsWhenSocketGoes covers the ordinary case: the
+// wait blocks while the daemon is up and returns once it has finished.
+func TestWaitForDaemonShutdownReturnsWhenSocketGoes(t *testing.T) {
+	d, _, _ := startShutdownTestDaemon(t)
+
+	// While the daemon is up the wait must not report success, or kill-server
+	// would return before anything had happened.
+	if err := WaitForDaemonShutdown(100 * time.Millisecond); !errors.Is(err, ErrShutdownTimeout) {
+		t.Fatalf("wait on a live daemon = %v, want ErrShutdownTimeout", err)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		d.Stop()
+	}()
+
+	start := time.Now()
+	if err := WaitForDaemonShutdown(10 * time.Second); err != nil {
+		t.Fatalf("WaitForDaemonShutdown: %v", err)
+	}
+	// It must have actually waited rather than returned on a stale observation.
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Errorf("wait returned after %v, before the daemon could have stopped", elapsed)
+	}
+}
+
+// TestWaitForDaemonShutdownTimesOut checks the bounded-wait behaviour when a
+// daemon never finishes: the caller gets a typed timeout rather than hanging or
+// being told the daemon stopped.
+func TestWaitForDaemonShutdownTimesOut(t *testing.T) {
+	startShutdownTestDaemon(t)
+
+	start := time.Now()
+	err := WaitForDaemonShutdown(200 * time.Millisecond)
+	if !errors.Is(err, ErrShutdownTimeout) {
+		t.Fatalf("err = %v, want ErrShutdownTimeout", err)
+	}
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Errorf("returned after %v, before the %v timeout elapsed", elapsed, 200*time.Millisecond)
+	}
+}
+
+// TestWaitForDaemonShutdownReturnsImmediatelyWhenAbsent covers kill-server being
+// run when no daemon is there: the signal is already in its final state, so the
+// wait must not burn the full timeout.
+func TestWaitForDaemonShutdownReturnsImmediatelyWhenAbsent(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	start := time.Now()
+	if err := WaitForDaemonShutdown(5 * time.Second); err != nil {
+		t.Fatalf("WaitForDaemonShutdown with no daemon: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %v with no daemon present, should return at once", elapsed)
+	}
+}

--- a/internal/session/main_test.go
+++ b/internal/session/main_test.go
@@ -1,0 +1,38 @@
+package session
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain redirects resurrection state for the whole test binary.
+//
+// The resurrection state directory is derived from xdg.StateHome, which is
+// resolved at package init, so a per-test t.Setenv cannot redirect it. Without
+// this, every test that creates a session persists a real state file into the
+// developer's ~/.local/state/tuios/sessions, which both pollutes their state
+// directory and leaves phantom sessions for the next real daemon start to
+// resurrect. Tests that need to inspect state files still set
+// resurrectionDirOverride themselves; this only provides a safe default.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "tuios-session-test-state")
+	if err != nil {
+		panic(err)
+	}
+	resurrectionDirOverride = tmp
+
+	code := m.Run()
+
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+// useResurrectionDir points resurrection state at dir and returns a function
+// that restores the previous value. Restoring the previous value rather than
+// clearing it keeps the TestMain default in place, so a later test cannot fall
+// back to the developer's real state directory.
+func useResurrectionDir(dir string) func() {
+	prev := resurrectionDirOverride
+	resurrectionDirOverride = dir
+	return func() { resurrectionDirOverride = prev }
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -15,6 +15,22 @@ type Manager struct {
 
 	// Configuration
 	socketPath string // Path to socket
+
+	// Lifecycle hooks (set by the daemon). onCreate fires after a session is
+	// registered; onDelete fires after it is removed but before it is stopped.
+	// Both run outside m.mu so a hook may safely call back into the manager.
+	onCreate func(*Session)
+	onDelete func(*Session)
+}
+
+// SetSessionHooks installs lifecycle callbacks invoked when a session is created
+// or deleted. The daemon uses these to install each session's event sink and to
+// publish session lifecycle events.
+func (m *Manager) SetSessionHooks(onCreate, onDelete func(*Session)) {
+	m.mu.Lock()
+	m.onCreate = onCreate
+	m.onDelete = onDelete
+	m.mu.Unlock()
 }
 
 // NewManager creates a new session manager.
@@ -46,11 +62,11 @@ func (m *Manager) SocketPath() string {
 // CreateSession creates a new session with the given name.
 func (m *Manager) CreateSession(name string, cfg *SessionConfig, width, height int) (*Session, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	// Check if name already exists
 	if name != "" {
 		if _, exists := m.sessions[name]; exists {
+			m.mu.Unlock()
 			return nil, fmt.Errorf("session '%s' already exists", name)
 		}
 	}
@@ -58,6 +74,7 @@ func (m *Manager) CreateSession(name string, cfg *SessionConfig, width, height i
 	// Create the session
 	session, err := NewSession(name, cfg, width, height)
 	if err != nil {
+		m.mu.Unlock()
 		return nil, err
 	}
 
@@ -67,7 +84,14 @@ func (m *Manager) CreateSession(name string, cfg *SessionConfig, width, height i
 	// Register the session
 	m.sessions[name] = session
 	m.byID[session.ID] = session
+	onCreate := m.onCreate
+	m.mu.Unlock()
 
+	// Fire the create hook outside the lock so it may install the event sink and
+	// publish a session-created event without risking a manager re-entry deadlock.
+	if onCreate != nil {
+		onCreate(session)
+	}
 	return session, nil
 }
 
@@ -115,7 +139,13 @@ func (m *Manager) DeleteSession(name string) error {
 	}
 	delete(m.sessions, name)
 	delete(m.byID, session.ID)
+	onDelete := m.onDelete
 	m.mu.Unlock()
+
+	// Fire the delete hook outside the lock (publishes a session-closed event).
+	if onDelete != nil {
+		onDelete(session)
+	}
 
 	// Stop the session (outside lock to avoid deadlock). Stop performs a final
 	// resurrection save, so remove the state file afterwards: an explicit kill

--- a/internal/session/protocol.go
+++ b/internal/session/protocol.go
@@ -136,6 +136,12 @@ type NewPayload struct {
 	SessionName string `json:"session_name,omitempty"` // Desired session name (auto-generated if empty)
 	Width       int    `json:"width"`                  // Initial terminal width
 	Height      int    `json:"height"`                 // Initial terminal height
+	// Detach requests a headless session: the daemon spawns an initial window
+	// with no client attached, so the session is immediately usable by control
+	// verbs. Additive and backward compatible; older daemons ignore it and
+	// simply create an empty session. Zero value keeps the pre-existing
+	// "create an empty session" behavior.
+	Detach bool `json:"detach,omitempty"`
 }
 
 // SessionInfo describes a single session for listing.

--- a/internal/session/protocol.go
+++ b/internal/session/protocol.go
@@ -171,6 +171,15 @@ type ResurrectPayload struct {
 	SessionName string `json:"session_name"` // Session to resurrect from saved state
 }
 
+// SessionEndedPayload tells an attached client that its session was terminated.
+// It is sent on MsgSessionEnded, a message type that has existed since the first
+// protocol version but had no payload defined, so both fields are optional and
+// an older client that ignores the message is unaffected.
+type SessionEndedPayload struct {
+	SessionName string `json:"session_name,omitempty"` // Session that ended
+	Reason      string `json:"reason,omitempty"`       // Short human explanation
+}
+
 // ResizePayload notifies of terminal resize.
 type ResizePayload struct {
 	Width  int `json:"width"`

--- a/internal/session/protocol.go
+++ b/internal/session/protocol.go
@@ -525,6 +525,32 @@ func ReadMessageConn(conn net.Conn, boundaryTimeout, bodyTimeout time.Duration) 
 	return readMessageBody(conn, totalLen)
 }
 
+// ReadMessageBuffered reads a framed binary message the same way as
+// ReadMessageConn, but reads the bytes from r (typically a *bufio.Reader
+// wrapping conn) while still applying the split boundary/body deadlines to conn.
+// The daemon wraps each accepted connection in a bufio.Reader to peek the first
+// byte for JSON-versus-binary detection, so the binary read loop must continue
+// through that same buffered reader rather than reading conn directly.
+func ReadMessageBuffered(conn net.Conn, r io.Reader, boundaryTimeout, bodyTimeout time.Duration) (*Message, CodecType, error) {
+	_ = conn.SetReadDeadline(time.Now().Add(boundaryTimeout))
+
+	var totalLen uint32
+	if err := binary.Read(r, binary.BigEndian, &totalLen); err != nil {
+		if err == io.EOF {
+			return nil, CodecGob, err
+		}
+		return nil, CodecGob, fmt.Errorf("failed to read message length: %w", err)
+	}
+
+	if bodyTimeout > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(bodyTimeout))
+	} else {
+		_ = conn.SetReadDeadline(time.Time{})
+	}
+
+	return readMessageBody(r, totalLen)
+}
+
 // readMessageBody reads the header and payload after the length prefix has
 // already been consumed from r.
 func readMessageBody(r io.Reader, totalLen uint32) (*Message, CodecType, error) {

--- a/internal/session/resurrection.go
+++ b/internal/session/resurrection.go
@@ -41,27 +41,48 @@ func getResurrectionPath(sessionName string) string {
 	return filepath.Join(getResurrectionDir(), sessionName+".json")
 }
 
-// getResurrectionArchiveDir returns the directory where corrupt or incompatible
-// state files are moved instead of being deleted, so they can be inspected.
-func getResurrectionArchiveDir() string {
+// ResurrectionStateDir returns the directory holding saved session state, so a
+// message can name where sessions are persisted.
+func ResurrectionStateDir() string {
+	return getResurrectionDir()
+}
+
+// ResurrectionArchiveDir returns the directory where corrupt or incompatible
+// state files are moved instead of being deleted, so they can be inspected. It
+// is exported so an error message can tell the user where their session went
+// rather than only that it is gone.
+func ResurrectionArchiveDir() string {
 	return filepath.Join(getResurrectionDir(), "archive")
 }
 
 // archiveResurrectionFile moves a bad state file into the archive directory,
-// tagging it with a timestamp. Best effort: on any failure the original file is
-// removed so it is not retried on every load. Never returns an error to callers
-// because the load must continue regardless.
-func archiveResurrectionFile(path string) {
-	archiveDir := getResurrectionArchiveDir()
+// tagging it with a timestamp, and returns where it landed. Best effort: on any
+// failure the original file is removed so it is not retried on every load, and
+// an empty path is returned. Never returns an error to callers because the load
+// must continue regardless.
+func archiveResurrectionFile(path string) string {
+	archiveDir := ResurrectionArchiveDir()
 	if err := os.MkdirAll(archiveDir, 0700); err != nil {
 		_ = os.Remove(path)
-		return
+		return ""
 	}
 	base := filepath.Base(path)
 	dest := filepath.Join(archiveDir, fmt.Sprintf("%s.%d.bak", base, time.Now().UnixNano()))
 	if err := os.Rename(path, dest); err != nil {
 		_ = os.Remove(path)
+		return ""
 	}
+	return dest
+}
+
+// archivedNote renders where an archived state file was moved to, for inclusion
+// in the error that reports it. It degrades to naming the archive directory when
+// the move itself failed.
+func archivedNote(dest string) string {
+	if dest == "" {
+		return "it could not be archived and was removed"
+	}
+	return "archived to " + dest
 }
 
 // SaveSessionForResurrection persists the session state to disk.
@@ -111,14 +132,15 @@ func LoadResurrectionState(sessionName string) (*SessionState, error) {
 
 	var state SessionState
 	if err := json.Unmarshal(data, &state); err != nil {
-		archiveResurrectionFile(path)
-		return nil, fmt.Errorf("corrupt resurrection data for session %q (archived): %w", sessionName, err)
+		dest := archiveResurrectionFile(path)
+		return nil, fmt.Errorf("saved state for session %q is corrupt and cannot be restored (%s): %w",
+			sessionName, archivedNote(dest), err)
 	}
 
 	if state.ResurrectionVersion > ResurrectionVersion {
-		archiveResurrectionFile(path)
-		return nil, fmt.Errorf("incompatible resurrection version %d for session %q (archived), this daemon supports up to %d",
-			state.ResurrectionVersion, sessionName, ResurrectionVersion)
+		dest := archiveResurrectionFile(path)
+		return nil, fmt.Errorf("saved state for session %q was written by a newer TUIOS (state version %d, this build reads up to %d) and cannot be restored (%s)",
+			sessionName, state.ResurrectionVersion, ResurrectionVersion, archivedNote(dest))
 	}
 
 	return &state, nil

--- a/internal/session/resurrection_test.go
+++ b/internal/session/resurrection_test.go
@@ -11,8 +11,7 @@ import (
 // BSP tree) and verifies every structural field survives a save/load cycle.
 func TestResurrectionRoundTripMultiWindowMultiWorkspace(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	original := &SessionState{
 		Name:             "multi",
@@ -106,8 +105,7 @@ func TestResurrectionRoundTripMultiWindowMultiWorkspace(t *testing.T) {
 // archived (not deleted, not fatal) and reported as an error.
 func TestLoadResurrectionCorruptFileArchived(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	path := filepath.Join(tmpDir, "broken.json")
 	if err := os.WriteFile(path, []byte("{ this is not valid json"), 0600); err != nil {
@@ -156,8 +154,7 @@ func TestLoadResurrectionCorruptFileArchived(t *testing.T) {
 // newer, incompatible schema is archived and refused.
 func TestLoadResurrectionIncompatibleVersionArchived(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	// Write a state file directly with a future version. Bypass Save (which
 	// would stamp the current version) by writing JSON by hand.
@@ -180,8 +177,7 @@ func TestLoadResurrectionIncompatibleVersionArchived(t *testing.T) {
 // the in-memory state has no version set (clients never set it).
 func TestSaveStampsCurrentVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	state := &SessionState{Name: "stamp"} // ResurrectionVersion left at 0
 	if err := SaveSessionForResurrection(state); err != nil {
@@ -202,8 +198,7 @@ func TestSaveStampsCurrentVersion(t *testing.T) {
 
 func TestSaveAndLoadResurrection(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	state := &SessionState{
 		Name:             "test-session",
@@ -248,8 +243,7 @@ func TestSaveAndLoadResurrection(t *testing.T) {
 
 func TestListResurrectableSessions(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	// Save two sessions
 	_ = SaveSessionForResurrection(&SessionState{Name: "session-a"})
@@ -266,8 +260,7 @@ func TestListResurrectableSessions(t *testing.T) {
 
 func TestRemoveResurrectionState(t *testing.T) {
 	tmpDir := t.TempDir()
-	resurrectionDirOverride = tmpDir
-	defer func() { resurrectionDirOverride = "" }()
+	defer useResurrectionDir(tmpDir)()
 
 	_ = SaveSessionForResurrection(&SessionState{Name: "to-remove"})
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -97,6 +97,12 @@ type SessionState struct {
 	// misinterpreted. Absent (0) means pre-versioning state, which is a
 	// structural subset of the current schema and loads fine.
 	ResurrectionVersion int `json:"resurrection_version,omitempty"`
+	// Options is a daemon-owned key/value store for session options set through
+	// the JSON verb protocol (set-option / get-option). It is additive: older
+	// clients and older on-disk state simply omit it. Keys are advisory names;
+	// the daemon records them verbatim so a later get-option can read them back
+	// and an attached TUI can apply the ones it understands.
+	Options map[string]string `json:"options,omitempty"`
 }
 
 // PTY represents a daemon-managed pseudo-terminal.
@@ -376,7 +382,43 @@ func (s *Session) GetState() *SessionState {
 		stateCopy.WorkspaceFocus = make(map[int]string)
 		maps.Copy(stateCopy.WorkspaceFocus, s.state.WorkspaceFocus)
 	}
+	if s.state.Options != nil {
+		stateCopy.Options = make(map[string]string, len(s.state.Options))
+		maps.Copy(stateCopy.Options, s.state.Options)
+	}
 	return &stateCopy
+}
+
+// SetOption records a daemon-owned session option under stateMu. It is the write
+// side of the JSON verb protocol's set-option and is safe for concurrent use.
+func (s *Session) SetOption(key, value string) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.state.Options == nil {
+		s.state.Options = make(map[string]string)
+	}
+	s.state.Options[key] = value
+}
+
+// GetOption reads a daemon-owned session option under stateMu, returning the
+// value and whether the key was set. It is the read side of get-option.
+func (s *Session) GetOption(key string) (string, bool) {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	if s.state.Options == nil {
+		return "", false
+	}
+	v, ok := s.state.Options[key]
+	return v, ok
+}
+
+// AllOptions returns a copy of every daemon-owned session option.
+func (s *Session) AllOptions() map[string]string {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	out := make(map[string]string, len(s.state.Options))
+	maps.Copy(out, s.state.Options)
+	return out
 }
 
 // ResurrectionState returns a copy of the session state enriched for on-disk
@@ -399,10 +441,15 @@ func (s *Session) ResurrectionState() *SessionState {
 	return state
 }
 
-// UpdateState updates the session state.
+// UpdateState updates the session state. Daemon-owned options (set through the
+// JSON verb protocol) are carried over when the incoming state does not include
+// them, so a TUI state sync - which never populates Options - does not wipe them.
 func (s *Session) UpdateState(state *SessionState) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
+	if state.Options == nil && s.state != nil {
+		state.Options = s.state.Options
+	}
 	s.state = state
 	s.LastActive = time.Now()
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -682,6 +683,47 @@ func (p *PTY) GetTerminalState() *TerminalState {
 	}
 
 	return state
+}
+
+// CaptureContent renders the PTY's current screen (and optionally its
+// scrollback) to text from the daemon-side VT emulator. When ansi is true the
+// output keeps SGR escape sequences; otherwise it is plain text. This lets
+// capture-pane answer from daemon state with no TUI client attached, mirroring
+// the client-side OS.capturePane rendering.
+func (p *PTY) CaptureContent(scrollback, ansi bool) string {
+	p.terminalMu.RLock()
+	defer p.terminalMu.RUnlock()
+
+	if p.terminal == nil {
+		return ""
+	}
+
+	var content string
+	if ansi {
+		content = p.terminal.Render()
+	} else {
+		content = p.terminal.String()
+	}
+
+	if scrollback {
+		scrollbackLen := p.terminal.ScrollbackLen()
+		if scrollbackLen > 0 {
+			var sb strings.Builder
+			for i := 0; i < scrollbackLen; i++ {
+				line := p.terminal.ScrollbackLine(i)
+				if ansi {
+					sb.WriteString(line.Render())
+				} else {
+					sb.WriteString(line.String())
+				}
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(content)
+			content = sb.String()
+		}
+	}
+
+	return content
 }
 
 // TerminalState represents the serializable state of a terminal.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -462,6 +463,20 @@ func (s *Session) GetOption(key string) (string, bool) {
 	}
 	v, ok := s.state.Options[key]
 	return v, ok
+}
+
+// OptionKeys returns every option key set on this session, sorted. It backs the
+// available-keys hint on a get-option miss, so a caller that guessed a key wrong
+// learns which keys exist without a second round trip.
+func (s *Session) OptionKeys() []string {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	keys := make([]string, 0, len(s.state.Options))
+	for k := range s.state.Options {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // AllOptions returns a copy of every daemon-owned session option.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -139,6 +139,11 @@ type PTY struct {
 
 	// Callback when PTY process exits - used by daemon to notify clients
 	onExit func(ptyID string)
+
+	// emit, when set, raises a control-plane event (output activity, bell, mode
+	// change, process exit) already tagged with this PTY's window and PTY ID. It
+	// is a no-op when the session has no event sink installed.
+	emit func(SessionEvent)
 }
 
 // Session represents a persistent TUIOS session.
@@ -156,6 +161,13 @@ type Session struct {
 	state            *SessionState
 	stopResurrection func() // Stops periodic resurrection saving
 	stateMu          sync.RWMutex
+
+	// eventSink, when set, receives control-plane events raised by this session
+	// and its PTYs (window lifecycle, output activity, bell, mode changes). The
+	// daemon installs it so events reach the event hub; nil for a session with no
+	// hub (e.g. bare unit tests).
+	eventSink   func(SessionEvent)
+	eventSinkMu sync.RWMutex
 
 	// Terminal size
 	width  int
@@ -212,6 +224,25 @@ func NewSession(name string, cfg *SessionConfig, width, height int) (*Session, e
 	})
 
 	return session, nil
+}
+
+// SetEventSink installs the control-plane event sink for this session. It is
+// safe to call concurrently and may be set after windows already exist; the
+// per-PTY emitters read it dynamically.
+func (s *Session) SetEventSink(fn func(SessionEvent)) {
+	s.eventSinkMu.Lock()
+	s.eventSink = fn
+	s.eventSinkMu.Unlock()
+}
+
+// emit forwards a control-plane event to the installed sink, if any.
+func (s *Session) emit(ev SessionEvent) {
+	s.eventSinkMu.RLock()
+	fn := s.eventSink
+	s.eventSinkMu.RUnlock()
+	if fn != nil {
+		fn(ev)
+	}
 }
 
 // CreatePTY creates a new PTY in this session. windowID, if non-empty, is the
@@ -298,6 +329,27 @@ func (s *Session) createPTY(windowID string, width, height int, cwd string, rest
 		vtWriteChan:  make(chan []byte, 256),
 		onExit:       onExit,
 	}
+
+	// Per-PTY control-plane event emitter, pre-tagged with this window and PTY
+	// ID. It routes through the session's event sink so events reach the daemon's
+	// event hub; when no sink is installed it is a cheap no-op.
+	pty.emit = func(ev SessionEvent) {
+		ev.Window = windowID
+		ev.PTYID = id
+		s.emit(ev)
+	}
+
+	// Raise control-plane events from the daemon-side VT emulator: bell, an
+	// app-driven title change, and alt-screen mode toggles. These fire from the
+	// single vtWriter goroutine; the emitter only does a non-blocking hub publish,
+	// so it never re-enters the terminal lock held during Write.
+	terminal.SetCallbacks(vt.Callbacks{
+		Bell:  func() { pty.emit(SessionEvent{Type: EventBell}) },
+		Title: func(title string) { pty.emit(SessionEvent{Type: EventWindowRetitled, Title: title}) },
+		AltScreen: func(on bool) {
+			pty.emit(SessionEvent{Type: EventModeChanged, Mode: "alt-screen", Enabled: on})
+		},
+	})
 
 	// Handle kitty graphics queries on the daemon side for low-latency
 	// responses. All other commands flow through the raw PTY broadcast.
@@ -965,6 +1017,14 @@ func (p *PTY) readOutput() {
 
 			// Broadcast to subscribers
 			p.broadcast(data)
+
+			// Raise a control-plane output-activity event. This is a lightweight
+			// signal (byte count only, no content) that drives wait-for-output and
+			// window-idle waits and lets a subscriber know the pane is active; the
+			// raw bytes still flow only through the binary subscriber stream.
+			if p.emit != nil {
+				p.emit(SessionEvent{Type: EventOutput, Bytes: n})
+			}
 		}
 	}
 }
@@ -1037,6 +1097,11 @@ func (p *PTY) monitorExit() {
 	// Notify callback (used by daemon to inform clients)
 	if p.onExit != nil {
 		p.onExit(p.ID)
+	}
+
+	// Raise a control-plane window-exit event so wait-for window-exit resolves.
+	if p.emit != nil {
+		p.emit(SessionEvent{Type: EventWindowExit})
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -496,14 +496,49 @@ func (s *Session) ResurrectionState() *SessionState {
 // UpdateState updates the session state. Daemon-owned options (set through the
 // JSON verb protocol) are carried over when the incoming state does not include
 // them, so a TUI state sync - which never populates Options - does not wipe them.
+//
+// This is where an attached TUI's mutations land, so it is also where the window
+// lifecycle events for those mutations are raised: the incoming state is diffed
+// against the state it replaces. See state_events.go.
 func (s *Session) UpdateState(state *SessionState) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 	if state.Options == nil && s.state != nil {
 		state.Options = s.state.Options
 	}
+	before := snapshotLifecycle(s.state)
 	s.state = state
 	s.LastActive = time.Now()
+	s.emitLifecycleLocked(before)
+}
+
+// mutateState runs fn against the canonical state under the state lock and
+// raises the window lifecycle events implied by whatever fn changed. Daemon-side
+// (headless) window operations go through it so they emit through the same diff
+// as a TUI state sync, rather than each op emitting for itself.
+func (s *Session) mutateState(fn func(state *SessionState) error) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	before := snapshotLifecycle(s.state)
+	if err := fn(s.state); err != nil {
+		return err
+	}
+	s.emitLifecycleLocked(before)
+	return nil
+}
+
+// emitLifecycleLocked diffs the current state against before and emits the
+// resulting events. It is called with the state lock held, deliberately: holding
+// it across the emit is what keeps a session's events in the same order as the
+// mutations that caused them when several callers mutate concurrently. It is
+// safe because the sink only stamps a sequence number and does non-blocking
+// channel sends; it never re-enters the session.
+func (s *Session) emitLifecycleLocked(before lifecycleSnapshot) {
+	events := diffLifecycle(before, snapshotLifecycle(s.state))
+	for _, ev := range events {
+		s.emit(ev)
+	}
 }
 
 // Stop closes all PTYs and cleans up.

--- a/internal/session/session_ended_test.go
+++ b/internal/session/session_ended_test.go
@@ -1,0 +1,201 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// This file covers the contract that makes 'tuios attach' exit when its session
+// is killed: the daemon must tell every attached client that the session is
+// gone, and the client must surface that exactly once.
+//
+// Before this existed, killing a session closed its PTYs and dropped it from the
+// manager but left every attached client connected to nothing, so the client sat
+// in a dead UI with no way to learn what had happened.
+
+// attachTestClient connects a TUIClient to the test daemon and attaches it to a
+// session, returning the client with its read loop running.
+func attachTestClient(t *testing.T, sessionName string) *TUIClient {
+	t.Helper()
+
+	c := NewTUIClient()
+	if err := c.Connect("test", 80, 24); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, err := c.AttachSession(sessionName, false, 80, 24); err != nil {
+		t.Fatalf("attach %s: %v", sessionName, err)
+	}
+	c.StartReadLoop()
+	return c
+}
+
+// TestKilledSessionNotifiesAttachedClient is the regression test for the
+// lingering client: killing a session must reach the attached client, naming the
+// session that ended.
+func TestKilledSessionNotifiesAttachedClient(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	client := attachTestClient(t, "work")
+
+	ended := make(chan string, 4)
+	client.OnSessionEnded(func(name, _ string) { ended <- name })
+
+	if err := d.manager.DeleteSession("work"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	select {
+	case name := <-ended:
+		if name != "work" {
+			t.Errorf("session ended for %q, want work", name)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the attached client was never told its session was killed; it would linger in a dead UI")
+	}
+}
+
+// TestSessionEndedFiresExactlyOnce guards against a client quitting twice or
+// reporting the wrong exit reason because the notification was duplicated.
+func TestSessionEndedFiresExactlyOnce(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	client := attachTestClient(t, "work")
+
+	ended := make(chan string, 8)
+	client.OnSessionEnded(func(name, _ string) { ended <- name })
+
+	if err := d.manager.DeleteSession("work"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	select {
+	case <-ended:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no session-ended notification")
+	}
+
+	// A second notification would mean the client saw the session die twice.
+	select {
+	case name := <-ended:
+		t.Fatalf("session-ended fired more than once (second: %q)", name)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// TestSessionEndedReachesEveryAttachedClient covers the multi-client case: a
+// killed session must not leave one of its clients behind.
+func TestSessionEndedReachesEveryAttachedClient(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	first := attachTestClient(t, "work")
+	second := attachTestClient(t, "work")
+
+	firstEnded := make(chan struct{}, 1)
+	secondEnded := make(chan struct{}, 1)
+	first.OnSessionEnded(func(string, string) { firstEnded <- struct{}{} })
+	second.OnSessionEnded(func(string, string) { secondEnded <- struct{}{} })
+
+	if err := d.manager.DeleteSession("work"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	for name, ch := range map[string]chan struct{}{"first": firstEnded, "second": secondEnded} {
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Errorf("the %s client was never told its session was killed", name)
+		}
+	}
+}
+
+// TestOtherSessionsAreUnaffected keeps the notification targeted: killing one
+// session must not evict clients attached to another.
+func TestOtherSessionsAreUnaffected(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+	makeSessionWithWindow(t, d, "notes")
+
+	survivor := attachTestClient(t, "notes")
+
+	ended := make(chan string, 1)
+	survivor.OnSessionEnded(func(name, _ string) { ended <- name })
+
+	if err := d.manager.DeleteSession("work"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	select {
+	case name := <-ended:
+		t.Fatalf("killing work evicted the client attached to notes (reported %q)", name)
+	case <-time.After(750 * time.Millisecond):
+	}
+}
+
+// TestKillSessionVerbNotifiesAttachedClient proves the notification is reached
+// through the control plane too, which is the path an agent or a script uses.
+func TestKillSessionVerbNotifiesAttachedClient(t *testing.T) {
+	d, socketPath := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	client := attachTestClient(t, "work")
+
+	ended := make(chan string, 1)
+	client.OnSessionEnded(func(name, _ string) { ended <- name })
+
+	c := dialVerb(t, socketPath)
+	resp := c.call(t, `{"id":1,"verb":"kill-session","params":{"session":"work"}}`)
+	result(t, resp)
+
+	select {
+	case name := <-ended:
+		if name != "work" {
+			t.Errorf("session ended for %q, want work", name)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("kill-session over the control plane did not notify the attached client")
+	}
+}
+
+// TestSessionEndedLeavesTheConnectionUsable checks the daemon does not slam the
+// connection shut along with the notification. The client needs a live socket to
+// finish its own shutdown; tearing it down here would turn a clean exit back
+// into the connection error this work replaced.
+func TestSessionEndedLeavesTheConnectionUsable(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+	makeSessionWithWindow(t, d, "notes")
+
+	client := attachTestClient(t, "work")
+
+	ended := make(chan struct{}, 1)
+	client.OnSessionEnded(func(string, string) { ended <- struct{}{} })
+
+	disconnected := make(chan error, 1)
+	client.OnDisconnect(func(err error) { disconnected <- err })
+
+	if err := d.manager.DeleteSession("work"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	select {
+	case <-ended:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no session-ended notification")
+	}
+
+	select {
+	case err := <-disconnected:
+		t.Fatalf("the daemon dropped the connection instead of leaving the client to exit cleanly: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// And it is still live enough to carry another request, which is what a
+	// client finishing its own shutdown relies on.
+	if _, err := client.SwitchSession("notes", 80, 24); err != nil {
+		t.Fatalf("the connection was unusable after session-ended: %v", err)
+	}
+}

--- a/internal/session/session_ops.go
+++ b/internal/session/session_ops.go
@@ -1,0 +1,300 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// maxDaemonWorkspaces bounds the workspace indices the daemon-side state
+// operations accept. It mirrors the TUI's workspace count (config.MaxWorkspaces)
+// but is duplicated here to keep the session package free of a config import.
+const maxDaemonWorkspaces = 9
+
+// These daemon-side operations mutate a session's canonical SessionState
+// directly, so mutating control verbs (create/close/focus/rename/move a window,
+// switch workspace, minimize/restore) work with no TUI client attached. When a
+// TUI client is attached the daemon keeps routing those verbs to it unchanged;
+// these methods are the headless path. The TUI, on its next attach, rebuilds
+// from this same state (the resurrection restore path), so a window created
+// headless shows up when a client later connects.
+
+// findWindowStateIndex resolves a window target string to an index into
+// state.Windows. It matches, in order: an exact window ID, a unique window ID
+// prefix, an exact CustomName, then an exact Title. It returns -1 when there is
+// no match, and an error when a prefix or name is ambiguous.
+func findWindowStateIndex(windows []WindowState, target string) (int, error) {
+	if target == "" {
+		return -1, fmt.Errorf("empty window target")
+	}
+
+	// Exact ID.
+	for i := range windows {
+		if windows[i].ID == target {
+			return i, nil
+		}
+	}
+
+	// Unique ID prefix.
+	prefixIdx, prefixCount := -1, 0
+	for i := range windows {
+		if strings.HasPrefix(windows[i].ID, target) {
+			prefixIdx = i
+			prefixCount++
+		}
+	}
+	if prefixCount == 1 {
+		return prefixIdx, nil
+	}
+	if prefixCount > 1 {
+		return -1, fmt.Errorf("ambiguous window ID prefix %q matches %d windows", target, prefixCount)
+	}
+
+	// Exact CustomName, then Title.
+	nameIdx, nameCount := -1, 0
+	for i := range windows {
+		if windows[i].CustomName == target || windows[i].Title == target {
+			nameIdx = i
+			nameCount++
+		}
+	}
+	if nameCount == 1 {
+		return nameIdx, nil
+	}
+	if nameCount > 1 {
+		return -1, fmt.Errorf("ambiguous window name %q matches %d windows", target, nameCount)
+	}
+
+	return -1, fmt.Errorf("no window found matching %q", target)
+}
+
+// AddDaemonWindow spawns a fresh PTY and appends a canonical window for it to
+// the session state, focusing it on the current workspace. onExit (may be nil)
+// is invoked with the PTY ID when the shell process exits. It returns a copy of
+// the created window state. This is the headless equivalent of the TUI creating
+// a new window; geometry is a nominal full-size box that a client re-tiles on
+// attach.
+func (s *Session) AddDaemonWindow(title string, onExit func(ptyID string)) (WindowState, error) {
+	width, height := s.Size()
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = 24
+	}
+
+	// WindowState dimensions are the outer window box (including the border);
+	// the shell gets the inner content size, matching restoreSession.
+	ptyWidth := max(width-2, 1)
+	ptyHeight := max(height-2, 1)
+
+	windowID := uuid.New().String()
+	pty, err := s.CreatePTY(windowID, ptyWidth, ptyHeight, onExit)
+	if err != nil {
+		return WindowState{}, err
+	}
+
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	if s.state.WorkspaceFocus == nil {
+		s.state.WorkspaceFocus = make(map[int]string)
+	}
+	workspace := s.state.CurrentWorkspace
+	if workspace < 1 {
+		workspace = 1
+		s.state.CurrentWorkspace = 1
+	}
+
+	win := WindowState{
+		ID:        windowID,
+		Title:     title,
+		X:         0,
+		Y:         0,
+		Width:     width,
+		Height:    height,
+		Workspace: workspace,
+		PTYID:     pty.ID,
+	}
+	s.state.Windows = append(s.state.Windows, win)
+	s.state.FocusedWindowID = windowID
+	s.state.WorkspaceFocus[workspace] = windowID
+
+	return win, nil
+}
+
+// CloseDaemonWindow removes the window matching target from the session state
+// and closes its PTY. It moves focus to another window in the same workspace
+// when the closed window was focused. It returns the closed window's ID.
+func (s *Session) CloseDaemonWindow(target string) (string, error) {
+	s.stateMu.Lock()
+
+	idx, err := findWindowStateIndex(s.state.Windows, target)
+	if err != nil {
+		s.stateMu.Unlock()
+		return "", err
+	}
+
+	closed := s.state.Windows[idx]
+	workspace := closed.Workspace
+	s.state.Windows = append(s.state.Windows[:idx], s.state.Windows[idx+1:]...)
+
+	// Repair focus if we removed the focused window.
+	if s.state.FocusedWindowID == closed.ID {
+		s.state.FocusedWindowID = ""
+		for i := range s.state.Windows {
+			if s.state.Windows[i].Workspace == workspace {
+				s.state.FocusedWindowID = s.state.Windows[i].ID
+				break
+			}
+		}
+	}
+	if s.state.WorkspaceFocus != nil && s.state.WorkspaceFocus[workspace] == closed.ID {
+		delete(s.state.WorkspaceFocus, workspace)
+		if s.state.FocusedWindowID != "" {
+			// Only re-point the workspace focus at a window that is actually on it.
+			for i := range s.state.Windows {
+				if s.state.Windows[i].ID == s.state.FocusedWindowID && s.state.Windows[i].Workspace == workspace {
+					s.state.WorkspaceFocus[workspace] = s.state.FocusedWindowID
+					break
+				}
+			}
+		}
+	}
+	s.stateMu.Unlock()
+
+	// Close the PTY outside the state lock.
+	if closed.PTYID != "" {
+		_ = s.ClosePTY(closed.PTYID)
+	}
+	return closed.ID, nil
+}
+
+// FocusDaemonWindow makes the window matching target the focused window,
+// switching the current workspace to that window's workspace.
+func (s *Session) FocusDaemonWindow(target string) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	idx, err := findWindowStateIndex(s.state.Windows, target)
+	if err != nil {
+		return err
+	}
+	win := s.state.Windows[idx]
+	s.state.FocusedWindowID = win.ID
+	s.state.CurrentWorkspace = win.Workspace
+	if s.state.WorkspaceFocus == nil {
+		s.state.WorkspaceFocus = make(map[int]string)
+	}
+	s.state.WorkspaceFocus[win.Workspace] = win.ID
+	return nil
+}
+
+// CycleDaemonFocus moves focus to the next (delta > 0) or previous (delta < 0)
+// window on the current workspace, wrapping around. It is a no-op when the
+// current workspace has fewer than two windows.
+func (s *Session) CycleDaemonFocus(delta int) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	// Collect indices of windows on the current workspace, in slice order.
+	var order []int
+	current := -1
+	for i := range s.state.Windows {
+		if s.state.Windows[i].Workspace != s.state.CurrentWorkspace {
+			continue
+		}
+		if s.state.Windows[i].ID == s.state.FocusedWindowID {
+			current = len(order)
+		}
+		order = append(order, i)
+	}
+	if len(order) == 0 {
+		return fmt.Errorf("no windows on workspace %d", s.state.CurrentWorkspace)
+	}
+	if current == -1 {
+		current = 0
+	}
+
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	next := ((current+step)%len(order) + len(order)) % len(order)
+	win := s.state.Windows[order[next]]
+	s.state.FocusedWindowID = win.ID
+	if s.state.WorkspaceFocus == nil {
+		s.state.WorkspaceFocus = make(map[int]string)
+	}
+	s.state.WorkspaceFocus[s.state.CurrentWorkspace] = win.ID
+	return nil
+}
+
+// RenameDaemonWindow sets the CustomName of the window matching target.
+func (s *Session) RenameDaemonWindow(target, name string) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	idx, err := findWindowStateIndex(s.state.Windows, target)
+	if err != nil {
+		return err
+	}
+	s.state.Windows[idx].CustomName = name
+	return nil
+}
+
+// MoveDaemonWindowToWorkspace moves the window matching target to workspace ws.
+func (s *Session) MoveDaemonWindowToWorkspace(target string, ws int) error {
+	if ws < 1 || ws > maxDaemonWorkspaces {
+		return fmt.Errorf("workspace %d out of range (1-%d)", ws, maxDaemonWorkspaces)
+	}
+
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	idx, err := findWindowStateIndex(s.state.Windows, target)
+	if err != nil {
+		return err
+	}
+	oldWorkspace := s.state.Windows[idx].Workspace
+	s.state.Windows[idx].Workspace = ws
+
+	// If the moved window held its old workspace's focus, drop it there.
+	if s.state.WorkspaceFocus != nil && s.state.WorkspaceFocus[oldWorkspace] == s.state.Windows[idx].ID {
+		delete(s.state.WorkspaceFocus, oldWorkspace)
+	}
+	return nil
+}
+
+// SwitchDaemonWorkspace sets the current workspace, restoring that workspace's
+// last-focused window when one is recorded.
+func (s *Session) SwitchDaemonWorkspace(ws int) error {
+	if ws < 1 || ws > maxDaemonWorkspaces {
+		return fmt.Errorf("workspace %d out of range (1-%d)", ws, maxDaemonWorkspaces)
+	}
+
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	s.state.CurrentWorkspace = ws
+	if s.state.WorkspaceFocus != nil {
+		if focus, ok := s.state.WorkspaceFocus[ws]; ok {
+			s.state.FocusedWindowID = focus
+		}
+	}
+	return nil
+}
+
+// SetDaemonWindowMinimized sets the minimized flag on the window matching target.
+func (s *Session) SetDaemonWindowMinimized(target string, minimized bool) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	idx, err := findWindowStateIndex(s.state.Windows, target)
+	if err != nil {
+		return err
+	}
+	s.state.Windows[idx].Minimized = minimized
+	return nil
+}

--- a/internal/session/session_ops.go
+++ b/internal/session/session_ops.go
@@ -19,6 +19,12 @@ const maxDaemonWorkspaces = 9
 // these methods are the headless path. The TUI, on its next attach, rebuilds
 // from this same state (the resurrection restore path), so a window created
 // headless shows up when a client later connects.
+//
+// Every mutation here runs inside Session.mutateState, which diffs the state
+// before and after and raises the window lifecycle events. None of these
+// operations emits an event itself: the diff is the single emit site shared with
+// the TUI's UpdateState path, which is what makes the events fire exactly once
+// and identically on both paths.
 
 // findWindowStateIndex resolves a window target string to an index into
 // state.Windows. It matches, in order: an exact window ID, a unique window ID
@@ -95,33 +101,32 @@ func (s *Session) AddDaemonWindow(title string, onExit func(ptyID string)) (Wind
 		return WindowState{}, err
 	}
 
-	s.stateMu.Lock()
+	var win WindowState
+	_ = s.mutateState(func(state *SessionState) error {
+		if state.WorkspaceFocus == nil {
+			state.WorkspaceFocus = make(map[int]string)
+		}
+		workspace := state.CurrentWorkspace
+		if workspace < 1 {
+			workspace = 1
+			state.CurrentWorkspace = 1
+		}
 
-	if s.state.WorkspaceFocus == nil {
-		s.state.WorkspaceFocus = make(map[int]string)
-	}
-	workspace := s.state.CurrentWorkspace
-	if workspace < 1 {
-		workspace = 1
-		s.state.CurrentWorkspace = 1
-	}
-
-	win := WindowState{
-		ID:        windowID,
-		Title:     title,
-		X:         0,
-		Y:         0,
-		Width:     width,
-		Height:    height,
-		Workspace: workspace,
-		PTYID:     pty.ID,
-	}
-	s.state.Windows = append(s.state.Windows, win)
-	s.state.FocusedWindowID = windowID
-	s.state.WorkspaceFocus[workspace] = windowID
-	s.stateMu.Unlock()
-
-	s.emit(SessionEvent{Type: EventWindowCreated, Window: windowID, PTYID: pty.ID, Title: title})
+		win = WindowState{
+			ID:        windowID,
+			Title:     title,
+			X:         0,
+			Y:         0,
+			Width:     width,
+			Height:    height,
+			Workspace: workspace,
+			PTYID:     pty.ID,
+		}
+		state.Windows = append(state.Windows, win)
+		state.FocusedWindowID = windowID
+		state.WorkspaceFocus[workspace] = windowID
+		return nil
+	})
 	return win, nil
 }
 
@@ -129,125 +134,120 @@ func (s *Session) AddDaemonWindow(title string, onExit func(ptyID string)) (Wind
 // and closes its PTY. It moves focus to another window in the same workspace
 // when the closed window was focused. It returns the closed window's ID.
 func (s *Session) CloseDaemonWindow(target string) (string, error) {
-	s.stateMu.Lock()
-
-	idx, err := findWindowStateIndex(s.state.Windows, target)
-	if err != nil {
-		s.stateMu.Unlock()
-		return "", err
-	}
-
-	closed := s.state.Windows[idx]
-	workspace := closed.Workspace
-	s.state.Windows = append(s.state.Windows[:idx], s.state.Windows[idx+1:]...)
-
-	// Repair focus if we removed the focused window.
-	if s.state.FocusedWindowID == closed.ID {
-		s.state.FocusedWindowID = ""
-		for i := range s.state.Windows {
-			if s.state.Windows[i].Workspace == workspace {
-				s.state.FocusedWindowID = s.state.Windows[i].ID
-				break
-			}
+	var closed WindowState
+	err := s.mutateState(func(state *SessionState) error {
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return err
 		}
-	}
-	if s.state.WorkspaceFocus != nil && s.state.WorkspaceFocus[workspace] == closed.ID {
-		delete(s.state.WorkspaceFocus, workspace)
-		if s.state.FocusedWindowID != "" {
-			// Only re-point the workspace focus at a window that is actually on it.
-			for i := range s.state.Windows {
-				if s.state.Windows[i].ID == s.state.FocusedWindowID && s.state.Windows[i].Workspace == workspace {
-					s.state.WorkspaceFocus[workspace] = s.state.FocusedWindowID
+
+		closed = state.Windows[idx]
+		workspace := closed.Workspace
+		state.Windows = append(state.Windows[:idx], state.Windows[idx+1:]...)
+
+		// Repair focus if we removed the focused window.
+		if state.FocusedWindowID == closed.ID {
+			state.FocusedWindowID = ""
+			for i := range state.Windows {
+				if state.Windows[i].Workspace == workspace {
+					state.FocusedWindowID = state.Windows[i].ID
 					break
 				}
 			}
 		}
+		if state.WorkspaceFocus != nil && state.WorkspaceFocus[workspace] == closed.ID {
+			delete(state.WorkspaceFocus, workspace)
+			if state.FocusedWindowID != "" {
+				// Only re-point the workspace focus at a window that is actually on it.
+				for i := range state.Windows {
+					if state.Windows[i].ID == state.FocusedWindowID && state.Windows[i].Workspace == workspace {
+						state.WorkspaceFocus[workspace] = state.FocusedWindowID
+						break
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
 	}
-	s.stateMu.Unlock()
 
 	// Close the PTY outside the state lock.
 	if closed.PTYID != "" {
 		_ = s.ClosePTY(closed.PTYID)
 	}
-	s.emit(SessionEvent{Type: EventWindowClosed, Window: closed.ID, PTYID: closed.PTYID})
 	return closed.ID, nil
 }
 
 // FocusDaemonWindow makes the window matching target the focused window,
 // switching the current workspace to that window's workspace.
 func (s *Session) FocusDaemonWindow(target string) error {
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
-
-	idx, err := findWindowStateIndex(s.state.Windows, target)
-	if err != nil {
-		return err
-	}
-	win := s.state.Windows[idx]
-	s.state.FocusedWindowID = win.ID
-	s.state.CurrentWorkspace = win.Workspace
-	if s.state.WorkspaceFocus == nil {
-		s.state.WorkspaceFocus = make(map[int]string)
-	}
-	s.state.WorkspaceFocus[win.Workspace] = win.ID
-	return nil
+	return s.mutateState(func(state *SessionState) error {
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return err
+		}
+		win := state.Windows[idx]
+		state.FocusedWindowID = win.ID
+		state.CurrentWorkspace = win.Workspace
+		if state.WorkspaceFocus == nil {
+			state.WorkspaceFocus = make(map[int]string)
+		}
+		state.WorkspaceFocus[win.Workspace] = win.ID
+		return nil
+	})
 }
 
 // CycleDaemonFocus moves focus to the next (delta > 0) or previous (delta < 0)
 // window on the current workspace, wrapping around. It is a no-op when the
 // current workspace has fewer than two windows.
 func (s *Session) CycleDaemonFocus(delta int) error {
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
-
-	// Collect indices of windows on the current workspace, in slice order.
-	var order []int
-	current := -1
-	for i := range s.state.Windows {
-		if s.state.Windows[i].Workspace != s.state.CurrentWorkspace {
-			continue
+	return s.mutateState(func(state *SessionState) error {
+		// Collect indices of windows on the current workspace, in slice order.
+		var order []int
+		current := -1
+		for i := range state.Windows {
+			if state.Windows[i].Workspace != state.CurrentWorkspace {
+				continue
+			}
+			if state.Windows[i].ID == state.FocusedWindowID {
+				current = len(order)
+			}
+			order = append(order, i)
 		}
-		if s.state.Windows[i].ID == s.state.FocusedWindowID {
-			current = len(order)
+		if len(order) == 0 {
+			return fmt.Errorf("no windows on workspace %d", state.CurrentWorkspace)
 		}
-		order = append(order, i)
-	}
-	if len(order) == 0 {
-		return fmt.Errorf("no windows on workspace %d", s.state.CurrentWorkspace)
-	}
-	if current == -1 {
-		current = 0
-	}
+		if current == -1 {
+			current = 0
+		}
 
-	step := 1
-	if delta < 0 {
-		step = -1
-	}
-	next := ((current+step)%len(order) + len(order)) % len(order)
-	win := s.state.Windows[order[next]]
-	s.state.FocusedWindowID = win.ID
-	if s.state.WorkspaceFocus == nil {
-		s.state.WorkspaceFocus = make(map[int]string)
-	}
-	s.state.WorkspaceFocus[s.state.CurrentWorkspace] = win.ID
-	return nil
+		step := 1
+		if delta < 0 {
+			step = -1
+		}
+		next := ((current+step)%len(order) + len(order)) % len(order)
+		win := state.Windows[order[next]]
+		state.FocusedWindowID = win.ID
+		if state.WorkspaceFocus == nil {
+			state.WorkspaceFocus = make(map[int]string)
+		}
+		state.WorkspaceFocus[state.CurrentWorkspace] = win.ID
+		return nil
+	})
 }
 
 // RenameDaemonWindow sets the CustomName of the window matching target.
 func (s *Session) RenameDaemonWindow(target, name string) error {
-	s.stateMu.Lock()
-
-	idx, err := findWindowStateIndex(s.state.Windows, target)
-	if err != nil {
-		s.stateMu.Unlock()
-		return err
-	}
-	s.state.Windows[idx].CustomName = name
-	winID := s.state.Windows[idx].ID
-	s.stateMu.Unlock()
-
-	s.emit(SessionEvent{Type: EventWindowRetitled, Window: winID, Title: name})
-	return nil
+	return s.mutateState(func(state *SessionState) error {
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return err
+		}
+		state.Windows[idx].CustomName = name
+		return nil
+	})
 }
 
 // MoveDaemonWindowToWorkspace moves the window matching target to workspace ws.
@@ -256,21 +256,20 @@ func (s *Session) MoveDaemonWindowToWorkspace(target string, ws int) error {
 		return fmt.Errorf("workspace %d out of range (1-%d)", ws, maxDaemonWorkspaces)
 	}
 
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
+	return s.mutateState(func(state *SessionState) error {
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return err
+		}
+		oldWorkspace := state.Windows[idx].Workspace
+		state.Windows[idx].Workspace = ws
 
-	idx, err := findWindowStateIndex(s.state.Windows, target)
-	if err != nil {
-		return err
-	}
-	oldWorkspace := s.state.Windows[idx].Workspace
-	s.state.Windows[idx].Workspace = ws
-
-	// If the moved window held its old workspace's focus, drop it there.
-	if s.state.WorkspaceFocus != nil && s.state.WorkspaceFocus[oldWorkspace] == s.state.Windows[idx].ID {
-		delete(s.state.WorkspaceFocus, oldWorkspace)
-	}
-	return nil
+		// If the moved window held its old workspace's focus, drop it there.
+		if state.WorkspaceFocus != nil && state.WorkspaceFocus[oldWorkspace] == state.Windows[idx].ID {
+			delete(state.WorkspaceFocus, oldWorkspace)
+		}
+		return nil
+	})
 }
 
 // SwitchDaemonWorkspace sets the current workspace, restoring that workspace's
@@ -280,27 +279,25 @@ func (s *Session) SwitchDaemonWorkspace(ws int) error {
 		return fmt.Errorf("workspace %d out of range (1-%d)", ws, maxDaemonWorkspaces)
 	}
 
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
-
-	s.state.CurrentWorkspace = ws
-	if s.state.WorkspaceFocus != nil {
-		if focus, ok := s.state.WorkspaceFocus[ws]; ok {
-			s.state.FocusedWindowID = focus
+	return s.mutateState(func(state *SessionState) error {
+		state.CurrentWorkspace = ws
+		if state.WorkspaceFocus != nil {
+			if focus, ok := state.WorkspaceFocus[ws]; ok {
+				state.FocusedWindowID = focus
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // SetDaemonWindowMinimized sets the minimized flag on the window matching target.
 func (s *Session) SetDaemonWindowMinimized(target string, minimized bool) error {
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
-
-	idx, err := findWindowStateIndex(s.state.Windows, target)
-	if err != nil {
-		return err
-	}
-	s.state.Windows[idx].Minimized = minimized
-	return nil
+	return s.mutateState(func(state *SessionState) error {
+		idx, err := findWindowStateIndex(state.Windows, target)
+		if err != nil {
+			return err
+		}
+		state.Windows[idx].Minimized = minimized
+		return nil
+	})
 }

--- a/internal/session/session_ops.go
+++ b/internal/session/session_ops.go
@@ -96,7 +96,6 @@ func (s *Session) AddDaemonWindow(title string, onExit func(ptyID string)) (Wind
 	}
 
 	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	if s.state.WorkspaceFocus == nil {
 		s.state.WorkspaceFocus = make(map[int]string)
@@ -120,7 +119,9 @@ func (s *Session) AddDaemonWindow(title string, onExit func(ptyID string)) (Wind
 	s.state.Windows = append(s.state.Windows, win)
 	s.state.FocusedWindowID = windowID
 	s.state.WorkspaceFocus[workspace] = windowID
+	s.stateMu.Unlock()
 
+	s.emit(SessionEvent{Type: EventWindowCreated, Window: windowID, PTYID: pty.ID, Title: title})
 	return win, nil
 }
 
@@ -168,6 +169,7 @@ func (s *Session) CloseDaemonWindow(target string) (string, error) {
 	if closed.PTYID != "" {
 		_ = s.ClosePTY(closed.PTYID)
 	}
+	s.emit(SessionEvent{Type: EventWindowClosed, Window: closed.ID, PTYID: closed.PTYID})
 	return closed.ID, nil
 }
 
@@ -234,13 +236,17 @@ func (s *Session) CycleDaemonFocus(delta int) error {
 // RenameDaemonWindow sets the CustomName of the window matching target.
 func (s *Session) RenameDaemonWindow(target, name string) error {
 	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	idx, err := findWindowStateIndex(s.state.Windows, target)
 	if err != nil {
+		s.stateMu.Unlock()
 		return err
 	}
 	s.state.Windows[idx].CustomName = name
+	winID := s.state.Windows[idx].ID
+	s.stateMu.Unlock()
+
+	s.emit(SessionEvent{Type: EventWindowRetitled, Window: winID, Title: name})
 	return nil
 }
 

--- a/internal/session/session_ops_test.go
+++ b/internal/session/session_ops_test.go
@@ -1,0 +1,205 @@
+package session
+
+import (
+	"testing"
+)
+
+// newTestSession creates a session backed by a real shell for the state-op tests.
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	sess, err := NewSession("ops-test", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	t.Cleanup(sess.Stop)
+	return sess
+}
+
+func TestAddDaemonWindow(t *testing.T) {
+	sess := newTestSession(t)
+
+	win, err := sess.AddDaemonWindow("shell", nil)
+	if err != nil {
+		t.Fatalf("AddDaemonWindow failed: %v", err)
+	}
+	if win.ID == "" {
+		t.Fatal("created window has empty ID")
+	}
+	if win.PTYID == "" {
+		t.Fatal("created window has empty PTYID")
+	}
+	if win.Workspace != 1 {
+		t.Errorf("workspace = %d, want 1", win.Workspace)
+	}
+
+	// The PTY must be live and registered on the session.
+	if pty := sess.GetPTY(win.PTYID); pty == nil {
+		t.Fatal("PTY not registered on session")
+	} else if pty.IsExited() {
+		t.Fatal("freshly created PTY already exited")
+	}
+
+	state := sess.GetState()
+	if len(state.Windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(state.Windows))
+	}
+	if state.FocusedWindowID != win.ID {
+		t.Errorf("focus = %q, want %q", state.FocusedWindowID, win.ID)
+	}
+	if state.WorkspaceFocus[1] != win.ID {
+		t.Errorf("workspace focus[1] = %q, want %q", state.WorkspaceFocus[1], win.ID)
+	}
+}
+
+func TestCloseDaemonWindow(t *testing.T) {
+	sess := newTestSession(t)
+
+	w1, _ := sess.AddDaemonWindow("one", nil)
+	w2, _ := sess.AddDaemonWindow("two", nil)
+
+	// Close the focused (second) window; focus must fall back to the first.
+	closedID, err := sess.CloseDaemonWindow(w2.ID)
+	if err != nil {
+		t.Fatalf("CloseDaemonWindow failed: %v", err)
+	}
+	if closedID != w2.ID {
+		t.Errorf("closed ID = %q, want %q", closedID, w2.ID)
+	}
+
+	state := sess.GetState()
+	if len(state.Windows) != 1 {
+		t.Fatalf("window count = %d, want 1", len(state.Windows))
+	}
+	if state.FocusedWindowID != w1.ID {
+		t.Errorf("focus after close = %q, want %q", state.FocusedWindowID, w1.ID)
+	}
+	if sess.GetPTY(w2.PTYID) != nil {
+		t.Error("closed window's PTY is still registered")
+	}
+}
+
+func TestCloseDaemonWindowByName(t *testing.T) {
+	sess := newTestSession(t)
+
+	w1, _ := sess.AddDaemonWindow("", nil)
+	if err := sess.RenameDaemonWindow(w1.ID, "build"); err != nil {
+		t.Fatalf("RenameDaemonWindow failed: %v", err)
+	}
+
+	if _, err := sess.CloseDaemonWindow("build"); err != nil {
+		t.Fatalf("CloseDaemonWindow by name failed: %v", err)
+	}
+	if len(sess.GetState().Windows) != 0 {
+		t.Error("window not removed when closed by name")
+	}
+}
+
+func TestFocusAndCycleDaemonWindows(t *testing.T) {
+	sess := newTestSession(t)
+
+	w1, _ := sess.AddDaemonWindow("one", nil)
+	w2, _ := sess.AddDaemonWindow("two", nil)
+	w3, _ := sess.AddDaemonWindow("three", nil)
+
+	if err := sess.FocusDaemonWindow(w1.ID); err != nil {
+		t.Fatalf("FocusDaemonWindow failed: %v", err)
+	}
+	if sess.GetState().FocusedWindowID != w1.ID {
+		t.Fatalf("focus = %q, want %q", sess.GetState().FocusedWindowID, w1.ID)
+	}
+
+	// Next wraps forward: w1 -> w2 -> w3 -> w1.
+	if err := sess.CycleDaemonFocus(1); err != nil {
+		t.Fatalf("CycleDaemonFocus failed: %v", err)
+	}
+	if got := sess.GetState().FocusedWindowID; got != w2.ID {
+		t.Errorf("after next, focus = %q, want %q", got, w2.ID)
+	}
+
+	// Prev wraps backward from w2 to w1.
+	if err := sess.CycleDaemonFocus(-1); err != nil {
+		t.Fatalf("CycleDaemonFocus(-1) failed: %v", err)
+	}
+	if got := sess.GetState().FocusedWindowID; got != w1.ID {
+		t.Errorf("after prev, focus = %q, want %q", got, w1.ID)
+	}
+
+	// Prev from the first window wraps to the last.
+	if err := sess.CycleDaemonFocus(-1); err != nil {
+		t.Fatalf("CycleDaemonFocus(-1) wrap failed: %v", err)
+	}
+	if got := sess.GetState().FocusedWindowID; got != w3.ID {
+		t.Errorf("after wrap prev, focus = %q, want %q", got, w3.ID)
+	}
+}
+
+func TestMoveAndSwitchWorkspace(t *testing.T) {
+	sess := newTestSession(t)
+
+	w1, _ := sess.AddDaemonWindow("one", nil)
+
+	if err := sess.MoveDaemonWindowToWorkspace(w1.ID, 3); err != nil {
+		t.Fatalf("MoveDaemonWindowToWorkspace failed: %v", err)
+	}
+	state := sess.GetState()
+	if state.Windows[0].Workspace != 3 {
+		t.Errorf("window workspace = %d, want 3", state.Windows[0].Workspace)
+	}
+
+	if err := sess.SwitchDaemonWorkspace(3); err != nil {
+		t.Fatalf("SwitchDaemonWorkspace failed: %v", err)
+	}
+	if sess.GetState().CurrentWorkspace != 3 {
+		t.Errorf("current workspace = %d, want 3", sess.GetState().CurrentWorkspace)
+	}
+
+	// Out-of-range workspaces are rejected.
+	if err := sess.SwitchDaemonWorkspace(0); err == nil {
+		t.Error("expected error for workspace 0")
+	}
+	if err := sess.MoveDaemonWindowToWorkspace(w1.ID, 99); err == nil {
+		t.Error("expected error for workspace 99")
+	}
+}
+
+func TestMinimizeDaemonWindow(t *testing.T) {
+	sess := newTestSession(t)
+
+	w1, _ := sess.AddDaemonWindow("one", nil)
+	if err := sess.SetDaemonWindowMinimized(w1.ID, true); err != nil {
+		t.Fatalf("SetDaemonWindowMinimized failed: %v", err)
+	}
+	if !sess.GetState().Windows[0].Minimized {
+		t.Error("window not minimized")
+	}
+	if err := sess.SetDaemonWindowMinimized(w1.ID, false); err != nil {
+		t.Fatalf("SetDaemonWindowMinimized(false) failed: %v", err)
+	}
+	if sess.GetState().Windows[0].Minimized {
+		t.Error("window still minimized after restore")
+	}
+}
+
+func TestFindWindowStateIndexAmbiguity(t *testing.T) {
+	windows := []WindowState{
+		{ID: "aaa-1", CustomName: "dup"},
+		{ID: "aaa-2", CustomName: "dup"},
+		{ID: "bbb-3", Title: "unique"},
+	}
+
+	if _, err := findWindowStateIndex(windows, "aaa"); err == nil {
+		t.Error("expected ambiguous prefix error")
+	}
+	if _, err := findWindowStateIndex(windows, "dup"); err == nil {
+		t.Error("expected ambiguous name error")
+	}
+	if idx, err := findWindowStateIndex(windows, "bbb-3"); err != nil || idx != 2 {
+		t.Errorf("exact ID match: idx=%d err=%v", idx, err)
+	}
+	if idx, err := findWindowStateIndex(windows, "unique"); err != nil || idx != 2 {
+		t.Errorf("title match: idx=%d err=%v", idx, err)
+	}
+	if _, err := findWindowStateIndex(windows, "nope"); err == nil {
+		t.Error("expected no-match error")
+	}
+}

--- a/internal/session/session_options_test.go
+++ b/internal/session/session_options_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSessionOptionsSetGet(t *testing.T) {
+	sess, err := NewSession("opt-test", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Stop()
+
+	if _, ok := sess.GetOption("border_style"); ok {
+		t.Fatalf("expected unset option to report ok=false")
+	}
+
+	sess.SetOption("border_style", "rounded")
+	v, ok := sess.GetOption("border_style")
+	if !ok || v != "rounded" {
+		t.Fatalf("GetOption = %q,%v; want rounded,true", v, ok)
+	}
+
+	sess.SetOption("border_style", "double")
+	if v, _ := sess.GetOption("border_style"); v != "double" {
+		t.Fatalf("overwrite failed: got %q", v)
+	}
+
+	// GetState must expose a copy of Options, not the live map.
+	state := sess.GetState()
+	if state.Options["border_style"] != "double" {
+		t.Fatalf("GetState Options missing value: %+v", state.Options)
+	}
+	state.Options["border_style"] = "mutated"
+	if v, _ := sess.GetOption("border_style"); v != "double" {
+		t.Fatalf("GetState returned a live map reference; option was mutated to %q", v)
+	}
+}
+
+func TestSessionOptionsSurviveStateSync(t *testing.T) {
+	sess, err := NewSession("opt-sync", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Stop()
+
+	sess.SetOption("theme", "dracula")
+
+	// A TUI state sync never populates Options; the daemon must preserve them.
+	sess.UpdateState(&SessionState{Name: "opt-sync", CurrentWorkspace: 1})
+
+	if v, ok := sess.GetOption("theme"); !ok || v != "dracula" {
+		t.Fatalf("option lost across UpdateState: %q,%v", v, ok)
+	}
+
+	// An explicit non-nil Options in the incoming state replaces the bag.
+	sess.UpdateState(&SessionState{Name: "opt-sync", Options: map[string]string{"theme": "nord"}})
+	if v, _ := sess.GetOption("theme"); v != "nord" {
+		t.Fatalf("explicit Options did not replace bag: %q", v)
+	}
+}
+
+func TestSessionOptionsConcurrent(t *testing.T) {
+	sess, err := NewSession("opt-race", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				sess.SetOption("k", "v")
+				_, _ = sess.GetOption("k")
+				_ = sess.AllOptions()
+				_ = sess.GetState()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/session/state_events.go
+++ b/internal/session/state_events.go
@@ -1,0 +1,166 @@
+package session
+
+// Window lifecycle events are derived, in one place, from the difference between
+// two canonical SessionState snapshots. This matters because a mutation reaches
+// daemon-owned state by one of two routes: the headless daemon-side ops in
+// session_ops.go mutate the state in place, and an attached TUI performs the
+// mutation itself and pushes the result back with UpdateState. Both routes funnel
+// through the helpers below, so a subscriber sees the same events, with the same
+// payloads and the same ordering, no matter which one ran. Emitting from the
+// diff (rather than from each op and again from the TUI bridge) is also what
+// makes the events exactly-once: state converges once, so it is diffed once.
+//
+// Events that hang off a PTY rather than off window state (output, bell,
+// mode-changed, window-exit, and OSC-driven title changes) are emitted by the
+// per-PTY emitter in session.go and are deliberately not derived here, so they
+// are not double-counted.
+
+// lifecycleWindow is the subset of a WindowState that window lifecycle events
+// are derived from. Geometry, z-order, and alt-screen state are excluded: they
+// change on nearly every render and raise no lifecycle event.
+type lifecycleWindow struct {
+	id         string
+	ptyID      string
+	title      string
+	customName string
+	workspace  int
+	minimized  bool
+}
+
+// lifecycleSnapshot is a copy of the lifecycle-relevant parts of a SessionState.
+// It is a copy, not a reference, because the headless ops mutate the state in
+// place and the "before" snapshot has to survive that.
+type lifecycleSnapshot struct {
+	windows   []lifecycleWindow // in state order
+	index     map[string]int    // window ID -> index into windows
+	focused   string
+	workspace int
+}
+
+// snapshotLifecycle captures the lifecycle-relevant parts of state. The caller
+// must hold the session's state lock.
+func snapshotLifecycle(state *SessionState) lifecycleSnapshot {
+	snap := lifecycleSnapshot{index: make(map[string]int)}
+	if state == nil {
+		return snap
+	}
+	snap.focused = state.FocusedWindowID
+	snap.workspace = state.CurrentWorkspace
+	snap.windows = make([]lifecycleWindow, 0, len(state.Windows))
+	for i := range state.Windows {
+		w := &state.Windows[i]
+		snap.index[w.ID] = len(snap.windows)
+		snap.windows = append(snap.windows, lifecycleWindow{
+			id:         w.ID,
+			ptyID:      w.PTYID,
+			title:      w.Title,
+			customName: w.CustomName,
+			workspace:  w.Workspace,
+			minimized:  w.Minimized,
+		})
+	}
+	return snap
+}
+
+// diffLifecycle returns the window lifecycle events implied by the move from
+// before to after, in a stable order: closes, then creates, then per-window
+// changes (rename, move, minimize/restore) in after-state order, then the
+// session-level workspace switch, then the focus change. Focus comes last
+// because it is usually a consequence of one of the earlier events, and a
+// consumer that reacts to focus wants the window it is focusing to already
+// exist in the picture it has built from the stream.
+func diffLifecycle(before, after lifecycleSnapshot) []SessionEvent {
+	var events []SessionEvent
+
+	for i := range before.windows {
+		w := &before.windows[i]
+		if _, ok := after.index[w.id]; !ok {
+			events = append(events, SessionEvent{
+				Type:   EventWindowClosed,
+				Window: w.id,
+				PTYID:  w.ptyID,
+			})
+		}
+	}
+
+	for i := range after.windows {
+		w := &after.windows[i]
+		if _, ok := before.index[w.id]; !ok {
+			events = append(events, SessionEvent{
+				Type:   EventWindowCreated,
+				Window: w.id,
+				PTYID:  w.ptyID,
+				Title:  w.displayTitle(),
+			})
+		}
+	}
+
+	for i := range after.windows {
+		w := &after.windows[i]
+		prevIdx, ok := before.index[w.id]
+		if !ok {
+			continue // already reported as created
+		}
+		prev := &before.windows[prevIdx]
+
+		// Only an explicit rename (CustomName) raises window-retitled from the
+		// diff. A Title change is the shell's OSC title sequence, which the
+		// per-PTY emitter already reports; deriving it here too would emit the
+		// same title change twice.
+		if w.customName != prev.customName {
+			events = append(events, SessionEvent{
+				Type:   EventWindowRetitled,
+				Window: w.id,
+				Title:  w.customName,
+			})
+		}
+		if w.workspace != prev.workspace {
+			events = append(events, SessionEvent{
+				Type:      EventWindowMoved,
+				Window:    w.id,
+				PTYID:     w.ptyID,
+				Workspace: w.workspace,
+			})
+		}
+		if w.minimized != prev.minimized {
+			evType := EventWindowRestored
+			if w.minimized {
+				evType = EventWindowMinimized
+			}
+			events = append(events, SessionEvent{
+				Type:   evType,
+				Window: w.id,
+				PTYID:  w.ptyID,
+			})
+		}
+	}
+
+	if after.workspace != before.workspace && after.workspace > 0 {
+		events = append(events, SessionEvent{
+			Type:      EventWorkspaceSwitched,
+			Workspace: after.workspace,
+		})
+	}
+
+	// A focus change is only reported for a window that still exists; losing
+	// focus because the focused window closed is already implied by
+	// window-closed, and an empty focus target has nothing to report.
+	if after.focused != before.focused && after.focused != "" {
+		ev := SessionEvent{Type: EventWindowFocused, Window: after.focused}
+		if idx, ok := after.index[after.focused]; ok {
+			ev.PTYID = after.windows[idx].ptyID
+		}
+		events = append(events, ev)
+	}
+
+	return events
+}
+
+// displayTitle is the title reported for a window in a lifecycle event: the
+// explicit name when one was set, otherwise the shell-reported title.
+func (w *lifecycleWindow) displayTitle() string {
+	if w.customName != "" {
+		return w.customName
+	}
+	return w.title
+}

--- a/internal/session/state_events_test.go
+++ b/internal/session/state_events_test.go
@@ -1,0 +1,468 @@
+package session
+
+import (
+	"encoding/json"
+
+	"reflect"
+	"testing"
+	"time"
+)
+
+// collectEvents reads event lines off a subscribed connection until it has want
+// of them or the read deadline expires. It returns what it managed to read, so a
+// caller can assert on "exactly N and no more" as well as on the contents.
+func collectEvents(t *testing.T, c *verbConn, want int, wait time.Duration) []map[string]any {
+	t.Helper()
+	var got []map[string]any
+	deadline := time.Now().Add(wait)
+	for len(got) < want {
+		_ = c.conn.SetReadDeadline(deadline)
+		line, err := c.r.ReadBytes('\n')
+		if err != nil {
+			break
+		}
+		var ev map[string]any
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("decode event %q: %v", string(line), err)
+		}
+		got = append(got, ev)
+	}
+	return got
+}
+
+// expectNoMoreEvents fails if any further event line arrives within grace. This
+// is how the exactly-once assertions are made: the expected events are drained
+// first, then the stream must be silent.
+func expectNoMoreEvents(t *testing.T, c *verbConn, grace time.Duration) {
+	t.Helper()
+	_ = c.conn.SetReadDeadline(time.Now().Add(grace))
+	line, err := c.r.ReadBytes('\n')
+	if err == nil {
+		t.Fatalf("unexpected extra event: %s", string(line))
+	}
+}
+
+func eventTypes(events []map[string]any) []string {
+	types := make([]string, 0, len(events))
+	for _, ev := range events {
+		s, _ := ev["type"].(string)
+		types = append(types, s)
+	}
+	return types
+}
+
+// subscribeTo opens an event stream filtered to one session and the given types.
+func subscribeTo(t *testing.T, sp, session string, types ...string) *verbConn {
+	t.Helper()
+	c := dialVerb(t, sp)
+	params := map[string]any{"session": session}
+	if len(types) > 0 {
+		params["types"] = types
+	}
+	req, err := json.Marshal(map[string]any{"id": 1, "verb": "subscribe", "params": params})
+	if err != nil {
+		t.Fatalf("marshal subscribe: %v", err)
+	}
+	ack := result(t, c.call(t, string(req)))
+	if ack["type"] != EventSubscribed {
+		t.Fatalf("subscribe ack type = %v, want subscribed", ack["type"])
+	}
+	return c
+}
+
+// lifecycleTypes are the window lifecycle event types under test. PTY-driven
+// types (output, bell, window-exit, mode-changed) are excluded so a live shell's
+// startup chatter cannot make these tests flaky.
+var lifecycleTypes = []string{
+	EventWindowCreated,
+	EventWindowClosed,
+	EventWindowRetitled,
+	EventWindowFocused,
+	EventWindowMoved,
+	EventWindowMinimized,
+	EventWindowRestored,
+	EventWorkspaceSwitched,
+}
+
+// syncingTUI is a fake attached TUI that behaves like the real one: it applies a
+// routed remote command to the session itself and pushes the resulting state
+// back to the daemon with UpdateState, which is the convergence point the
+// lifecycle events are derived from. It never emits events itself.
+type syncingTUI struct {
+	d    *Daemon
+	sess *Session
+	conn *connState
+}
+
+// attachSyncingTUI registers the fake TUI and serves routed remote commands with
+// apply until the test ends.
+func attachSyncingTUI(t *testing.T, d *Daemon, sess *Session, apply func(state *SessionState) *CommandResultPayload) *syncingTUI {
+	t.Helper()
+	tui, clientSide := newFakeTUI(t, d, sess.ID)
+	s := &syncingTUI{d: d, sess: sess, conn: tui}
+
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+
+	go func() {
+		for {
+			msg, _, err := ReadMessageWithCodec(clientSide)
+			if err != nil {
+				return
+			}
+			select {
+			case <-done:
+				return
+			default:
+			}
+			var rc RemoteCommandPayload
+			if err := msg.ParsePayloadWithCodec(&rc, DefaultCodec()); err != nil {
+				return
+			}
+			state := sess.GetState()
+			res := apply(state)
+			// The real TUI owns the state and syncs it back; do the same, so the
+			// daemon converges through the one path that raises the events.
+			s.sync(state)
+			res.RequestID = rc.RequestID
+			resMsg, err := NewMessage(MsgCommandResult, res)
+			if err != nil {
+				return
+			}
+			_ = d.handleCommandResult(tui, resMsg)
+		}
+	}()
+	return s
+}
+
+// sync pushes a state snapshot to the daemon exactly as a TUI client does, via
+// the daemon's update-state handler.
+func (s *syncingTUI) sync(state *SessionState) {
+	msg, err := NewMessageWithCodec(MsgUpdateState, state, DefaultCodec())
+	if err != nil {
+		return
+	}
+	_ = s.d.handleUpdateState(s.conn, msg)
+}
+
+// newTUIWindow builds the window a TUI would add for a new-window command,
+// including a live PTY, and appends it to state with focus, mirroring
+// AddDaemonWindow.
+func newTUIWindow(t *testing.T, sess *Session, state *SessionState, id, title string) {
+	t.Helper()
+	pty, err := sess.CreatePTY(id, 78, 22, nil)
+	if err != nil {
+		t.Fatalf("CreatePTY: %v", err)
+	}
+	ws := state.CurrentWorkspace
+	if ws < 1 {
+		ws = 1
+		state.CurrentWorkspace = 1
+	}
+	state.Windows = append(state.Windows, WindowState{
+		ID: id, Title: title, Width: 80, Height: 24, Workspace: ws, PTYID: pty.ID,
+	})
+	state.FocusedWindowID = id
+	if state.WorkspaceFocus == nil {
+		state.WorkspaceFocus = make(map[int]string)
+	}
+	state.WorkspaceFocus[ws] = id
+}
+
+// TestLifecycleEventsMatchHeadlessAndAttached is the core guarantee: a
+// subscriber sees the same event stream for the same operation whether the
+// daemon performed it headlessly or an attached TUI did. Previously the attached
+// case produced no window lifecycle events at all.
+func TestLifecycleEventsMatchHeadlessAndAttached(t *testing.T) {
+	d, sp := startTestDaemon(t)
+
+	// Headless: no client attached, the daemon mutates its own state.
+	headless := makeSessionWithWindow(t, d, "headless")
+	hsub := subscribeTo(t, sp, "headless", lifecycleTypes...)
+
+	created, err := headless.AddDaemonWindow("build", nil)
+	if err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+	if _, err := headless.CloseDaemonWindow(created.ID); err != nil {
+		t.Fatalf("CloseDaemonWindow: %v", err)
+	}
+	// Creating focuses the new window and closing it hands focus back, so each
+	// mutation raises its lifecycle event plus the focus change it caused.
+	headlessEvents := collectEvents(t, hsub, 4, 3*time.Second)
+
+	// Attached: an attached TUI performs the same two mutations and syncs.
+	attached := makeSessionWithWindow(t, d, "attached")
+	firstWindow := attached.GetState().Windows[0].ID
+
+	var closeTarget string
+	tui := attachSyncingTUI(t, d, attached, func(state *SessionState) *CommandResultPayload {
+		if closeTarget == "" {
+			newTUIWindow(t, attached, state, "tui-window-id", "build")
+			return &CommandResultPayload{Success: true, Data: map[string]any{"window_id": "tui-window-id"}}
+		}
+		for i := range state.Windows {
+			if state.Windows[i].ID != closeTarget {
+				continue
+			}
+			state.Windows = append(state.Windows[:i], state.Windows[i+1:]...)
+			state.FocusedWindowID = firstWindow
+			break
+		}
+		return &CommandResultPayload{Success: true}
+	})
+	_ = tui
+
+	asub := subscribeTo(t, sp, "attached", lifecycleTypes...)
+
+	if _, verr := d.verbNewWindow(nil, json.RawMessage(`{"session":"attached","name":"build"}`)); verr != nil {
+		t.Fatalf("verbNewWindow: %v", verr)
+	}
+	closeTarget = "tui-window-id"
+	if _, verr := d.verbCloseWindow(nil, json.RawMessage(`{"session":"attached","window":"tui-window-id"}`)); verr != nil {
+		t.Fatalf("verbCloseWindow: %v", verr)
+	}
+	attachedEvents := collectEvents(t, asub, 4, 3*time.Second)
+
+	if got, want := eventTypes(headlessEvents), eventTypes(attachedEvents); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event streams differ:\n headless = %v\n attached = %v", got, want)
+	}
+	if got := eventTypes(headlessEvents); !reflect.DeepEqual(got, []string{
+		EventWindowCreated, EventWindowFocused, EventWindowClosed, EventWindowFocused,
+	}) {
+		t.Fatalf("unexpected event sequence: %v", got)
+	}
+
+	// Payload shape must match too, not just the type sequence.
+	for i := range headlessEvents {
+		h, a := headlessEvents[i], attachedEvents[i]
+		for _, field := range []string{"session", "window", "pty_id", "seq", "time"} {
+			if _, ok := h[field]; ok != hasKey(a, field) {
+				t.Errorf("event %d (%v): field %q present=%v headless, %v attached",
+					i, h["type"], field, ok, hasKey(a, field))
+			}
+		}
+		if h["type"] == EventWindowCreated && h["title"] != a["title"] {
+			t.Errorf("window-created title = %v headless, %v attached", h["title"], a["title"])
+		}
+	}
+}
+
+func hasKey(m map[string]any, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+// TestTUIDrivenWindowLifecycleIsObserved is the regression test for the reported
+// bug: a window created and then closed by an attached TUI, with no control-plane
+// verb involved at all, must still reach a subscriber.
+func TestTUIDrivenWindowLifecycleIsObserved(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+	tui := &syncingTUI{d: d, sess: sess}
+	tui.conn, _ = newFakeTUI(t, d, sess.ID)
+
+	sub := subscribeTo(t, sp, "work", EventWindowCreated, EventWindowClosed)
+
+	// The TUI creates a window on its own (a human pressing the new-window key).
+	state := sess.GetState()
+	newTUIWindow(t, sess, state, "human-window", "shell")
+	tui.sync(state)
+
+	// ...and then closes it.
+	state = sess.GetState()
+	state.Windows = state.Windows[:len(state.Windows)-1]
+	tui.sync(state)
+
+	events := collectEvents(t, sub, 2, 3*time.Second)
+	if got := eventTypes(events); !reflect.DeepEqual(got, []string{EventWindowCreated, EventWindowClosed}) {
+		t.Fatalf("event types = %v, want created then closed", got)
+	}
+	for _, ev := range events {
+		if ev["window"] != "human-window" {
+			t.Errorf("event %v carried window %v, want human-window", ev["type"], ev["window"])
+		}
+		if ev["pty_id"] == nil || ev["pty_id"] == "" {
+			t.Errorf("event %v missing pty_id", ev["type"])
+		}
+	}
+	expectNoMoreEvents(t, sub, 300*time.Millisecond)
+}
+
+// TestLifecycleEventsFireExactlyOnce verifies the headless path does not
+// double-emit now that it converges through the same diff as the TUI path, and
+// that a redundant state sync (identical state pushed again) emits nothing.
+func TestLifecycleEventsFireExactlyOnce(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+	sub := subscribeTo(t, sp, "work", lifecycleTypes...)
+
+	if _, err := sess.AddDaemonWindow("only", nil); err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+
+	// One create raises exactly one window-created (plus the focus change it
+	// causes), never two of either.
+	events := collectEvents(t, sub, 2, 3*time.Second)
+	if got := eventTypes(events); !reflect.DeepEqual(got, []string{EventWindowCreated, EventWindowFocused}) {
+		t.Fatalf("event types = %v, want one window-created then one window-focused", got)
+	}
+	expectNoMoreEvents(t, sub, 300*time.Millisecond)
+
+	// Re-syncing the very same state is a no-op for the event stream.
+	tui, _ := newFakeTUI(t, d, sess.ID)
+	(&syncingTUI{d: d, sess: sess, conn: tui}).sync(sess.GetState())
+	expectNoMoreEvents(t, sub, 300*time.Millisecond)
+}
+
+// TestLifecycleEventSequenceIsMonotonic verifies events keep strictly increasing
+// sequence numbers across a mix of headless operations.
+func TestLifecycleEventSequenceIsMonotonic(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+	sub := subscribeTo(t, sp, "work", lifecycleTypes...)
+
+	a, err := sess.AddDaemonWindow("a", nil)
+	if err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+	if err := sess.RenameDaemonWindow(a.ID, "renamed"); err != nil {
+		t.Fatalf("RenameDaemonWindow: %v", err)
+	}
+	if err := sess.MoveDaemonWindowToWorkspace(a.ID, 3); err != nil {
+		t.Fatalf("MoveDaemonWindowToWorkspace: %v", err)
+	}
+	if err := sess.SwitchDaemonWorkspace(3); err != nil {
+		t.Fatalf("SwitchDaemonWorkspace: %v", err)
+	}
+	if err := sess.SetDaemonWindowMinimized(a.ID, true); err != nil {
+		t.Fatalf("SetDaemonWindowMinimized: %v", err)
+	}
+
+	events := collectEvents(t, sub, 6, 3*time.Second)
+	want := []string{
+		EventWindowCreated,
+		EventWindowFocused,
+		EventWindowRetitled,
+		EventWindowMoved,
+		EventWorkspaceSwitched,
+		EventWindowMinimized,
+	}
+	if got := eventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event types = %v, want %v", got, want)
+	}
+
+	var prev float64
+	for i, ev := range events {
+		seq, ok := ev["seq"].(float64)
+		if !ok {
+			t.Fatalf("event %d has no numeric seq: %v", i, ev["seq"])
+		}
+		if seq <= prev {
+			t.Fatalf("seq not monotonic at event %d: %v after %v", i, seq, prev)
+		}
+		prev = seq
+	}
+
+	if events[3]["workspace"] != float64(3) {
+		t.Errorf("window-moved workspace = %v, want 3", events[3]["workspace"])
+	}
+	if events[4]["workspace"] != float64(3) {
+		t.Errorf("workspace-switched workspace = %v, want 3", events[4]["workspace"])
+	}
+	if events[2]["title"] != "renamed" {
+		t.Errorf("window-retitled title = %v, want renamed", events[2]["title"])
+	}
+}
+
+// TestDiffLifecycleOrdering pins the ordering the diff produces for a mutation
+// that changes several things at once: closes before creates, and the focus
+// change last so a consumer building a model from the stream already knows about
+// the window being focused.
+func TestDiffLifecycleOrdering(t *testing.T) {
+	before := snapshotLifecycle(&SessionState{
+		Windows: []WindowState{
+			{ID: "gone", PTYID: "pty-gone", Workspace: 1},
+			{ID: "stays", PTYID: "pty-stays", Workspace: 1},
+		},
+		FocusedWindowID:  "gone",
+		CurrentWorkspace: 1,
+	})
+	after := snapshotLifecycle(&SessionState{
+		Windows: []WindowState{
+			{ID: "stays", PTYID: "pty-stays", Workspace: 2, CustomName: "named", Minimized: true},
+			{ID: "fresh", PTYID: "pty-fresh", Workspace: 2, Title: "sh"},
+		},
+		FocusedWindowID:  "fresh",
+		CurrentWorkspace: 2,
+	})
+
+	var got []string
+	for _, ev := range diffLifecycle(before, after) {
+		got = append(got, ev.Type)
+	}
+	want := []string{
+		EventWindowClosed,
+		EventWindowCreated,
+		EventWindowRetitled,
+		EventWindowMoved,
+		EventWindowMinimized,
+		EventWorkspaceSwitched,
+		EventWindowFocused,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("diff order = %v, want %v", got, want)
+	}
+}
+
+// TestDiffLifecycleIgnoresNoise verifies changes that are not window lifecycle
+// changes raise nothing, so a TUI syncing on every render does not flood the
+// event stream.
+func TestDiffLifecycleIgnoresNoise(t *testing.T) {
+	base := []WindowState{{ID: "w", PTYID: "p", Workspace: 1, Title: "sh", X: 0, Y: 0, Width: 80, Height: 24}}
+	before := snapshotLifecycle(&SessionState{Windows: base, FocusedWindowID: "w", CurrentWorkspace: 1})
+
+	moved := []WindowState{{ID: "w", PTYID: "p", Workspace: 1, Title: "sh", X: 10, Y: 5, Width: 40, Height: 12, Z: 3, IsAltScreen: true}}
+	after := snapshotLifecycle(&SessionState{Windows: moved, FocusedWindowID: "w", CurrentWorkspace: 1})
+
+	if events := diffLifecycle(before, after); len(events) != 0 {
+		t.Fatalf("geometry/z/alt-screen changes raised events: %+v", events)
+	}
+}
+
+// TestDiffLifecycleIgnoresShellTitle verifies a shell-driven Title change raises
+// nothing from the diff. The per-PTY emitter already reports OSC title changes,
+// so deriving them here as well would report the same change twice.
+func TestDiffLifecycleIgnoresShellTitle(t *testing.T) {
+	before := snapshotLifecycle(&SessionState{
+		Windows:          []WindowState{{ID: "w", PTYID: "p", Workspace: 1, Title: "bash"}},
+		FocusedWindowID:  "w",
+		CurrentWorkspace: 1,
+	})
+	after := snapshotLifecycle(&SessionState{
+		Windows:          []WindowState{{ID: "w", PTYID: "p", Workspace: 1, Title: "vim"}},
+		FocusedWindowID:  "w",
+		CurrentWorkspace: 1,
+	})
+
+	if events := diffLifecycle(before, after); len(events) != 0 {
+		t.Fatalf("shell title change raised events: %+v", events)
+	}
+}
+
+// TestUpdateStateFromDisconnectedClientStillEmits guards the wiring: events must
+// come from the daemon's update-state handler, not from anything TUI-side.
+func TestUpdateStateFromDisconnectedClientStillEmits(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+	sub := subscribeTo(t, sp, "work", EventWindowCreated)
+
+	state := sess.GetState()
+	state.Windows = append(state.Windows, WindowState{ID: "added", PTYID: "pty-added", Workspace: 1, Title: "x"})
+	sess.UpdateState(state)
+
+	events := collectEvents(t, sub, 1, 3*time.Second)
+	if len(events) != 1 || events[0]["window"] != "added" {
+		t.Fatalf("events = %v, want one window-created for 'added'", events)
+	}
+}

--- a/internal/session/state_events_test.go
+++ b/internal/session/state_events_test.go
@@ -466,3 +466,32 @@ func TestUpdateStateFromDisconnectedClientStillEmits(t *testing.T) {
 		t.Fatalf("events = %v, want one window-created for 'added'", events)
 	}
 }
+
+// TestRestoredSessionRaisesWindowCreated pins the documented resurrection
+// behavior: restoring a session raises session-created and then a window-created
+// per restored window, because from a subscriber's point of view those windows
+// come into existence at that moment.
+func TestRestoredSessionRaisesWindowCreated(t *testing.T) {
+	d, sp := startTestDaemon(t)
+
+	sub := dialVerb(t, sp)
+	result(t, sub.call(t, `{"id":1,"verb":"subscribe","params":{"session":"revived","types":["session-created","window-created"]}}`))
+
+	if _, err := d.restoreSession(&SessionState{
+		Name:             "revived",
+		Windows:          []WindowState{{ID: "w1", Title: "one", Width: 80, Height: 24, Workspace: 1}},
+		CurrentWorkspace: 1,
+		Width:            80,
+		Height:           24,
+	}); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+
+	events := collectEvents(t, sub, 2, 3*time.Second)
+	if got := eventTypes(events); !reflect.DeepEqual(got, []string{EventSessionCreated, EventWindowCreated}) {
+		t.Fatalf("event types = %v, want session-created then window-created", got)
+	}
+	if events[1]["window"] != "w1" {
+		t.Errorf("window-created window = %v, want w1", events[1]["window"])
+	}
+}

--- a/internal/session/tuiclient.go
+++ b/internal/session/tuiclient.go
@@ -28,6 +28,11 @@ type ClientLeftHandler func(clientID string, clientCount int)
 type SessionResizeHandler func(width, height, clientCount int)
 type ForceRefreshHandler func(reason string)
 
+// SessionEndedHandler is called when the daemon reports that the attached
+// session was terminated. It runs on the read-loop goroutine, so the handler
+// should only signal the UI (e.g. p.Send), never mutate model state directly.
+type SessionEndedHandler func(sessionName, reason string)
+
 // DisconnectHandler is called once when the read loop tears the connection down
 // because of an unexpected disconnect (daemon crash, reset, or framing desync).
 // It is not called for an app-initiated Close.
@@ -73,6 +78,8 @@ type TUIClient struct {
 	sessionResizeHandler SessionResizeHandler
 	forceRefreshHandler  ForceRefreshHandler
 	disconnectHandler    DisconnectHandler
+	sessionEndedHandler  SessionEndedHandler
+	sessionEndedOnce     sync.Once // gates the single session-ended notification
 	disconnectOnce       sync.Once // gates the single disconnect notification
 	multiClientMu        sync.RWMutex
 
@@ -458,6 +465,14 @@ func (c *TUIClient) OnForceRefresh(handler ForceRefreshHandler) {
 	c.multiClientMu.Unlock()
 }
 
+// OnSessionEnded registers a handler invoked when the daemon reports that the
+// attached session was terminated. It fires at most once per client.
+func (c *TUIClient) OnSessionEnded(handler SessionEndedHandler) {
+	c.multiClientMu.Lock()
+	c.sessionEndedHandler = handler
+	c.multiClientMu.Unlock()
+}
+
 // OnDisconnect registers a handler invoked when the daemon connection is torn
 // down unexpectedly (crash, reset, or framing desync). It fires at most once and
 // runs on the read-loop goroutine, so the handler should only signal the UI
@@ -752,6 +767,27 @@ func (c *TUIClient) handleMessage(msg *Message) {
 		if closedHandler != nil {
 			closedHandler()
 		}
+
+	case MsgSessionEnded:
+		// The attached session was destroyed (killed from the CLI, from another
+		// client, or over the control plane). Notify once so the app can exit;
+		// the connection itself is still usable, so it is not torn down here.
+		var payload SessionEndedPayload
+		if err := msg.ParsePayloadWithCodec(&payload, c.codec); err != nil {
+			debugLog("[CLIENT] Failed to parse session ended: %v", err)
+		}
+		name := payload.SessionName
+		if name == "" {
+			name = c.SessionName()
+		}
+		c.sessionEndedOnce.Do(func() {
+			c.multiClientMu.RLock()
+			handler := c.sessionEndedHandler
+			c.multiClientMu.RUnlock()
+			if handler != nil {
+				handler(name, payload.Reason)
+			}
+		})
 
 	case MsgDetached:
 		// Session detached  - handled via pendingResponses in SwitchSession.

--- a/internal/session/verb_bridge_test.go
+++ b/internal/session/verb_bridge_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+// newFakeTUI registers a connState that looks like an attached TUI client and
+// returns it along with the client-side pipe end the test drives.
+func newFakeTUI(t *testing.T, d *Daemon, sessionID string) (*connState, net.Conn) {
+	t.Helper()
+	serverSide, clientSide := net.Pipe()
+	tui := &connState{
+		conn:             serverSide,
+		clientID:         "fake-tui",
+		done:             make(chan struct{}),
+		codec:            DefaultCodec(),
+		ptySubscriptions: make(map[string]struct{}),
+		sessionID:        sessionID,
+		isTUIClient:      true,
+	}
+	d.clientsMu.Lock()
+	d.clients[tui.clientID] = tui
+	d.clientsMu.Unlock()
+	t.Cleanup(func() { _ = clientSide.Close(); _ = serverSide.Close() })
+	return tui, clientSide
+}
+
+// answerRemoteCommand reads the one remote command the daemon routes to the fake
+// TUI and replies with the given result, mimicking what the real TUI does.
+func answerRemoteCommand(t *testing.T, d *Daemon, tui *connState, clientSide net.Conn, result *CommandResultPayload) {
+	go func() {
+		msg, _, err := ReadMessageWithCodec(clientSide)
+		if err != nil {
+			return
+		}
+		var rc RemoteCommandPayload
+		if err := msg.ParsePayloadWithCodec(&rc, DefaultCodec()); err != nil {
+			return
+		}
+		result.RequestID = rc.RequestID
+		resMsg, err := NewMessage(MsgCommandResult, result)
+		if err != nil {
+			return
+		}
+		_ = d.handleCommandResult(tui, resMsg)
+	}()
+}
+
+func pendingCount(d *Daemon) int {
+	d.pendingRequestsMu.RLock()
+	defer d.pendingRequestsMu.RUnlock()
+	return len(d.pendingRequests)
+}
+
+func TestRouteToTUISyncDeliversResult(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	defer d.manager.Shutdown()
+
+	tui, clientSide := newFakeTUI(t, d, "sess-1")
+	answerRemoteCommand(t, d, tui, clientSide, &CommandResultPayload{
+		Success: true, Message: "done", Data: map[string]any{"window_id": "w-123"},
+	})
+
+	res, err := d.routeToTUISync(tui, "req-abc",
+		&RemoteCommandPayload{CommandType: "tape_command", TapeCommand: "NewWindow"},
+		3*time.Second)
+	if err != nil {
+		t.Fatalf("routeToTUISync: %v", err)
+	}
+	if !res.Success || res.Data["window_id"] != "w-123" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if n := pendingCount(d); n != 0 {
+		t.Errorf("pending requests not cleaned up: %d", n)
+	}
+}
+
+func TestRouteToTUISyncTimeout(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	defer d.manager.Shutdown()
+
+	tui, clientSide := newFakeTUI(t, d, "sess-2")
+	// Drain the command but never reply.
+	go func() { _, _, _ = ReadMessageWithCodec(clientSide) }()
+
+	_, err := d.routeToTUISync(tui, "req-timeout",
+		&RemoteCommandPayload{CommandType: "send_keys", Keys: "x"},
+		150*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if n := pendingCount(d); n != 0 {
+		t.Errorf("pending requests not cleaned up after timeout: %d", n)
+	}
+}
+
+// TestVerbNewWindowRoutesToAttachedTUI verifies that with a TUI attached the
+// new-window verb routes to it (rather than mutating daemon-owned state), so the
+// daemon and the live renderer stay in sync.
+func TestVerbNewWindowRoutesToAttachedTUI(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	defer d.manager.Shutdown()
+
+	sess, err := d.manager.CreateSession("routed", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	tui, clientSide := newFakeTUI(t, d, sess.ID)
+	answerRemoteCommand(t, d, tui, clientSide, &CommandResultPayload{
+		Success: true, Data: map[string]any{"window_id": "tui-win", "name": "build"},
+	})
+
+	requester := &connState{clientID: "ctl", done: make(chan struct{}), codec: DefaultCodec()}
+	out, verr := d.verbNewWindow(requester, json.RawMessage(`{"session":"routed","name":"build"}`))
+	if verr != nil {
+		t.Fatalf("verbNewWindow: %v", verr)
+	}
+	m := out.(map[string]any)
+	if m["window_id"] != "tui-win" {
+		t.Fatalf("expected routed window_id, got %v", m)
+	}
+	// The routed path must not have created a daemon-owned window.
+	if got := len(sess.GetState().Windows); got != 0 {
+		t.Errorf("routed new-window mutated daemon state: %d windows", got)
+	}
+}
+
+// TestVerbSetOptionRecordsAndRoutes verifies set-option records the value in
+// daemon-owned state and reports applied=true when the attached TUI accepts it.
+func TestVerbSetOptionRecordsAndRoutes(t *testing.T) {
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	defer d.manager.Shutdown()
+
+	sess, err := d.manager.CreateSession("cfg", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	tui, clientSide := newFakeTUI(t, d, sess.ID)
+	answerRemoteCommand(t, d, tui, clientSide, &CommandResultPayload{Success: true})
+
+	out, verr := d.verbSetOption(nil, json.RawMessage(`{"session":"cfg","key":"border_style","value":"double"}`))
+	if verr != nil {
+		t.Fatalf("verbSetOption: %v", verr)
+	}
+	m := out.(map[string]any)
+	if m["applied"] != true {
+		t.Errorf("applied = %v, want true", m["applied"])
+	}
+	if v, ok := sess.GetOption("border_style"); !ok || v != "double" {
+		t.Errorf("option not recorded: %q,%v", v, ok)
+	}
+}

--- a/internal/session/verb_client.go
+++ b/internal/session/verb_client.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// VerbClient is a minimal client for the line-delimited JSON verb protocol. It
+// is the counterpart the tuios CLI uses to drive the daemon's control surface.
+// One call is in flight at a time; it is safe for sequential use from a single
+// goroutine (the callMu guards against accidental concurrent Call).
+type VerbClient struct {
+	conn   net.Conn
+	r      *bufio.Reader
+	nextID int
+	callMu sync.Mutex
+}
+
+// VerbCallError is returned by VerbClient.Call when the daemon answers with an
+// error envelope. It exposes the stable string code alongside the message.
+type VerbCallError struct {
+	Code    string
+	Message string
+}
+
+func (e *VerbCallError) Error() string {
+	if e.Code == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
+}
+
+// DialVerbClient connects to the running daemon's socket for JSON verb calls.
+func DialVerbClient() (*VerbClient, error) {
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get socket path: %w", err)
+	}
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	return &VerbClient{conn: conn, r: bufio.NewReader(conn)}, nil
+}
+
+// Close closes the underlying connection.
+func (c *VerbClient) Close() error {
+	if c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+// Call sends a verb request with the given params (may be nil) and returns the
+// raw result object. A daemon error envelope is returned as a *VerbCallError.
+func (c *VerbClient) Call(verb string, params any) (json.RawMessage, error) {
+	c.callMu.Lock()
+	defer c.callMu.Unlock()
+
+	c.nextID++
+	id := c.nextID
+
+	var rawParams json.RawMessage
+	if params != nil {
+		p, err := json.Marshal(params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode params: %w", err)
+		}
+		rawParams = p
+	}
+
+	req := verbRequest{
+		ID:     json.RawMessage(fmt.Sprintf("%d", id)),
+		Verb:   verb,
+		Params: rawParams,
+	}
+	line, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+	line = append(line, '\n')
+
+	_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	if _, err := c.conn.Write(line); err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	_ = c.conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	respLine, err := c.r.ReadBytes('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var resp verbResponse
+	if err := json.Unmarshal(respLine, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, &VerbCallError{Code: resp.Error.Code, Message: resp.Error.Message}
+	}
+
+	rawResult, err := json.Marshal(resp.Result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-encode result: %w", err)
+	}
+	return rawResult, nil
+}

--- a/internal/session/verb_client.go
+++ b/internal/session/verb_client.go
@@ -18,13 +18,19 @@ type VerbClient struct {
 	r      *bufio.Reader
 	nextID int
 	callMu sync.Mutex
+
+	// daemon is what the daemon reported during the hello handshake, or nil
+	// when no handshake was performed.
+	daemon *DaemonHandshake
 }
 
 // VerbCallError is returned by VerbClient.Call when the daemon answers with an
-// error envelope. It exposes the stable string code alongside the message.
+// error envelope. It exposes the stable string code and the structured hint
+// alongside the message, so a caller can render the remedy the daemon named.
 type VerbCallError struct {
 	Code    string
 	Message string
+	Hint    *VerbHint
 }
 
 func (e *VerbCallError) Error() string {
@@ -34,8 +40,20 @@ func (e *VerbCallError) Error() string {
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 
-// DialVerbClient connects to the running daemon's socket for JSON verb calls.
+// DialVerbClient connects to the running daemon's socket for JSON verb calls,
+// without announcing a client version.
 func DialVerbClient() (*VerbClient, error) {
+	return DialVerbClientAs("")
+}
+
+// DialVerbClientAs connects to the running daemon's socket and performs the
+// hello handshake, announcing clientVersion.
+//
+// A daemon too old to speak the JSON protocol fails here with a
+// *ProtocolMismatchError naming both versions and the command that fixes it,
+// rather than surfacing later as an unexplained connection reset. A daemon that
+// speaks the protocol but predates the handshake verb connects normally.
+func DialVerbClientAs(clientVersion string) (*VerbClient, error) {
 	socketPath, err := GetSocketPath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get socket path: %w", err)
@@ -44,8 +62,21 @@ func DialVerbClient() (*VerbClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to daemon: %w", err)
 	}
-	return &VerbClient{conn: conn, r: bufio.NewReader(conn)}, nil
+	c := &VerbClient{conn: conn, r: bufio.NewReader(conn)}
+
+	hs, err := c.handshake(clientVersion)
+	if err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	c.daemon = hs
+	return c, nil
 }
+
+// Daemon returns what the daemon reported during the handshake. Its Protocol is
+// zero when the daemon predates the handshake verb. It is nil only for a client
+// built without dialing.
+func (c *VerbClient) Daemon() *DaemonHandshake { return c.daemon }
 
 // Close closes the underlying connection.
 func (c *VerbClient) Close() error {
@@ -100,7 +131,11 @@ func (c *VerbClient) Call(verb string, params any) (json.RawMessage, error) {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 	if resp.Error != nil {
-		return nil, &VerbCallError{Code: resp.Error.Code, Message: resp.Error.Message}
+		return nil, &VerbCallError{
+			Code:    resp.Error.Code,
+			Message: resp.Error.Message,
+			Hint:    resp.Error.Hint,
+		}
 	}
 
 	rawResult, err := json.Marshal(resp.Result)

--- a/internal/session/verb_compat.go
+++ b/internal/session/verb_compat.go
@@ -1,0 +1,235 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// This file detects the one failure that has no good error message anywhere
+// else: a newly upgraded CLI talking to a daemon that is still running the old
+// binary.
+//
+// The JSON verb protocol distinguishes itself from the binary protocol by its
+// first byte (see detectJSONClient). A daemon that predates the JSON protocol
+// has no such detection: it reads the '{' of the first request line as the high
+// byte of a big-endian length prefix, computes an absurd frame length, gives up,
+// and closes the connection. The client sees "connection reset by peer" or a
+// bare EOF, which explains nothing and suggests nothing.
+//
+// So the client opens with a hello handshake. Three outcomes tell it everything:
+//
+//   - a hello result: the daemon speaks this protocol, and reports its version.
+//   - unknown_verb: a JSON-speaking daemon from before the handshake existed.
+//     Usable, but old; its version comes from the legacy binary handshake.
+//   - the connection dies with nothing read: a daemon from before the JSON
+//     protocol. Its version also comes from the legacy binary handshake, which
+//     every daemon since the beginning answers.
+//
+// Only the last case is fatal, and it is reported as a ProtocolMismatchError
+// carrying both versions and the command that fixes it.
+
+// clientHandshakeTimeout bounds the handshake exchange. It is short because the
+// daemon is a local process on a unix socket: anything slower is a hang, and a
+// hang here would stall every CLI command.
+const clientHandshakeTimeout = 5 * time.Second
+
+// DaemonHandshake is what a daemon reports about itself during the hello
+// exchange.
+type DaemonHandshake struct {
+	// Protocol is the verb protocol version the daemon speaks. Zero means the
+	// daemon answered unknown_verb, i.e. it predates the handshake verb.
+	Protocol int `json:"protocol"`
+	// MinProtocol is the oldest protocol version the daemon still serves.
+	MinProtocol int `json:"min_protocol"`
+	// DaemonVersion is the daemon's build version.
+	DaemonVersion string `json:"daemon_version"`
+	// PID is the daemon process id, so a human can find it.
+	PID int `json:"pid"`
+	// Sessions is how many sessions the daemon currently holds, which is what a
+	// user wants to know before being told to restart it.
+	Sessions int `json:"sessions"`
+}
+
+// ProtocolMismatchError reports that the running daemon cannot speak the control
+// protocol this client uses. It is the specific, actionable form of what would
+// otherwise surface as "connection reset by peer".
+type ProtocolMismatchError struct {
+	// ClientVersion is this binary's version, when the caller supplied one.
+	ClientVersion string
+	// DaemonVersion is the running daemon's version, when it could be learned
+	// from the legacy handshake. Empty when even that failed.
+	DaemonVersion string
+	// DaemonPID identifies the process to restart, when known.
+	DaemonPID int
+	// Sessions is how many sessions the daemon holds, when known, so the
+	// message can say what restarting it costs.
+	Sessions int
+	// ClientProtocol and DaemonProtocol are the two protocol versions. A
+	// DaemonProtocol of 0 means the daemon does not speak the JSON protocol at
+	// all.
+	ClientProtocol int
+	DaemonProtocol int
+	// Cause is the underlying transport or protocol error, kept for wrapping.
+	Cause error
+}
+
+func (e *ProtocolMismatchError) Error() string {
+	var b strings.Builder
+	b.WriteString("the running TUIOS daemon does not speak this CLI's control protocol")
+
+	switch {
+	case e.DaemonVersion != "" && e.ClientVersion != "":
+		fmt.Fprintf(&b, " (daemon %s, CLI %s)", e.DaemonVersion, e.ClientVersion)
+	case e.DaemonVersion != "":
+		fmt.Fprintf(&b, " (daemon %s)", e.DaemonVersion)
+	case e.ClientVersion != "":
+		fmt.Fprintf(&b, " (CLI %s)", e.ClientVersion)
+	}
+
+	b.WriteString(".\nMost likely cause: TUIOS was upgraded while the daemon kept running, so the old daemon is still serving the socket.")
+	b.WriteString("\nFix: run 'tuios kill-server', then run this command again.")
+	if e.Sessions > 0 {
+		fmt.Fprintf(&b, "\nNote: the daemon is holding %d session(s); they are saved and restored when it restarts (see 'tuios resurrect').", e.Sessions)
+	}
+	if e.DaemonPID > 0 {
+		fmt.Fprintf(&b, "\nDaemon PID: %d.", e.DaemonPID)
+	}
+	return b.String()
+}
+
+func (e *ProtocolMismatchError) Unwrap() error { return e.Cause }
+
+// handshake performs the hello exchange on a freshly dialed verb connection.
+//
+// It returns a *ProtocolMismatchError only when the daemon cannot speak the JSON
+// protocol at all. A daemon that answers unknown_verb is older than the
+// handshake but still fully usable, so that returns a zero-protocol handshake
+// and no error: refusing to talk to it would break the compatibility the verb
+// protocol promises.
+func (c *VerbClient) handshake(clientVersion string) (*DaemonHandshake, error) {
+	raw, err := c.Call("hello", map[string]any{
+		"client":   "tuios",
+		"version":  clientVersion,
+		"protocol": VerbProtocolVersion,
+	})
+	if err == nil {
+		var hs DaemonHandshake
+		if uerr := json.Unmarshal(raw, &hs); uerr != nil {
+			return nil, fmt.Errorf("failed to decode daemon handshake: %w", uerr)
+		}
+		return &hs, nil
+	}
+
+	var callErr *VerbCallError
+	if errors.As(err, &callErr) {
+		switch callErr.Code {
+		case ErrVerbUnknownVerb:
+			// A JSON daemon from before the handshake verb. Usable as-is.
+			return &DaemonHandshake{}, nil
+		case ErrVerbProtocolMismatch:
+			// The daemon understood us and refused: it already knows both
+			// versions, so report exactly what it said.
+			return nil, &ProtocolMismatchError{
+				ClientVersion:  clientVersion,
+				ClientProtocol: VerbProtocolVersion,
+				Cause:          err,
+			}
+		}
+		// Any other error envelope means the daemon is speaking the protocol
+		// fine and simply disliked this call; that is not a mismatch.
+		return nil, err
+	}
+
+	if !isConnectionGone(err) {
+		return nil, err
+	}
+
+	// The connection died without a response line, which is exactly what a
+	// pre-JSON daemon does with a request line. Learn its version over the
+	// legacy binary handshake, which every daemon has always answered.
+	mismatch := &ProtocolMismatchError{
+		ClientVersion:  clientVersion,
+		ClientProtocol: VerbProtocolVersion,
+		DaemonPID:      GetDaemonPID(),
+		Cause:          err,
+	}
+	if legacy, lerr := probeLegacyDaemon(clientVersion); lerr == nil {
+		mismatch.DaemonVersion = legacy.Version
+		mismatch.Sessions = len(legacy.SessionNames)
+	}
+	return nil, mismatch
+}
+
+// isConnectionGone reports whether err means the peer hung up or reset the
+// connection rather than answering. Those are the shapes a pre-JSON daemon
+// produces when it chokes on a request line.
+func isConnectionGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// Fall back to the message for platforms and wrappers that do not expose a
+	// comparable sentinel.
+	msg := err.Error()
+	return strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "closed network connection")
+}
+
+// probeLegacyDaemon opens a second connection and performs the binary hello
+// handshake, which every daemon version understands, to learn the running
+// daemon's version. It is only used to enrich a mismatch error, so any failure
+// simply means the version stays unknown.
+func probeLegacyDaemon(clientVersion string) (*WelcomePayload, error) {
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialTimeout("unix", socketPath, clientHandshakeTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	msg, err := NewMessage(MsgHello, &HelloPayload{
+		Version:        clientVersion,
+		Term:           "dumb",
+		Width:          80,
+		Height:         24,
+		PreferredCodec: "gob",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_ = conn.SetWriteDeadline(time.Now().Add(clientHandshakeTimeout))
+	if err := WriteMessage(conn, msg); err != nil {
+		return nil, err
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(clientHandshakeTimeout))
+	resp, _, err := ReadMessageWithCodec(conn)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Type != MsgWelcome {
+		return nil, fmt.Errorf("expected welcome, got message type %d", resp.Type)
+	}
+
+	var welcome WelcomePayload
+	if err := resp.ParsePayload(&welcome); err != nil {
+		return nil, err
+	}
+	return &welcome, nil
+}

--- a/internal/session/verb_compat.go
+++ b/internal/session/verb_compat.go
@@ -81,7 +81,7 @@ type ProtocolMismatchError struct {
 
 func (e *ProtocolMismatchError) Error() string {
 	var b strings.Builder
-	b.WriteString("the running TUIOS daemon does not speak this CLI's control protocol")
+	b.WriteString("The running TUIOS daemon does not speak this CLI's control protocol")
 
 	switch {
 	case e.DaemonVersion != "" && e.ClientVersion != "":

--- a/internal/session/verb_compat_test.go
+++ b/internal/session/verb_compat_test.go
@@ -1,0 +1,308 @@
+package session
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// legacyDaemon is a faithful stand-in for a daemon built before the JSON verb
+// protocol existed. It reproduces the only two behaviors that matter for
+// compatibility detection:
+//
+//   - it answers the binary hello handshake with a welcome carrying its version,
+//     which is how a new client learns what is actually running, and
+//   - it reads every connection as binary frames, so a JSON request line is
+//     decoded as a bogus length prefix and the connection is dropped, exactly as
+//     the old read loop did on a framing error.
+//
+// This is deliberately not a mock of the new daemon with a feature switched off:
+// it is the old wire behavior, so the test proves the client copes with the real
+// upgrade scenario.
+type legacyDaemon struct {
+	ln       net.Listener
+	version  string
+	sessions []string
+}
+
+func startLegacyDaemon(t *testing.T, version string, sessions ...string) *legacyDaemon {
+	t.Helper()
+
+	// Point GetSocketPath at an isolated runtime dir so the fake daemon takes
+	// the place of the real one for this test only.
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		t.Fatalf("GetSocketPath: %v", err)
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	d := &legacyDaemon{ln: ln, version: version, sessions: sessions}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go d.serve()
+	return d
+}
+
+func (d *legacyDaemon) serve() {
+	for {
+		conn, err := d.ln.Accept()
+		if err != nil {
+			return
+		}
+		go d.handle(conn)
+	}
+}
+
+func (d *legacyDaemon) handle(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		msg, _, err := ReadMessageWithCodec(conn)
+		if err != nil {
+			// The old read loop returned here, closing the connection. A JSON
+			// request line lands in exactly this branch: '{' is 0x7b, so the
+			// length prefix reads as ~2GB and fails the 16MB sanity check.
+			return
+		}
+		if msg.Type != MsgHello {
+			continue
+		}
+		welcome, err := NewMessage(MsgWelcome, &WelcomePayload{
+			Version:      d.version,
+			SessionNames: d.sessions,
+			Codec:        "gob",
+		})
+		if err != nil {
+			return
+		}
+		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		if err := WriteMessage(conn, welcome); err != nil {
+			return
+		}
+	}
+}
+
+// TestHandshakeAgainstLegacyDaemonReportsMismatch is the regression test for the
+// bug this work exists to kill: a new CLI against an old still-running daemon
+// used to fail with a bare "failed to read response: connection reset by peer".
+func TestHandshakeAgainstLegacyDaemonReportsMismatch(t *testing.T) {
+	startLegacyDaemon(t, "0.9.0", "work", "notes")
+
+	_, err := DialVerbClientAs("1.4.0")
+	if err == nil {
+		t.Fatal("expected the handshake against a pre-JSON daemon to fail")
+	}
+
+	var mismatch *ProtocolMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected a *ProtocolMismatchError, got %T: %v", err, err)
+	}
+
+	if mismatch.DaemonVersion != "0.9.0" {
+		t.Errorf("daemon version = %q, want 0.9.0 (learned over the legacy handshake)", mismatch.DaemonVersion)
+	}
+	if mismatch.ClientVersion != "1.4.0" {
+		t.Errorf("client version = %q, want 1.4.0", mismatch.ClientVersion)
+	}
+	if mismatch.Sessions != 2 {
+		t.Errorf("sessions = %d, want 2", mismatch.Sessions)
+	}
+
+	// The message is the whole point: it must say what failed, why, and the
+	// exact command that fixes it, naming both versions.
+	msg := mismatch.Error()
+	for _, want := range []string{
+		"does not speak this CLI's control protocol",
+		"daemon 0.9.0",
+		"CLI 1.4.0",
+		"upgraded while the daemon kept running",
+		"tuios kill-server",
+		"2 session(s)",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("mismatch message missing %q\n--- message ---\n%s", want, msg)
+		}
+	}
+
+	// It must not surface as the raw transport error a user cannot act on.
+	if strings.Contains(msg, "failed to read response") {
+		t.Errorf("mismatch message leaked the raw transport error:\n%s", msg)
+	}
+}
+
+// TestHandshakeAgainstCurrentDaemonSucceeds pins the happy path: a current
+// daemon answers hello with its protocol range and identity.
+func TestHandshakeAgainstCurrentDaemonSucceeds(t *testing.T) {
+	startTestDaemon(t)
+
+	client, err := DialVerbClientAs("1.4.0")
+	if err != nil {
+		t.Fatalf("handshake against the current daemon failed: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	hs := client.Daemon()
+	if hs == nil {
+		t.Fatal("expected a handshake result")
+	}
+	if hs.Protocol != VerbProtocolVersion {
+		t.Errorf("protocol = %d, want %d", hs.Protocol, VerbProtocolVersion)
+	}
+	if hs.MinProtocol != MinVerbProtocolVersion {
+		t.Errorf("min protocol = %d, want %d", hs.MinProtocol, MinVerbProtocolVersion)
+	}
+	if hs.DaemonVersion != "test" {
+		t.Errorf("daemon version = %q, want test", hs.DaemonVersion)
+	}
+	if hs.PID != os.Getpid() {
+		t.Errorf("pid = %d, want %d", hs.PID, os.Getpid())
+	}
+}
+
+// TestHelloRejectsNewerClientProtocol covers the other direction of the
+// handshake: a daemon that is asked for a protocol it does not implement says so
+// with the protocol_mismatch code and the kill-server remedy, instead of
+// accepting the call and misbehaving later.
+func TestHelloRejectsNewerClientProtocol(t *testing.T) {
+	_, socketPath := startTestDaemon(t)
+	c := dialVerb(t, socketPath)
+
+	resp := c.call(t, `{"id":1,"verb":"hello","params":{"client":"tuios","version":"9.9.9","protocol":99}}`)
+	e := errorOf(t, resp)
+
+	if code, _ := e["code"].(string); code != ErrVerbProtocolMismatch {
+		t.Fatalf("code = %v, want %s", e["code"], ErrVerbProtocolMismatch)
+	}
+	hint, ok := e["hint"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a hint on a protocol mismatch, got %v", e)
+	}
+	if cmd, _ := hint["command"].(string); cmd != "tuios kill-server" {
+		t.Errorf("hint command = %v, want tuios kill-server", hint["command"])
+	}
+	if detail, _ := hint["detail"].(string); !strings.Contains(detail, "9.9.9") {
+		t.Errorf("hint detail should name the client version, got %v", hint["detail"])
+	}
+}
+
+// TestHandshakeToleratesDaemonWithoutHelloVerb proves the handshake is a
+// compatibility check and not a new requirement: a daemon that speaks the verb
+// protocol but has never heard of hello answers unknown_verb, and the client
+// treats it as usable rather than refusing to talk to it.
+func TestHandshakeToleratesDaemonWithoutHelloVerb(t *testing.T) {
+	startTestDaemon(t)
+
+	// Temporarily remove the hello verb from the registry to reproduce a daemon
+	// built before the handshake existed.
+	entry := verbRegistry["hello"]
+	delete(verbRegistry, "hello")
+	t.Cleanup(func() { verbRegistry["hello"] = entry })
+
+	client, err := DialVerbClientAs("1.4.0")
+	if err != nil {
+		t.Fatalf("a daemon without the hello verb must still be usable, got: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if hs := client.Daemon(); hs == nil || hs.Protocol != 0 {
+		t.Errorf("expected a zero-protocol handshake for a pre-handshake daemon, got %+v", hs)
+	}
+
+	// And it must actually work, not just connect.
+	if _, err := client.Call("list-sessions", nil); err != nil {
+		t.Errorf("list-sessions against a pre-handshake daemon failed: %v", err)
+	}
+}
+
+// TestDialVerbClientReportsMissingDaemon checks the plain "nothing is listening"
+// case still produces a connect error rather than a mismatch, so the two states
+// stay distinguishable to the CLI.
+func TestDialVerbClientReportsMissingDaemon(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	_, err := DialVerbClientAs("1.4.0")
+	if err == nil {
+		t.Fatal("expected an error dialing a socket that does not exist")
+	}
+	var mismatch *ProtocolMismatchError
+	if errors.As(err, &mismatch) {
+		t.Fatalf("a missing daemon must not be reported as a protocol mismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to connect to daemon") {
+		t.Errorf("error = %q, want a connect failure", err)
+	}
+}
+
+// TestProbeLegacyDaemonIgnoresStaleSocket makes sure the version probe cannot
+// hang or panic when the socket file exists but nothing is listening, which is
+// the stale-socket state the CLI also has to explain.
+func TestProbeLegacyDaemonIgnoresStaleSocket(t *testing.T) {
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	socketPath, err := GetSocketPath()
+	if err != nil {
+		t.Fatalf("GetSocketPath: %v", err)
+	}
+	if err := os.WriteFile(socketPath, nil, 0o600); err != nil {
+		t.Fatalf("write stale socket: %v", err)
+	}
+	if filepath.Dir(socketPath) != filepath.Join(runtimeDir, "tuios") {
+		t.Fatalf("socket path %q escaped the isolated runtime dir", socketPath)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = probeLegacyDaemon("1.4.0")
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("probeLegacyDaemon hung on a stale socket")
+	}
+}
+
+// TestVerbCallErrorCarriesHint checks the hint survives the client decode, so
+// the CLI can render the remedy the daemon named rather than inventing one.
+func TestVerbCallErrorCarriesHint(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	client, err := DialVerbClientAs("test")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.Call("list-windows", map[string]any{"session": "wrok"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown session")
+	}
+	var callErr *VerbCallError
+	if !errors.As(err, &callErr) {
+		t.Fatalf("expected a *VerbCallError, got %T", err)
+	}
+	if callErr.Code != ErrVerbSessionNotFound {
+		t.Errorf("code = %q, want %q", callErr.Code, ErrVerbSessionNotFound)
+	}
+	if callErr.Hint == nil {
+		t.Fatal("hint did not survive the client decode")
+	}
+	if callErr.Hint.DidYouMean != "work" {
+		t.Errorf("did_you_mean = %q, want work", callErr.Hint.DidYouMean)
+	}
+	if !slices.Contains(callErr.Hint.Available, "work") {
+		t.Errorf("available = %v, want it to contain work", callErr.Hint.Available)
+	}
+}

--- a/internal/session/verb_compat_test.go
+++ b/internal/session/verb_compat_test.go
@@ -122,7 +122,7 @@ func TestHandshakeAgainstLegacyDaemonReportsMismatch(t *testing.T) {
 	// exact command that fixes it, naming both versions.
 	msg := mismatch.Error()
 	for _, want := range []string{
-		"does not speak this CLI's control protocol",
+		"The running TUIOS daemon does not speak this CLI's control protocol",
 		"daemon 0.9.0",
 		"CLI 1.4.0",
 		"upgraded while the daemon kept running",

--- a/internal/session/verb_handlers.go
+++ b/internal/session/verb_handlers.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"encoding/json"
-	"sort"
+	"errors"
 	"strings"
 	"time"
 
@@ -13,12 +13,6 @@ import (
 // that client's result before failing with command_failed.
 const routedVerbTimeout = 10 * time.Second
 
-// sortVerbEntries sorts the list-verbs output by verb name for deterministic
-// output.
-func sortVerbEntries(verbs []map[string]string) {
-	sort.Slice(verbs, func(i, j int) bool { return verbs[i]["verb"] < verbs[j]["verb"] })
-}
-
 // decodeParams unmarshals a request's params into v, returning an invalid_params
 // error on failure. Empty params decode to the zero value of v.
 func decodeParams(params json.RawMessage, v any) *verbError {
@@ -26,35 +20,96 @@ func decodeParams(params json.RawMessage, v any) *verbError {
 		return nil
 	}
 	if err := json.Unmarshal(params, v); err != nil {
-		return newVerbError(ErrVerbInvalidParams, "could not decode params: "+err.Error())
+		return hintedVerbError(ErrVerbInvalidParams, "could not decode params: "+err.Error(), &VerbHint{
+			Verb:   "list-verbs",
+			Detail: "Call list-verbs to get this verb's parameter schema, including each parameter's type.",
+		})
 	}
 	return nil
 }
 
 // resolveVerbSession resolves a session name (empty means most recently active)
-// to a live session, or a session_not_found error.
+// to a live session, or a session_not_found error whose hint lists the sessions
+// that do exist and suggests the closest name.
 func (d *Daemon) resolveVerbSession(name string) (*Session, *verbError) {
 	sess := d.findTargetSession(name)
-	if sess == nil {
-		if name == "" {
-			return nil, newVerbError(ErrVerbSessionNotFound, "no sessions exist")
-		}
-		return nil, newVerbError(ErrVerbSessionNotFound, "session "+name+" not found")
+	if sess != nil {
+		return sess, nil
 	}
-	return sess, nil
+
+	available := d.sessionNames()
+	if name == "" {
+		return nil, hintedVerbError(ErrVerbSessionNotFound, "no sessions exist", &VerbHint{
+			Param:   "session",
+			Command: "tuios new --detach",
+			Detail:  "The daemon is running but holds no sessions. Create one, or restore a saved one with 'tuios resurrect'.",
+		})
+	}
+	return nil, hintedVerbError(ErrVerbSessionNotFound, "session "+name+" not found", &VerbHint{
+		Param:      "session",
+		Command:    "tuios ls",
+		DidYouMean: closestMatch(name, available),
+		Available:  available,
+	})
 }
 
-// mapResolveErr classifies a window/PTY resolution error into a stable code.
-func mapResolveErr(err error) *verbError {
+// mapResolveErr classifies a window/PTY resolution error into a stable code and
+// attaches the remedy for that class. sess may be nil when the caller has no
+// session context, in which case the available-window list is omitted.
+func mapResolveErr(err error, sess *Session) *verbError {
 	msg := err.Error()
+
+	// A command that genuinely needs a renderer is its own class: the caller has
+	// to attach a client, not fix a parameter.
+	var needsClient errNeedsClient
+	if errors.As(err, &needsClient) {
+		hint := &VerbHint{
+			Command: "tuios attach",
+			Detail:  "This command changes what is drawn on screen, so it only runs with a client attached. Attach to the session, then retry.",
+		}
+		if sess != nil {
+			hint.Command = "tuios attach " + sess.Name
+		}
+		return hintedVerbError(ErrVerbNeedsClient, msg, hint)
+	}
+
 	switch {
 	case strings.Contains(msg, "no windows"):
-		return newVerbError(ErrVerbNoWindows, msg)
+		return hintedVerbError(ErrVerbNoWindows, msg, &VerbHint{
+			Verb:    "new-window",
+			Command: "tuios run-command NewWindow",
+			Detail:  "The session exists but holds no windows. Create one before addressing a window.",
+		})
 	case strings.Contains(msg, "has no PTY"), strings.Contains(msg, "is gone"):
-		return newVerbError(ErrVerbPTYNotFound, msg)
+		return hintedVerbError(ErrVerbPTYNotFound, msg, &VerbHint{
+			Verb:   "list-windows",
+			Detail: "The window exists but its shell has already exited, so there is nothing to write to. Close it or create a new window.",
+		})
 	default:
-		return newVerbError(ErrVerbWindowNotFound, msg)
+		hint := &VerbHint{Param: "window", Verb: "list-windows", Command: "tuios list-windows --json"}
+		if sess != nil {
+			hint.Available = windowTargets(sess.GetState())
+			hint.DidYouMean = closestMatch(targetFromError(msg), hint.Available)
+		}
+		return hintedVerbError(ErrVerbWindowNotFound, msg, hint)
 	}
+}
+
+// targetFromError extracts the window target from a resolution error message so
+// a did-you-mean suggestion can be computed. Every resolution error quotes the
+// target it failed on (`no window found matching "build"`), so the first quoted
+// run is the target. A message without one yields no target and therefore no
+// suggestion, which is the safe outcome.
+func targetFromError(msg string) string {
+	_, rest, ok := strings.Cut(msg, `"`)
+	if !ok {
+		return ""
+	}
+	target, _, ok := strings.Cut(rest, `"`)
+	if !ok {
+		return ""
+	}
+	return target
 }
 
 // commonParams are the fields shared by session/window-targeted verbs.
@@ -146,7 +201,7 @@ func (d *Daemon) verbNewWindow(_ *connState, params json.RawMessage) (any, *verb
 	onExit := func(ptyID string) { d.notifyPTYClosed(sess.ID, ptyID) }
 	data, err := d.executeDaemonCommand(sess, "NewWindow", args, onExit)
 	if err != nil {
-		return nil, newVerbError(ErrVerbInternal, err.Error())
+		return nil, mapResolveErr(err, sess)
 	}
 	out := map[string]any{"type": "window_created"}
 	for k, v := range data {
@@ -187,7 +242,7 @@ func (d *Daemon) verbCloseWindow(_ *connState, params json.RawMessage) (any, *ve
 
 	onExit := func(ptyID string) { d.notifyPTYClosed(sess.ID, ptyID) }
 	if _, err := d.executeDaemonCommand(sess, "CloseWindow", args, onExit); err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 	return map[string]any{"type": "ok"}, nil
 }
@@ -204,7 +259,7 @@ func (d *Daemon) verbSendKeys(_ *connState, params json.RawMessage) (any, *verbE
 		return nil, verr
 	}
 	if p.Keys == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "keys is required")
+		return nil, invalidParam("keys", `keys is required, e.g. "ls,Enter" or "ctrl+c"`)
 	}
 	sess, verr := d.resolveVerbSession(p.Session)
 	if verr != nil {
@@ -238,7 +293,7 @@ func (d *Daemon) verbSendKeys(_ *connState, params json.RawMessage) (any, *verbE
 	}
 
 	if err := d.sendKeysDaemonSide(sess, payload); err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 	return map[string]any{"type": "ok"}, nil
 }
@@ -262,7 +317,7 @@ func (d *Daemon) verbSendText(_ *connState, params json.RawMessage) (any, *verbE
 	// straight to the daemon-owned PTY.
 	pty, err := d.resolvePTYForTarget(sess, p.Window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 	if _, err := pty.Write([]byte(p.Text)); err != nil {
 		return nil, newVerbError(ErrVerbInternal, err.Error())
@@ -292,7 +347,7 @@ func (d *Daemon) verbCapturePane(_ *connState, params json.RawMessage) (any, *ve
 
 	pty, err := d.resolvePTYForTarget(sess, p.Window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 
 	scrollback := p.Scrollback || p.Source == "recent" || p.Source == "recent-unwrapped"
@@ -327,7 +382,7 @@ func (d *Daemon) verbResize(_ *connState, params json.RawMessage) (any, *verbErr
 		return nil, verr
 	}
 	if p.Width <= 0 || p.Height <= 0 {
-		return nil, newVerbError(ErrVerbInvalidParams, "width and height must be positive")
+		return nil, invalidParam("width", "width and height must both be positive")
 	}
 	sess, verr := d.resolveVerbSession(p.Session)
 	if verr != nil {
@@ -335,7 +390,7 @@ func (d *Daemon) verbResize(_ *connState, params json.RawMessage) (any, *verbErr
 	}
 	pty, err := d.resolvePTYForTarget(sess, p.Window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 	if err := pty.Resize(p.Width, p.Height); err != nil {
 		return nil, newVerbError(ErrVerbInternal, err.Error())
@@ -351,10 +406,18 @@ func (d *Daemon) verbKillSession(_ *connState, params json.RawMessage) (any, *ve
 		return nil, verr
 	}
 	if p.Session == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "session is required")
+		return nil, hintedVerbError(ErrVerbInvalidParams,
+			"session is required (kill-session never guesses which session to destroy)",
+			&VerbHint{Param: "session", Command: "tuios ls", Available: d.sessionNames()})
 	}
 	if err := d.manager.DeleteSession(p.Session); err != nil {
-		return nil, newVerbError(ErrVerbSessionNotFound, err.Error())
+		available := d.sessionNames()
+		return nil, hintedVerbError(ErrVerbSessionNotFound, err.Error(), &VerbHint{
+			Param:      "session",
+			Command:    "tuios ls",
+			DidYouMean: closestMatch(p.Session, available),
+			Available:  available,
+		})
 	}
 	return map[string]any{"type": "ok"}, nil
 }
@@ -369,7 +432,7 @@ func (d *Daemon) verbSetOption(_ *connState, params json.RawMessage) (any, *verb
 		return nil, verr
 	}
 	if p.Key == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "key is required")
+		return nil, invalidParam("key", `key is required, e.g. "appearance.dockbar_position"`)
 	}
 	sess, verr := d.resolveVerbSession(p.Session)
 	if verr != nil {
@@ -404,7 +467,7 @@ func (d *Daemon) verbGetOption(_ *connState, params json.RawMessage) (any, *verb
 		return nil, verr
 	}
 	if p.Key == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "key is required")
+		return nil, invalidParam("key", `key is required, e.g. "appearance.dockbar_position"`)
 	}
 	sess, verr := d.resolveVerbSession(p.Session)
 	if verr != nil {
@@ -412,7 +475,15 @@ func (d *Daemon) verbGetOption(_ *connState, params json.RawMessage) (any, *verb
 	}
 	value, ok := sess.GetOption(p.Key)
 	if !ok {
-		return nil, newVerbError(ErrVerbOptionNotFound, "option "+p.Key+" is not set")
+		available := sess.OptionKeys()
+		return nil, hintedVerbError(ErrVerbOptionNotFound, "option "+p.Key+" is not set on session "+sess.Name, &VerbHint{
+			Param:      "key",
+			Verb:       "set-option",
+			Command:    "tuios set-config " + p.Key + " <value>",
+			DidYouMean: closestMatch(p.Key, available),
+			Available:  available,
+			Detail:     "get-option only reads options previously set through set-option on this session; it does not read the config file.",
+		})
 	}
 	return map[string]any{"type": "option", "key": p.Key, "value": value}, nil
 }

--- a/internal/session/verb_handlers.go
+++ b/internal/session/verb_handlers.go
@@ -1,0 +1,462 @@
+package session
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// routedVerbTimeout bounds how long a verb routed to an attached TUI waits for
+// that client's result before failing with command_failed.
+const routedVerbTimeout = 10 * time.Second
+
+// sortVerbEntries sorts the list-verbs output by verb name for deterministic
+// output.
+func sortVerbEntries(verbs []map[string]string) {
+	sort.Slice(verbs, func(i, j int) bool { return verbs[i]["verb"] < verbs[j]["verb"] })
+}
+
+// decodeParams unmarshals a request's params into v, returning an invalid_params
+// error on failure. Empty params decode to the zero value of v.
+func decodeParams(params json.RawMessage, v any) *verbError {
+	if len(params) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(params, v); err != nil {
+		return newVerbError(ErrVerbInvalidParams, "could not decode params: "+err.Error())
+	}
+	return nil
+}
+
+// resolveVerbSession resolves a session name (empty means most recently active)
+// to a live session, or a session_not_found error.
+func (d *Daemon) resolveVerbSession(name string) (*Session, *verbError) {
+	sess := d.findTargetSession(name)
+	if sess == nil {
+		if name == "" {
+			return nil, newVerbError(ErrVerbSessionNotFound, "no sessions exist")
+		}
+		return nil, newVerbError(ErrVerbSessionNotFound, "session "+name+" not found")
+	}
+	return sess, nil
+}
+
+// mapResolveErr classifies a window/PTY resolution error into a stable code.
+func mapResolveErr(err error) *verbError {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "no windows"):
+		return newVerbError(ErrVerbNoWindows, msg)
+	case strings.Contains(msg, "has no PTY"), strings.Contains(msg, "is gone"):
+		return newVerbError(ErrVerbPTYNotFound, msg)
+	default:
+		return newVerbError(ErrVerbWindowNotFound, msg)
+	}
+}
+
+// commonParams are the fields shared by session/window-targeted verbs.
+type commonParams struct {
+	Session string `json:"session"`
+	Window  string `json:"window"`
+}
+
+func (d *Daemon) verbListSessions(_ *connState, _ json.RawMessage) (any, *verbError) {
+	return map[string]any{
+		"type":     "session_list",
+		"sessions": d.manager.ListSessions(),
+	}, nil
+}
+
+func (d *Daemon) verbSessionInfo(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+	hasClient := d.findTUIClient(sess.ID) != nil
+	data := buildSessionInfoData(sess, sess.GetState(), hasClient)
+	data["type"] = "session_info"
+	return data, nil
+}
+
+func (d *Daemon) verbListWindows(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+	data := buildWindowListData(sess.GetState())
+	data["type"] = "window_list"
+	return data, nil
+}
+
+func (d *Daemon) verbNewWindow(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Name    string `json:"name"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	var args []string
+	if p.Name != "" {
+		args = []string{p.Name}
+	}
+
+	// With a TUI attached, route so the daemon and the live renderer stay in
+	// sync (the TUI overwrites daemon state on its next sync). Headless, create
+	// the window directly against daemon-owned state.
+	if tui := d.findTUIClient(sess.ID); tui != nil {
+		res, err := d.routeToTUISync(tui, uuid.New().String(), &RemoteCommandPayload{
+			CommandType: "tape_command",
+			TapeCommand: "NewWindow",
+			TapeArgs:    args,
+		}, routedVerbTimeout)
+		if err != nil {
+			return nil, newVerbError(ErrVerbCommandFailed, err.Error())
+		}
+		if !res.Success {
+			return nil, newVerbError(ErrVerbCommandFailed, res.Message)
+		}
+		out := map[string]any{"type": "window_created"}
+		for k, v := range res.Data {
+			out[k] = v
+		}
+		return out, nil
+	}
+
+	onExit := func(ptyID string) { d.notifyPTYClosed(sess.ID, ptyID) }
+	data, err := d.executeDaemonCommand(sess, "NewWindow", args, onExit)
+	if err != nil {
+		return nil, newVerbError(ErrVerbInternal, err.Error())
+	}
+	out := map[string]any{"type": "window_created"}
+	for k, v := range data {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (d *Daemon) verbCloseWindow(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p commonParams
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	var args []string
+	if p.Window != "" {
+		args = []string{p.Window}
+	}
+
+	if tui := d.findTUIClient(sess.ID); tui != nil {
+		res, err := d.routeToTUISync(tui, uuid.New().String(), &RemoteCommandPayload{
+			CommandType: "tape_command",
+			TapeCommand: "CloseWindow",
+			TapeArgs:    args,
+		}, routedVerbTimeout)
+		if err != nil {
+			return nil, newVerbError(ErrVerbCommandFailed, err.Error())
+		}
+		if !res.Success {
+			return nil, newVerbError(ErrVerbCommandFailed, res.Message)
+		}
+		return map[string]any{"type": "ok"}, nil
+	}
+
+	onExit := func(ptyID string) { d.notifyPTYClosed(sess.ID, ptyID) }
+	if _, err := d.executeDaemonCommand(sess, "CloseWindow", args, onExit); err != nil {
+		return nil, mapResolveErr(err)
+	}
+	return map[string]any{"type": "ok"}, nil
+}
+
+func (d *Daemon) verbSendKeys(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Window  string `json:"window"`
+		Keys    string `json:"keys"`
+		Literal bool   `json:"literal"`
+		Raw     bool   `json:"raw"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.Keys == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "keys is required")
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	payload := &SendKeysPayload{
+		Keys:         p.Keys,
+		Literal:      p.Literal,
+		Raw:          p.Raw,
+		WindowTarget: p.Window,
+	}
+
+	// Route to the TUI when attached so window-manager keys (the prefix) are
+	// honored; otherwise write the parsed bytes straight to the target PTY.
+	if tui := d.findTUIClient(sess.ID); tui != nil {
+		res, err := d.routeToTUISync(tui, uuid.New().String(), &RemoteCommandPayload{
+			CommandType:  "send_keys",
+			Keys:         p.Keys,
+			Literal:      p.Literal,
+			Raw:          p.Raw,
+			WindowTarget: p.Window,
+		}, routedVerbTimeout)
+		if err != nil {
+			return nil, newVerbError(ErrVerbCommandFailed, err.Error())
+		}
+		if !res.Success {
+			return nil, newVerbError(ErrVerbCommandFailed, res.Message)
+		}
+		return map[string]any{"type": "ok"}, nil
+	}
+
+	if err := d.sendKeysDaemonSide(sess, payload); err != nil {
+		return nil, mapResolveErr(err)
+	}
+	return map[string]any{"type": "ok"}, nil
+}
+
+func (d *Daemon) verbSendText(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Window  string `json:"window"`
+		Text    string `json:"text"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	// Literal text is always safe to write to a PTY whether or not a TUI is
+	// attached (the TUI just renders the PTY's output), so send-text goes
+	// straight to the daemon-owned PTY.
+	pty, err := d.resolvePTYForTarget(sess, p.Window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+	if _, err := pty.Write([]byte(p.Text)); err != nil {
+		return nil, newVerbError(ErrVerbInternal, err.Error())
+	}
+	return map[string]any{"type": "ok"}, nil
+}
+
+func (d *Daemon) verbCapturePane(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session    string `json:"session"`
+		Window     string `json:"window"`
+		Source     string `json:"source"`     // visible | recent | recent-unwrapped
+		Styled     bool   `json:"styled"`     // include ANSI styling
+		Scrollback bool   `json:"scrollback"` // alias for source=recent
+		ANSI       bool   `json:"ansi"`       // alias for styled
+		Lines      int    `json:"lines"`      // if >0, keep only the last N lines
+		Start      int    `json:"start"`      // 1-based inclusive region start
+		End        int    `json:"end"`        // 1-based inclusive region end
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	pty, err := d.resolvePTYForTarget(sess, p.Window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+
+	scrollback := p.Scrollback || p.Source == "recent" || p.Source == "recent-unwrapped"
+	ansi := p.Styled || p.ANSI
+	content := pty.CaptureContent(scrollback, ansi)
+	content = sliceCaptureLines(content, p.Start, p.End, p.Lines)
+
+	source := p.Source
+	if source == "" {
+		if scrollback {
+			source = "recent"
+		} else {
+			source = "visible"
+		}
+	}
+	return map[string]any{
+		"type":    "pane_content",
+		"content": content,
+		"source":  source,
+		"styled":  ansi,
+	}, nil
+}
+
+func (d *Daemon) verbResize(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Window  string `json:"window"`
+		Width   int    `json:"width"`
+		Height  int    `json:"height"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.Width <= 0 || p.Height <= 0 {
+		return nil, newVerbError(ErrVerbInvalidParams, "width and height must be positive")
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+	pty, err := d.resolvePTYForTarget(sess, p.Window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+	if err := pty.Resize(p.Width, p.Height); err != nil {
+		return nil, newVerbError(ErrVerbInternal, err.Error())
+	}
+	return map[string]any{"type": "resized", "width": p.Width, "height": p.Height}, nil
+}
+
+func (d *Daemon) verbKillSession(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.Session == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "session is required")
+	}
+	if err := d.manager.DeleteSession(p.Session); err != nil {
+		return nil, newVerbError(ErrVerbSessionNotFound, err.Error())
+	}
+	return map[string]any{"type": "ok"}, nil
+}
+
+func (d *Daemon) verbSetOption(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Key     string `json:"key"`
+		Value   string `json:"value"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.Key == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "key is required")
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	// Record the option in daemon-owned state so get-option can read it back.
+	sess.SetOption(p.Key, p.Value)
+
+	// When a TUI is attached, also route the change so options it understands
+	// apply to the live renderer. A routing failure is not fatal: the option is
+	// still recorded, so applied reflects only whether the live apply succeeded.
+	applied := false
+	if tui := d.findTUIClient(sess.ID); tui != nil {
+		res, err := d.routeToTUISync(tui, uuid.New().String(), &RemoteCommandPayload{
+			CommandType: "set_config",
+			ConfigPath:  p.Key,
+			ConfigValue: p.Value,
+		}, routedVerbTimeout)
+		applied = err == nil && res != nil && res.Success
+	}
+
+	return map[string]any{"type": "option_set", "key": p.Key, "value": p.Value, "applied": applied}, nil
+}
+
+func (d *Daemon) verbGetOption(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Key     string `json:"key"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.Key == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "key is required")
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+	value, ok := sess.GetOption(p.Key)
+	if !ok {
+		return nil, newVerbError(ErrVerbOptionNotFound, "option "+p.Key+" is not set")
+	}
+	return map[string]any{"type": "option", "key": p.Key, "value": value}, nil
+}
+
+// sliceCaptureLines applies the optional region/lines selection to captured
+// content. start/end are 1-based inclusive line numbers; when both are zero the
+// region is ignored. lines, when > 0 and no region is given, keeps only the last
+// N lines. It preserves a trailing newline when the input had one.
+func sliceCaptureLines(content string, start, end, lines int) string {
+	if start <= 0 && end <= 0 && lines <= 0 {
+		return content
+	}
+
+	trailing := strings.HasSuffix(content, "\n")
+	body := content
+	if trailing {
+		body = strings.TrimSuffix(body, "\n")
+	}
+	split := strings.Split(body, "\n")
+
+	var selected []string
+	switch {
+	case start > 0 || end > 0:
+		lo := start
+		if lo <= 0 {
+			lo = 1
+		}
+		hi := end
+		if hi <= 0 || hi > len(split) {
+			hi = len(split)
+		}
+		if lo > len(split) || lo > hi {
+			return ""
+		}
+		selected = split[lo-1 : hi]
+	case lines > 0 && lines < len(split):
+		selected = split[len(split)-lines:]
+	default:
+		selected = split
+	}
+
+	out := strings.Join(selected, "\n")
+	if trailing && out != "" {
+		out += "\n"
+	}
+	return out
+}

--- a/internal/session/verb_handlers.go
+++ b/internal/session/verb_handlers.go
@@ -50,6 +50,7 @@ func (d *Daemon) resolveVerbSession(name string) (*Session, *verbError) {
 		Command:    "tuios ls",
 		DidYouMean: closestMatch(name, available),
 		Available:  available,
+		Detail:     "the name matches no live session. A session that was killed is gone; one that was never started may still have saved state ('tuios resurrect').",
 	})
 }
 
@@ -86,7 +87,12 @@ func mapResolveErr(err error, sess *Session) *verbError {
 			Detail: "The window exists but its shell has already exited, so there is nothing to write to. Close it or create a new window.",
 		})
 	default:
-		hint := &VerbHint{Param: "window", Verb: "list-windows", Command: "tuios list-windows --json"}
+		hint := &VerbHint{
+			Param:   "window",
+			Verb:    "list-windows",
+			Command: "tuios list-windows --json",
+			Detail:  "the window target matched no window. A window is addressable by its id, a unique id prefix, or its exact name.",
+		}
 		if sess != nil {
 			hint.Available = windowTargets(sess.GetState())
 			hint.DidYouMean = closestMatch(targetFromError(msg), hint.Available)

--- a/internal/session/verb_handlers.go
+++ b/internal/session/verb_handlers.go
@@ -335,7 +335,7 @@ func (d *Daemon) verbCapturePane(_ *connState, params json.RawMessage) (any, *ve
 	var p struct {
 		Session    string `json:"session"`
 		Window     string `json:"window"`
-		Source     string `json:"source"`     // visible | recent | recent-unwrapped
+		Source     string `json:"source"`     // visible | recent
 		Styled     bool   `json:"styled"`     // include ANSI styling
 		Scrollback bool   `json:"scrollback"` // alias for source=recent
 		ANSI       bool   `json:"ansi"`       // alias for styled
@@ -344,6 +344,9 @@ func (d *Daemon) verbCapturePane(_ *connState, params json.RawMessage) (any, *ve
 		End        int    `json:"end"`        // 1-based inclusive region end
 	}
 	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if verr := validateCaptureSource(p.Source); verr != nil {
 		return nil, verr
 	}
 	sess, verr := d.resolveVerbSession(p.Session)
@@ -356,7 +359,7 @@ func (d *Daemon) verbCapturePane(_ *connState, params json.RawMessage) (any, *ve
 		return nil, mapResolveErr(err, sess)
 	}
 
-	scrollback := p.Scrollback || p.Source == "recent" || p.Source == "recent-unwrapped"
+	scrollback := p.Scrollback || p.Source == "recent"
 	ansi := p.Styled || p.ANSI
 	content := pty.CaptureContent(scrollback, ansi)
 	content = sliceCaptureLines(content, p.Start, p.End, p.Lines)

--- a/internal/session/verb_hints.go
+++ b/internal/session/verb_hints.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -19,7 +21,17 @@ import (
 // invalid_params hint, so the two can never drift apart.
 var (
 	// captureSources are the buffers capture-pane can read.
-	captureSources = []string{"visible", "recent", "recent-unwrapped"}
+	captureSources = []string{"visible", "recent"}
+	// retiredCaptureSources maps a capture source that was once accepted to the
+	// reason it no longer is, so the rejection can say what happened rather than
+	// only listing what is allowed. "recent-unwrapped" was documented as reserved
+	// and behaved as a silent alias for "recent"; the emulator does not record
+	// which rows are soft wrapped (the scrollback wrap flag is written as a
+	// constant and the live screen carries none), so unwrapping cannot be
+	// implemented without guessing at row boundaries.
+	retiredCaptureSources = map[string]string{
+		"recent-unwrapped": "unwrapped capture is not implemented; it previously returned the same physical rows as \"recent\" without unwrapping them",
+	}
 	// waitConditions are the conditions wait-for understands.
 	waitConditions = []string{"session-exists", "window-output", "window-exit", "window-idle"}
 	// knownEventTypes are the event types a subscribe filter can name.
@@ -101,6 +113,32 @@ func invalidParam(param, message string, accepted ...string) *verbError {
 		Accepted: accepted,
 		Verb:     "list-verbs",
 	})
+}
+
+// validateCaptureSource checks a capture-pane source against the accepted set.
+// An empty source is valid and means the default. A source that was once
+// accepted is rejected with the reason it went away, so a caller that was
+// relying on it learns why rather than only what to use instead.
+func validateCaptureSource(source string) *verbError {
+	if source == "" || slices.Contains(captureSources, source) {
+		return nil
+	}
+	msg := "unknown capture source " + strconv.Quote(source)
+	hint := &VerbHint{
+		Param:    "source",
+		Accepted: captureSources,
+		Verb:     "list-verbs",
+	}
+	if reason, retired := retiredCaptureSources[source]; retired {
+		// A retired value is a closed-set miss with history: name the successor
+		// directly instead of relying on edit distance, which would not connect
+		// "recent-unwrapped" to "recent".
+		hint.DidYouMean = "recent"
+		hint.Detail = reason
+	} else {
+		hint.DidYouMean = closestMatch(source, captureSources)
+	}
+	return hintedVerbError(ErrVerbInvalidParams, msg, hint)
 }
 
 // closestMatch returns the candidate closest to target by edit distance, or ""

--- a/internal/session/verb_hints.go
+++ b/internal/session/verb_hints.go
@@ -1,0 +1,215 @@
+package session
+
+import (
+	"sort"
+	"strings"
+)
+
+// This file carries the machine-readable remedy surface of the verb protocol.
+//
+// Every error envelope may carry a "hint" object alongside its stable code and
+// human message. The hint names the thing that resolves the failure: the verb to
+// call, the CLI command to run, the parameter that was wrong and what it
+// accepts, the closest spelling to what the caller asked for, and the set of
+// values that do exist. All fields are omitempty, so an existing consumer that
+// only reads code and message is unaffected.
+
+// The closed value sets the protocol accepts. They are the single source of
+// truth for both the list-verbs parameter schema and the "accepted" field on an
+// invalid_params hint, so the two can never drift apart.
+var (
+	// captureSources are the buffers capture-pane can read.
+	captureSources = []string{"visible", "recent", "recent-unwrapped"}
+	// waitConditions are the conditions wait-for understands.
+	waitConditions = []string{"session-exists", "window-output", "window-exit", "window-idle"}
+	// knownEventTypes are the event types a subscribe filter can name.
+	knownEventTypes = []string{
+		EventWindowCreated, EventWindowClosed, EventWindowExit, EventWindowRetitled,
+		EventWindowFocused, EventWindowMoved, EventWindowMinimized, EventWindowRestored,
+		EventWorkspaceSwitched, EventOutput, EventBell, EventModeChanged,
+		EventSessionCreated, EventSessionClosed, EventGap,
+	}
+)
+
+// errorCodeCatalog documents every stable error code for the list-verbs result,
+// so an agent can learn the failure vocabulary without reading the docs. Keep it
+// in sync with the ErrVerb* constants.
+var errorCodeCatalog = []struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}{
+	{ErrVerbInvalidRequest, "The line was not a valid request envelope, or the connection is in the wrong state for the verb."},
+	{ErrVerbUnknownVerb, "No such verb. The hint carries the closest match and the full verb list."},
+	{ErrVerbInvalidParams, "A parameter was missing, malformed, or outside its accepted set. The hint names the parameter."},
+	{ErrVerbSessionNotFound, "The named session does not exist. The hint lists the sessions that do."},
+	{ErrVerbWindowNotFound, "The window target did not resolve. The hint lists the addressable windows."},
+	{ErrVerbNoWindows, "The session exists but holds no windows to act on."},
+	{ErrVerbPTYNotFound, "The target window has no live PTY; its shell has already exited."},
+	{ErrVerbNeedsClient, "The verb needs an attached client to render it, and none is attached."},
+	{ErrVerbOptionNotFound, "The option was never set on this session."},
+	{ErrVerbCommandFailed, "The verb was routed to the attached client and came back failed."},
+	{ErrVerbTimeout, "A wait-for condition did not match before its timeout elapsed."},
+	{ErrVerbProtocolMismatch, "The caller's protocol version is outside the range this daemon accepts."},
+	{ErrVerbInternal, "Unexpected server-side failure."},
+}
+
+// VerbHint is the structured remedy attached to an error envelope. Every field
+// is optional; a hint is only attached when at least one field is meaningful.
+type VerbHint struct {
+	// Verb names the protocol verb that resolves or explains the failure, e.g.
+	// "list-verbs" for an unknown verb or "new-window" for an empty session.
+	Verb string `json:"verb,omitempty"`
+	// Command is the exact CLI invocation that resolves the failure, written so
+	// it can be copied and run as-is (placeholders are in <angle brackets>).
+	Command string `json:"command,omitempty"`
+	// Param names the offending parameter for invalid_params.
+	Param string `json:"param,omitempty"`
+	// Accepted lists the values Param will take, when that set is closed.
+	Accepted []string `json:"accepted,omitempty"`
+	// DidYouMean is the closest match to what the caller asked for, when one is
+	// close enough to be worth suggesting.
+	DidYouMean string `json:"did_you_mean,omitempty"`
+	// Available lists what does exist (session names, window ids, verb names),
+	// so an agent can pick a valid target without a second round trip.
+	Available []string `json:"available,omitempty"`
+	// Detail is one sentence of extra context that does not fit the fields
+	// above, such as why a wait-for timed out.
+	Detail string `json:"detail,omitempty"`
+}
+
+// empty reports whether the hint carries nothing worth serializing.
+func (h *VerbHint) empty() bool {
+	return h == nil || (h.Verb == "" && h.Command == "" && h.Param == "" &&
+		len(h.Accepted) == 0 && h.DidYouMean == "" && len(h.Available) == 0 && h.Detail == "")
+}
+
+// hintedVerbError builds a *verbError carrying a hint. A hint with no populated
+// field is dropped so the envelope stays clean.
+func hintedVerbError(code, message string, hint *VerbHint) *verbError {
+	e := newVerbError(code, message)
+	if !hint.empty() {
+		e.Hint = hint
+	}
+	return e
+}
+
+// invalidParam builds an invalid_params error naming the offending parameter and
+// the values it accepts (accepted may be nil when the set is open).
+func invalidParam(param, message string, accepted ...string) *verbError {
+	return hintedVerbError(ErrVerbInvalidParams, message, &VerbHint{
+		Param:    param,
+		Accepted: accepted,
+		Verb:     "list-verbs",
+	})
+}
+
+// closestMatch returns the candidate closest to target by edit distance, or ""
+// when nothing is close enough to suggest. The threshold scales with the length
+// of the target so short names do not match everything: a 3-character target
+// tolerates one edit, a 10-character target tolerates three.
+func closestMatch(target string, candidates []string) string {
+	if target == "" || len(candidates) == 0 {
+		return ""
+	}
+	// Scale the tolerance with the length of the target so a short name does not
+	// match everything, and cap it so two long but genuinely different names
+	// ("list-windows" and "close-window") are never suggested for each other.
+	limit := min(len(target)/4+1, 3)
+
+	best := ""
+	bestDist := limit + 1
+	for _, c := range candidates {
+		if c == target {
+			// An exact match is never a suggestion; the caller failed for some
+			// other reason and "did you mean the thing you typed" is noise.
+			continue
+		}
+		d := editDistance(strings.ToLower(target), strings.ToLower(c))
+		if d < bestDist || (d == bestDist && c < best) {
+			bestDist = d
+			best = c
+		}
+	}
+	if bestDist > limit {
+		return ""
+	}
+	return best
+}
+
+// editDistance returns the Levenshtein distance between a and b using a single
+// rolling row, which is enough for the short identifiers compared here.
+func editDistance(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			cur[j] = min(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(br)]
+}
+
+// knownVerbNames returns every registered verb name in sorted order.
+func knownVerbNames() []string {
+	names := make([]string, 0, len(verbRegistry))
+	for name := range verbRegistry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sessionNames returns the names of every live session, sorted, for the
+// available list on a session_not_found hint.
+func (d *Daemon) sessionNames() []string {
+	infos := d.manager.ListSessions()
+	names := make([]string, 0, len(infos))
+	for _, info := range infos {
+		names = append(names, info.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// windowTargets returns the addressable identifiers of a session's windows (id
+// and display name for each), sorted, for a window_not_found hint. Ids and names
+// are both accepted by the window parameter, so both belong in the list.
+func windowTargets(state *SessionState) []string {
+	if state == nil {
+		return nil
+	}
+	targets := make([]string, 0, len(state.Windows)*2)
+	for _, w := range state.Windows {
+		if w.ID != "" {
+			targets = append(targets, w.ID)
+		}
+		name := w.CustomName
+		if name == "" {
+			name = w.Title
+		}
+		if name != "" && name != w.ID {
+			targets = append(targets, name)
+		}
+	}
+	sort.Strings(targets)
+	return targets
+}

--- a/internal/session/verb_hints_test.go
+++ b/internal/session/verb_hints_test.go
@@ -1,0 +1,323 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// errorOf extracts the error object from a response, failing when the response
+// carried a result instead.
+func errorOf(t *testing.T, resp map[string]any) map[string]any {
+	t.Helper()
+	e, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an error envelope, got: %v", resp)
+	}
+	return e
+}
+
+// hintOf extracts the hint object from an error envelope, failing when there is
+// none. Every degraded state covered here is expected to name its remedy.
+func hintOf(t *testing.T, e map[string]any) map[string]any {
+	t.Helper()
+	h, ok := e["hint"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a hint on this error, got: %v", e)
+	}
+	return h
+}
+
+// hintStrings reads a string-list field off a hint.
+func hintStrings(t *testing.T, hint map[string]any, field string) []string {
+	t.Helper()
+	raw, ok := hint[field].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("hint field %q holds a non-string entry: %v", field, v)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestVerbErrorHints is the table of degraded states an agent can hit, and what
+// each one must tell it. Every row asserts the stable code plus the specific
+// hint fields that make the failure self-explaining: the parameter at fault, the
+// values it accepts, the closest name to what was asked for, what does exist,
+// and the verb or CLI command that resolves it.
+func TestVerbErrorHints(t *testing.T) {
+	d, socketPath := startTestDaemon(t)
+
+	sess := makeSessionWithWindow(t, d, "work")
+	if _, err := d.manager.CreateSession("scratch", &SessionConfig{}, 80, 24); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	sess.SetOption("appearance.border_style", "rounded")
+
+	// An empty session exercises the no-windows state without disturbing "work".
+	if _, err := d.manager.CreateSession("empty", &SessionConfig{}, 80, 24); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		req  string
+
+		wantCode string
+		// wantMessage are substrings the human message must contain.
+		wantMessage []string
+		// wantHint are exact string fields the hint must carry.
+		wantHint map[string]string
+		// wantAccepted and wantAvailable are membership checks on list fields.
+		wantAccepted  []string
+		wantAvailable []string
+	}{
+		{
+			name:     "unknown verb suggests the closest one and list-verbs",
+			req:      `{"id":1,"verb":"list-window"}`,
+			wantCode: ErrVerbUnknownVerb,
+			wantHint: map[string]string{
+				"verb":         "list-verbs",
+				"command":      "tuios list-verbs",
+				"did_you_mean": "list-windows",
+			},
+			wantAvailable: []string{"list-windows", "capture-pane", "wait-for"},
+		},
+		{
+			name:     "a request with no verb is told the envelope shape",
+			req:      `{"id":1,"params":{}}`,
+			wantCode: ErrVerbInvalidRequest,
+			wantHint: map[string]string{"param": "verb", "verb": "list-verbs"},
+		},
+		{
+			name:        "unknown session lists the sessions that exist",
+			req:         `{"id":1,"verb":"list-windows","params":{"session":"scratchh"}}`,
+			wantCode:    ErrVerbSessionNotFound,
+			wantMessage: []string{"scratchh", "not found"},
+			wantHint: map[string]string{
+				"param":        "session",
+				"command":      "tuios ls",
+				"did_you_mean": "scratch",
+			},
+			wantAvailable: []string{"work", "scratch", "empty"},
+		},
+		{
+			name:        "unknown window lists the addressable windows",
+			req:         `{"id":1,"verb":"send-text","params":{"session":"work","window":"nope","text":"hi"}}`,
+			wantCode:    ErrVerbWindowNotFound,
+			wantMessage: []string{"nope"},
+			wantHint: map[string]string{
+				"param":   "window",
+				"verb":    "list-windows",
+				"command": "tuios list-windows --json",
+			},
+		},
+		{
+			name:     "a session with no windows is told how to make one",
+			req:      `{"id":1,"verb":"capture-pane","params":{"session":"empty"}}`,
+			wantCode: ErrVerbNoWindows,
+			wantHint: map[string]string{
+				"verb":    "new-window",
+				"command": "tuios run-command NewWindow",
+			},
+		},
+		{
+			name:        "a missing required parameter is named",
+			req:         `{"id":1,"verb":"send-keys","params":{"session":"work"}}`,
+			wantCode:    ErrVerbInvalidParams,
+			wantMessage: []string{"keys is required"},
+			wantHint:    map[string]string{"param": "keys"},
+		},
+		{
+			name:        "an out-of-range parameter is named",
+			req:         `{"id":1,"verb":"resize","params":{"session":"work","width":0,"height":10}}`,
+			wantCode:    ErrVerbInvalidParams,
+			wantMessage: []string{"positive"},
+			wantHint:    map[string]string{"param": "width"},
+		},
+		{
+			name:     "a parameter with a closed value set lists the values",
+			req:      `{"id":1,"verb":"wait-for","params":{"condition":"window-outpt","session":"work"}}`,
+			wantCode: ErrVerbInvalidParams,
+			wantHint: map[string]string{
+				"param":        "condition",
+				"did_you_mean": "window-output",
+			},
+			wantAccepted: waitConditions,
+		},
+		{
+			name:     "a wrongly typed parameter points at the schema",
+			req:      `{"id":1,"verb":"resize","params":{"width":"wide"}}`,
+			wantCode: ErrVerbInvalidParams,
+			wantHint: map[string]string{"verb": "list-verbs"},
+		},
+		{
+			name:        "kill-session refuses to guess and lists the candidates",
+			req:         `{"id":1,"verb":"kill-session","params":{}}`,
+			wantCode:    ErrVerbInvalidParams,
+			wantMessage: []string{"session is required"},
+			wantHint: map[string]string{
+				"param":   "session",
+				"command": "tuios ls",
+			},
+			wantAvailable: []string{"work", "scratch", "empty"},
+		},
+		{
+			name:        "an unset option lists the options that are set",
+			req:         `{"id":1,"verb":"get-option","params":{"session":"work","key":"appearance.border_styl"}}`,
+			wantCode:    ErrVerbOptionNotFound,
+			wantMessage: []string{"appearance.border_styl", "work"},
+			wantHint: map[string]string{
+				"param":        "key",
+				"verb":         "set-option",
+				"did_you_mean": "appearance.border_style",
+			},
+			wantAvailable: []string{"appearance.border_style"},
+		},
+		{
+			name:        "a wait that times out says how to see what happened",
+			req:         `{"id":1,"verb":"wait-for","params":{"condition":"window-output","session":"work","pattern":"never-appears-xyz","timeout":150}}`,
+			wantCode:    ErrVerbTimeout,
+			wantMessage: []string{"never-appears-xyz"},
+			wantHint: map[string]string{
+				"param": "pattern",
+				"verb":  "capture-pane",
+			},
+		},
+		{
+			name:     "unsubscribing without a stream points at subscribe",
+			req:      `{"id":1,"verb":"unsubscribe"}`,
+			wantCode: ErrVerbInvalidRequest,
+			wantHint: map[string]string{"verb": "subscribe"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A fresh connection per row: some rows leave connection state
+			// (subscriptions) behind, and rows must not influence each other.
+			c := dialVerb(t, socketPath)
+			resp := c.call(t, tc.req)
+			e := errorOf(t, resp)
+
+			if code, _ := e["code"].(string); code != tc.wantCode {
+				t.Fatalf("code = %v, want %v (full error: %v)", e["code"], tc.wantCode, e)
+			}
+
+			message, _ := e["message"].(string)
+			if message == "" {
+				t.Error("error carries no human message")
+			}
+			for _, want := range tc.wantMessage {
+				if !strings.Contains(message, want) {
+					t.Errorf("message %q does not contain %q", message, want)
+				}
+			}
+
+			hint := hintOf(t, e)
+			for field, want := range tc.wantHint {
+				if got, _ := hint[field].(string); got != want {
+					t.Errorf("hint[%s] = %q, want %q (full hint: %v)", field, got, want, hint)
+				}
+			}
+			for _, want := range tc.wantAccepted {
+				if !slices.Contains(hintStrings(t, hint, "accepted"), want) {
+					t.Errorf("hint accepted list missing %q: %v", want, hint["accepted"])
+				}
+			}
+			for _, want := range tc.wantAvailable {
+				if !slices.Contains(hintStrings(t, hint, "available"), want) {
+					t.Errorf("hint available list missing %q: %v", want, hint["available"])
+				}
+			}
+		})
+	}
+}
+
+// TestNeedsClientHintNamesTheAttachCommand covers the one degraded state that
+// cannot be reproduced through a parameter mistake: a verb that genuinely needs
+// a renderer, called against a session with no attached client.
+func TestNeedsClientHintNamesTheAttachCommand(t *testing.T) { //nolint:revive
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	// Rendering-dependent commands reach this classification through
+	// executeDaemonCommand's default branch. Drive the classification directly:
+	// no verb in the registry routes one headlessly today, and this keeps the
+	// mapping honest the moment one does.
+	sess := d.manager.GetSession("work")
+	verr := mapResolveErr(errNeedsClient{verb: "ToggleTiling"}, sess)
+	if verr.Code != ErrVerbNeedsClient {
+		t.Fatalf("code = %s, want %s", verr.Code, ErrVerbNeedsClient)
+	}
+	if verr.Hint == nil || verr.Hint.Command != "tuios attach work" {
+		t.Fatalf("hint should name the attach command for this session, got %+v", verr.Hint)
+	}
+	if !strings.Contains(verr.Message, "ToggleTiling") {
+		t.Errorf("message should name the command that needs a client, got %q", verr.Message)
+	}
+}
+
+// TestHintsAreOmittedWhenEmpty guards the backward-compatibility promise: an
+// error with nothing useful to suggest must not carry an empty hint object,
+// because a consumer checking for the field's presence would be misled.
+func TestHintsAreOmittedWhenEmpty(t *testing.T) {
+	e := hintedVerbError(ErrVerbInternal, "boom", &VerbHint{})
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "hint") {
+		t.Errorf("an empty hint must be omitted, got %s", data)
+	}
+
+	// And the legacy constructor must keep producing a hint-free envelope.
+	data, err = json.Marshal(newVerbError(ErrVerbInternal, "boom"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(data), `{"code":"internal","message":"boom"}`; got != want {
+		t.Errorf("envelope = %s, want %s", got, want)
+	}
+}
+
+// TestClosestMatch pins the suggestion policy, which is what keeps did_you_mean
+// useful rather than noisy: near misses are suggested, unrelated names are not,
+// and a name that is already correct is never suggested back.
+func TestClosestMatch(t *testing.T) {
+	verbs := []string{"list-windows", "list-sessions", "new-window", "close-window", "capture-pane"}
+
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{"list-window", "list-windows"},   // one deletion
+		{"list-sesions", "list-sessions"}, // one deletion mid-word
+		{"New-Window", "new-window"},      // case only
+		{"capture-pain", "capture-pane"},  // one substitution
+		{"list-windows", ""},              // already correct: nothing to suggest
+		{"", ""},                          // nothing asked for
+		{"totally-unrelated-thing", ""},   // too far from everything
+		{"xyz", ""},                       // short and unrelated
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.target), func(t *testing.T) {
+			if got := closestMatch(tc.target, verbs); got != tc.want {
+				t.Errorf("closestMatch(%q) = %q, want %q", tc.target, got, tc.want)
+			}
+		})
+	}
+
+	if got := closestMatch("anything", nil); got != "" {
+		t.Errorf("closestMatch with no candidates = %q, want empty", got)
+	}
+}

--- a/internal/session/verb_hints_test.go
+++ b/internal/session/verb_hints_test.go
@@ -154,6 +154,32 @@ func TestVerbErrorHints(t *testing.T) {
 			wantAccepted: waitConditions,
 		},
 		{
+			name:     "an unknown capture source lists the sources that exist",
+			req:      `{"id":1,"verb":"capture-pane","params":{"session":"work","source":"visable"}}`,
+			wantCode: ErrVerbInvalidParams,
+			wantHint: map[string]string{
+				"param":        "source",
+				"did_you_mean": "visible",
+			},
+			wantAccepted: captureSources,
+		},
+		{
+			name:        "the retired capture source says why it went away",
+			req:         `{"id":1,"verb":"capture-pane","params":{"session":"work","source":"recent-unwrapped"}}`,
+			wantCode:    ErrVerbInvalidParams,
+			wantMessage: []string{"recent-unwrapped"},
+			wantHint: map[string]string{
+				"param":        "source",
+				// did_you_mean here proves the retired-value branch ran: the
+				// edit distance from "recent-unwrapped" to "recent" is far
+				// outside closestMatch's tolerance, so the generic path could
+				// never suggest it.
+				"did_you_mean": "recent",
+				"detail":       retiredCaptureSources["recent-unwrapped"],
+			},
+			wantAccepted: captureSources,
+		},
+		{
 			name:     "a wrongly typed parameter points at the schema",
 			req:      `{"id":1,"verb":"resize","params":{"width":"wide"}}`,
 			wantCode: ErrVerbInvalidParams,

--- a/internal/session/verb_introspect_test.go
+++ b/internal/session/verb_introspect_test.go
@@ -1,0 +1,217 @@
+package session
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestListVerbsDescribesEveryVerb is the contract an agent relies on: list-verbs
+// alone is enough to drive the control plane. Every registered verb must carry a
+// description and a parameter schema, and the reply must carry the protocol
+// range, the error-code catalog, and the envelope shape.
+func TestListVerbsDescribesEveryVerb(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	res := result(t, c.call(t, `{"id":1,"verb":"list-verbs"}`))
+
+	if res["version"] != float64(VerbProtocolVersion) {
+		t.Errorf("version = %v, want %d", res["version"], VerbProtocolVersion)
+	}
+	if res["min_version"] != float64(MinVerbProtocolVersion) {
+		t.Errorf("min_version = %v, want %d", res["min_version"], MinVerbProtocolVersion)
+	}
+	if res["daemon_version"] != "test" {
+		t.Errorf("daemon_version = %v, want test", res["daemon_version"])
+	}
+
+	envelope, ok := res["envelope"].(map[string]any)
+	if !ok {
+		t.Fatal("reply carries no envelope documentation")
+	}
+	for _, field := range []string{"transport", "request", "success", "failure", "hint"} {
+		if s, _ := envelope[field].(string); s == "" {
+			t.Errorf("envelope documentation is missing %q", field)
+		}
+	}
+
+	codes, ok := res["error_codes"].([]any)
+	if !ok || len(codes) == 0 {
+		t.Fatal("reply carries no error-code catalog")
+	}
+	documented := map[string]bool{}
+	for _, entry := range codes {
+		e, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("error-code entry is not an object: %v", entry)
+		}
+		code, _ := e["code"].(string)
+		desc, _ := e["description"].(string)
+		if code == "" || desc == "" {
+			t.Errorf("error-code entry is incomplete: %v", e)
+		}
+		documented[code] = true
+	}
+	// Every code the daemon can actually emit must be documented, or an agent
+	// meets a code it cannot interpret.
+	for _, code := range []string{
+		ErrVerbInvalidRequest, ErrVerbUnknownVerb, ErrVerbInvalidParams,
+		ErrVerbSessionNotFound, ErrVerbWindowNotFound, ErrVerbNoWindows,
+		ErrVerbPTYNotFound, ErrVerbNeedsClient, ErrVerbOptionNotFound,
+		ErrVerbCommandFailed, ErrVerbTimeout, ErrVerbProtocolMismatch, ErrVerbInternal,
+	} {
+		if !documented[code] {
+			t.Errorf("error code %q is emitted by the daemon but not documented by list-verbs", code)
+		}
+	}
+
+	verbs, ok := res["verbs"].([]any)
+	if !ok || len(verbs) != len(verbRegistry) {
+		t.Fatalf("verbs list wrong: got %v entries, want %d", len(verbs), len(verbRegistry))
+	}
+
+	var names []string
+	for _, entry := range verbs {
+		v, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("verb entry is not an object: %v", entry)
+		}
+		name, _ := v["verb"].(string)
+		names = append(names, name)
+
+		if desc, _ := v["description"].(string); desc == "" {
+			t.Errorf("verb %q has no description", name)
+		}
+		params, ok := v["params"].([]any)
+		if !ok {
+			t.Errorf("verb %q has no params list (it must be present even when empty)", name)
+			continue
+		}
+		for _, raw := range params {
+			p, ok := raw.(map[string]any)
+			if !ok {
+				t.Fatalf("verb %q has a non-object param: %v", name, raw)
+			}
+			pname, _ := p["name"].(string)
+			ptype, _ := p["type"].(string)
+			pdesc, _ := p["description"].(string)
+			if pname == "" || ptype == "" || pdesc == "" {
+				t.Errorf("verb %q has an incompletely documented param: %v", name, p)
+			}
+			if !slices.Contains([]string{"string", "int", "bool", "[]string"}, ptype) {
+				t.Errorf("verb %q param %q has unknown type %q", name, pname, ptype)
+			}
+		}
+	}
+
+	if !slices.IsSorted(names) {
+		t.Errorf("verbs are not in a stable sorted order: %v", names)
+	}
+}
+
+// TestListVerbsExamplesAreValidRequests keeps the documented examples honest: an
+// agent that copies one must get a well-formed request naming a real verb.
+func TestListVerbsExamplesAreValidRequests(t *testing.T) {
+	for name, entry := range verbRegistry {
+		for _, example := range entry.examples {
+			var req verbRequest
+			if err := json.Unmarshal([]byte(example), &req); err != nil {
+				t.Errorf("verb %q has an example that is not valid JSON: %s (%v)", name, example, err)
+				continue
+			}
+			if req.Verb != name {
+				t.Errorf("verb %q has an example for a different verb %q: %s", name, req.Verb, example)
+			}
+			if _, ok := verbRegistry[req.Verb]; !ok {
+				t.Errorf("example names an unregistered verb %q: %s", req.Verb, example)
+			}
+		}
+	}
+}
+
+// TestListVerbsAcceptedValuesMatchTheImplementation guards the one way a schema
+// silently rots: the accepted-value lists must be the same lists the handlers
+// actually enforce.
+func TestListVerbsAcceptedValuesMatchTheImplementation(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	res := result(t, c.call(t, `{"id":1,"verb":"list-verbs","params":{"verb":"wait-for"}}`))
+	verbs, ok := res["verbs"].([]any)
+	if !ok || len(verbs) != 1 {
+		t.Fatalf("naming a verb should return exactly that verb, got %v", res["verbs"])
+	}
+	doc := verbs[0].(map[string]any)
+	if doc["verb"] != "wait-for" {
+		t.Fatalf("described the wrong verb: %v", doc["verb"])
+	}
+
+	var accepted []string
+	for _, raw := range doc["params"].([]any) {
+		p := raw.(map[string]any)
+		if p["name"] != "condition" {
+			continue
+		}
+		for _, v := range p["accepted"].([]any) {
+			accepted = append(accepted, v.(string))
+		}
+	}
+	if !slices.Equal(accepted, waitConditions) {
+		t.Fatalf("documented conditions %v do not match the implemented set %v", accepted, waitConditions)
+	}
+
+	// And each documented condition must actually be accepted by the handler:
+	// a rejected one comes back as invalid_params naming the condition param.
+	for _, condition := range accepted {
+		resp := c.call(t, `{"id":2,"verb":"wait-for","params":{"condition":"`+condition+`","timeout":1}}`)
+		e, ok := resp["error"].(map[string]any)
+		if !ok {
+			continue // it matched immediately, which also means it was accepted
+		}
+		if code, _ := e["code"].(string); code == ErrVerbInvalidParams {
+			hint, _ := e["hint"].(map[string]any)
+			if param, _ := hint["param"].(string); param == "condition" {
+				t.Errorf("condition %q is documented as accepted but the handler rejects it: %v", condition, e)
+			}
+		}
+	}
+}
+
+// TestListVerbsForUnknownVerbSuggestsOne checks the introspection verb is itself
+// self-explaining when misused.
+func TestListVerbsForUnknownVerbSuggestsOne(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	resp := c.call(t, `{"id":1,"verb":"list-verbs","params":{"verb":"capture-pain"}}`)
+	e := errorOf(t, resp)
+	if code, _ := e["code"].(string); code != ErrVerbUnknownVerb {
+		t.Fatalf("code = %v, want %v", e["code"], ErrVerbUnknownVerb)
+	}
+	hint := hintOf(t, e)
+	if got, _ := hint["did_you_mean"].(string); got != "capture-pane" {
+		t.Errorf("did_you_mean = %q, want capture-pane", got)
+	}
+}
+
+// TestEveryVerbIsDocumented is the guard that makes the schema a build-time
+// obligation: adding a verb without documenting it fails here rather than
+// silently shipping an undiscoverable verb.
+func TestEveryVerbIsDocumented(t *testing.T) {
+	for name, entry := range verbRegistry {
+		if entry.description == "" {
+			t.Errorf("verb %q has no description", name)
+		}
+		if !strings.HasSuffix(entry.description, ".") {
+			t.Errorf("verb %q description should read as a sentence: %q", name, entry.description)
+		}
+		if entry.handler == nil {
+			t.Errorf("verb %q has no handler", name)
+		}
+		if len(entry.examples) == 0 {
+			t.Errorf("verb %q has no example request", name)
+		}
+	}
+}

--- a/internal/session/verb_introspect_test.go
+++ b/internal/session/verb_introspect_test.go
@@ -179,6 +179,60 @@ func TestListVerbsAcceptedValuesMatchTheImplementation(t *testing.T) {
 	}
 }
 
+// TestCaptureSourcesMatchTheImplementation is the capture-pane half of the same
+// contract: the documented source list must equal the enforced set, and every
+// documented source must survive the handler's validation. This is what stops a
+// source from being advertised while doing nothing, which is how
+// "recent-unwrapped" became a silent alias for "recent".
+func TestCaptureSourcesMatchTheImplementation(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+	c := dialVerb(t, sp)
+
+	res := result(t, c.call(t, `{"id":1,"verb":"list-verbs","params":{"verb":"capture-pane"}}`))
+	doc := res["verbs"].([]any)[0].(map[string]any)
+
+	var accepted []string
+	for _, raw := range doc["params"].([]any) {
+		p := raw.(map[string]any)
+		if p["name"] != "source" {
+			continue
+		}
+		for _, v := range p["accepted"].([]any) {
+			accepted = append(accepted, v.(string))
+		}
+	}
+	if !slices.Equal(accepted, captureSources) {
+		t.Fatalf("documented sources %v do not match the implemented set %v", accepted, captureSources)
+	}
+
+	// Each documented source must capture rather than be rejected, and must be
+	// echoed back as the source that was actually used.
+	for _, source := range accepted {
+		res := result(t, c.call(t, `{"id":2,"verb":"capture-pane","params":{"session":"work","source":"`+source+`"}}`))
+		if got, _ := res["source"].(string); got != source {
+			t.Errorf("capture with source %q reported source %q", source, got)
+		}
+	}
+
+	// A retired source must not merely be undocumented, it must be refused, so a
+	// caller still passing it finds out instead of silently getting "recent".
+	for retired := range retiredCaptureSources {
+		if slices.Contains(captureSources, retired) {
+			t.Errorf("%q is listed as both accepted and retired", retired)
+		}
+		resp := c.call(t, `{"id":3,"verb":"capture-pane","params":{"session":"work","source":"`+retired+`"}}`)
+		e, ok := resp["error"].(map[string]any)
+		if !ok {
+			t.Errorf("retired source %q was accepted: %v", retired, resp)
+			continue
+		}
+		if code, _ := e["code"].(string); code != ErrVerbInvalidParams {
+			t.Errorf("retired source %q rejected with %q, want %q", retired, code, ErrVerbInvalidParams)
+		}
+	}
+}
+
 // TestListVerbsForUnknownVerbSuggestsOne checks the introspection verb is itself
 // self-explaining when misused.
 func TestListVerbsForUnknownVerbSuggestsOne(t *testing.T) {

--- a/internal/session/verb_protocol.go
+++ b/internal/session/verb_protocol.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net"
+	"os"
 	"time"
 )
 
@@ -47,7 +49,18 @@ const (
 	ErrVerbCommandFailed   = "command_failed"    // a verb routed to the attached client came back failed
 	ErrVerbTimeout         = "timeout"           // a wait-for condition did not match before its timeout
 	ErrVerbInternal        = "internal"          // unexpected server-side failure
+
+	// ErrVerbProtocolMismatch reports that the caller's protocol version is
+	// outside the range this daemon accepts. It is only ever produced by the
+	// hello verb, which exists so a mismatch is reported in this shape rather
+	// than surfacing later as a framing or decode failure.
+	ErrVerbProtocolMismatch = "protocol_mismatch"
 )
+
+// MinVerbProtocolVersion is the oldest protocol version this daemon still
+// serves. A caller announcing anything older is told to upgrade rather than
+// being allowed to proceed into undefined behavior.
+const MinVerbProtocolVersion = 1
 
 // verbRequest is one decoded request line. ID is opaque (number, string, or
 // absent) and echoed back on the response.
@@ -57,10 +70,14 @@ type verbRequest struct {
 	Params json.RawMessage `json:"params,omitempty"`
 }
 
-// verbError is the error envelope with a stable string code.
+// verbError is the error envelope with a stable string code. Hint, when
+// present, names the verb, CLI command, parameter, or closest spelling that
+// resolves the failure; it is additive and always omitempty, so a consumer that
+// reads only code and message is unaffected.
 type verbError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string    `json:"code"`
+	Message string    `json:"message"`
+	Hint    *VerbHint `json:"hint,omitempty"`
 }
 
 func (e *verbError) Error() string { return e.Code + ": " + e.Message }
@@ -82,10 +99,46 @@ type verbResponse struct {
 // *verbError describing why it failed.
 type verbHandler func(d *Daemon, cs *connState, params json.RawMessage) (any, *verbError)
 
-// verbEntry pairs a handler with a one-line description for list-verbs.
+// verbParam documents one parameter of a verb for the list-verbs introspection
+// output, so an agent can discover the full call shape without reading the docs.
+type verbParam struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"` // string | int | bool | []string
+	Required    bool     `json:"required,omitempty"`
+	Description string   `json:"description"`
+	Accepted    []string `json:"accepted,omitempty"` // closed value set, when there is one
+	Default     string   `json:"default,omitempty"`
+}
+
+// verbEntry pairs a handler with the documentation list-verbs reports: a
+// one-line description, the parameter schema, and copy-pasteable examples.
 type verbEntry struct {
 	description string
+	params      []verbParam
+	examples    []string
 	handler     verbHandler
+}
+
+// verbDoc is the serialized form of a verbEntry in the list-verbs result.
+type verbDoc struct {
+	Verb        string      `json:"verb"`
+	Description string      `json:"description"`
+	Params      []verbParam `json:"params"`
+	Examples    []string    `json:"examples,omitempty"`
+}
+
+// sessionParam is the session selector shared by nearly every verb.
+var sessionParam = verbParam{
+	Name:        "session",
+	Type:        "string",
+	Description: "Session name. Omit to target the most recently active session.",
+}
+
+// windowParam is the window selector shared by window-targeted verbs.
+var windowParam = verbParam{
+	Name:        "window",
+	Type:        "string",
+	Description: "Window id or name. Omit to target the focused window.",
 }
 
 // verbRegistry is the dispatch table for every JSON verb the daemon supports.
@@ -96,69 +149,161 @@ var verbRegistry map[string]verbEntry
 
 func init() {
 	verbRegistry = map[string]verbEntry{
+		"hello": {
+			description: "Handshake: report the protocol version this daemon speaks and the version range it accepts.",
+			params: []verbParam{
+				{Name: "client", Type: "string", Description: "Name of the calling program, for the daemon log."},
+				{Name: "version", Type: "string", Description: "Version string of the calling program."},
+				{Name: "protocol", Type: "int", Description: "Protocol version the caller speaks. The daemon reports a mismatch rather than failing later."},
+			},
+			examples: []string{`{"id":1,"verb":"hello","params":{"client":"tuios","version":"1.2.3","protocol":1}}`},
+			handler:  (*Daemon).verbHello,
+		},
 		"list-verbs": {
-			description: "List every supported verb and the protocol version.",
-			handler:     (*Daemon).verbListVerbs,
+			description: "List every supported verb with its parameter schema and examples, plus the protocol version and error-code catalog.",
+			params: []verbParam{
+				{Name: "verb", Type: "string", Description: "Describe only this verb. Omit to describe all of them."},
+			},
+			examples: []string{
+				`{"id":1,"verb":"list-verbs"}`,
+				`{"id":1,"verb":"list-verbs","params":{"verb":"capture-pane"}}`,
+			},
+			handler: (*Daemon).verbListVerbs,
 		},
 		"list-sessions": {
 			description: "List all sessions the daemon holds.",
+			examples:    []string{`{"id":1,"verb":"list-sessions"}`},
 			handler:     (*Daemon).verbListSessions,
 		},
 		"session-info": {
-			description: "Report details about one session (params: session).",
+			description: "Report details about one session.",
+			params:      []verbParam{sessionParam},
+			examples:    []string{`{"id":1,"verb":"session-info","params":{"session":"work"}}`},
 			handler:     (*Daemon).verbSessionInfo,
 		},
 		"list-windows": {
-			description: "List the windows in a session (params: session).",
+			description: "List the windows in a session.",
+			params:      []verbParam{sessionParam},
+			examples:    []string{`{"id":1,"verb":"list-windows","params":{"session":"work"}}`},
 			handler:     (*Daemon).verbListWindows,
 		},
 		"new-window": {
-			description: "Create a new window (params: session, name).",
-			handler:     (*Daemon).verbNewWindow,
+			description: "Create a new window.",
+			params: []verbParam{
+				sessionParam,
+				{Name: "name", Type: "string", Description: "Name for the new window. Omit to use the shell's title."},
+			},
+			examples: []string{`{"id":1,"verb":"new-window","params":{"session":"work","name":"build"}}`},
+			handler:  (*Daemon).verbNewWindow,
 		},
 		"close-window": {
-			description: "Close a window (params: session, window).",
+			description: "Close a window.",
+			params:      []verbParam{sessionParam, windowParam},
+			examples:    []string{`{"id":1,"verb":"close-window","params":{"session":"work","window":"build"}}`},
 			handler:     (*Daemon).verbCloseWindow,
 		},
 		"send-keys": {
-			description: "Send parsed key tokens to a window (params: session, window, keys, literal, raw).",
-			handler:     (*Daemon).verbSendKeys,
+			description: "Send parsed key tokens to a window.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "keys", Type: "string", Required: true, Description: `Key sequence, e.g. "ctrl+b,n" or "Hello World".`},
+				{Name: "literal", Type: "bool", Description: "Send the keys to the PTY without parsing them as key names.", Default: "false"},
+				{Name: "raw", Type: "bool", Description: "Treat every character as its own key instead of splitting on spaces and commas.", Default: "false"},
+			},
+			examples: []string{`{"id":1,"verb":"send-keys","params":{"session":"work","keys":"ls,Enter"}}`},
+			handler:  (*Daemon).verbSendKeys,
 		},
 		"send-text": {
-			description: "Send literal text to a window's PTY (params: session, window, text).",
-			handler:     (*Daemon).verbSendText,
+			description: "Send literal text to a window's PTY.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "text", Type: "string", Required: true, Description: "Text written verbatim to the PTY."},
+			},
+			examples: []string{`{"id":1,"verb":"send-text","params":{"session":"work","text":"echo hi\n"}}`},
+			handler:  (*Daemon).verbSendText,
 		},
 		"capture-pane": {
-			description: "Capture a pane's content (params: session, window, source, styled, lines, start, end).",
-			handler:     (*Daemon).verbCapturePane,
+			description: "Capture a pane's content.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "source", Type: "string", Description: "Which buffer to capture.", Accepted: captureSources, Default: "visible"},
+				{Name: "styled", Type: "bool", Description: "Include ANSI styling in the captured text.", Default: "false"},
+				{Name: "lines", Type: "int", Description: "Keep only the last N lines. Ignored when start or end is given."},
+				{Name: "start", Type: "int", Description: "1-based inclusive first line of the region to keep."},
+				{Name: "end", Type: "int", Description: "1-based inclusive last line of the region to keep."},
+			},
+			examples: []string{`{"id":1,"verb":"capture-pane","params":{"session":"work","source":"recent","lines":50}}`},
+			handler:  (*Daemon).verbCapturePane,
 		},
 		"resize": {
-			description: "Resize a window's PTY (params: session, window, width, height).",
-			handler:     (*Daemon).verbResize,
+			description: "Resize a window's PTY.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "width", Type: "int", Required: true, Description: "New width in columns. Must be positive."},
+				{Name: "height", Type: "int", Required: true, Description: "New height in rows. Must be positive."},
+			},
+			examples: []string{`{"id":1,"verb":"resize","params":{"session":"work","width":120,"height":40}}`},
+			handler:  (*Daemon).verbResize,
 		},
 		"kill-session": {
-			description: "Terminate a session (params: session).",
-			handler:     (*Daemon).verbKillSession,
+			description: "Terminate a session and every window in it.",
+			params: []verbParam{
+				{Name: "session", Type: "string", Required: true, Description: "Session to terminate."},
+			},
+			examples: []string{`{"id":1,"verb":"kill-session","params":{"session":"work"}}`},
+			handler:  (*Daemon).verbKillSession,
 		},
 		"set-option": {
-			description: "Set a session option (params: session, key, value).",
-			handler:     (*Daemon).verbSetOption,
+			description: "Set a session option, applied live when a client is attached.",
+			params: []verbParam{
+				sessionParam,
+				{Name: "key", Type: "string", Required: true, Description: `Option path, e.g. "appearance.dockbar_position".`},
+				{Name: "value", Type: "string", Description: "New value, as a string."},
+			},
+			examples: []string{`{"id":1,"verb":"set-option","params":{"session":"work","key":"appearance.dockbar_position","value":"top"}}`},
+			handler:  (*Daemon).verbSetOption,
 		},
 		"get-option": {
-			description: "Read a session option (params: session, key).",
-			handler:     (*Daemon).verbGetOption,
+			description: "Read a session option previously set with set-option.",
+			params: []verbParam{
+				sessionParam,
+				{Name: "key", Type: "string", Required: true, Description: "Option path to read."},
+			},
+			examples: []string{`{"id":1,"verb":"get-option","params":{"session":"work","key":"appearance.dockbar_position"}}`},
+			handler:  (*Daemon).verbGetOption,
 		},
 		"subscribe": {
-			description: "Open a long-lived event stream on this connection (params: session, window, types, queue).",
-			handler:     (*Daemon).verbSubscribe,
+			description: "Open a long-lived event stream on this connection. Events are delivered from the moment of subscription; there is no backfill.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "types", Type: "[]string", Description: "Only deliver these event types. Omit for all of them.", Accepted: knownEventTypes},
+				{Name: "queue", Type: "int", Description: "Buffered events before the stream marks a gap.", Default: "256"},
+			},
+			examples: []string{`{"id":1,"verb":"subscribe","params":{"session":"work","types":["window-created","window-closed"]}}`},
+			handler:  (*Daemon).verbSubscribe,
 		},
 		"unsubscribe": {
 			description: "Close this connection's event stream.",
+			examples:    []string{`{"id":1,"verb":"unsubscribe"}`},
 			handler:     (*Daemon).verbUnsubscribe,
 		},
 		"wait-for": {
-			description: "Block until a condition matches (params: condition, session, window, pattern, idle, timeout).",
-			handler:     (*Daemon).verbWaitFor,
+			description: "Block until a condition matches, or fail with the timeout code.",
+			params: []verbParam{
+				{Name: "condition", Type: "string", Required: true, Description: "Condition to wait for.", Accepted: waitConditions},
+				sessionParam,
+				windowParam,
+				{Name: "pattern", Type: "string", Description: "Regular expression, required by window-output."},
+				{Name: "idle", Type: "int", Description: "Milliseconds of silence that count as idle, for window-idle.", Default: "500"},
+				{Name: "timeout", Type: "int", Description: "Milliseconds to wait before failing with the timeout code.", Default: "30000"},
+			},
+			examples: []string{`{"id":1,"verb":"wait-for","params":{"condition":"window-output","session":"work","pattern":"done","timeout":10000}}`},
+			handler:  (*Daemon).verbWaitFor,
 		},
 	}
 }
@@ -257,16 +402,28 @@ func (d *Daemon) dispatchVerbLine(cs *connState, line []byte) error {
 
 	if req.Verb == "" {
 		return d.writeVerbResponse(cs, &verbResponse{
-			ID:    req.ID,
-			Error: newVerbError(ErrVerbInvalidRequest, "request is missing the \"verb\" field"),
+			ID: req.ID,
+			Error: hintedVerbError(ErrVerbInvalidRequest, "request is missing the \"verb\" field", &VerbHint{
+				Param:     "verb",
+				Verb:      "list-verbs",
+				Available: knownVerbNames(),
+				Detail:    `Every request line is an object of the form {"id":1,"verb":"list-verbs","params":{}}.`,
+			}),
 		})
 	}
 
 	entry, ok := verbRegistry[req.Verb]
 	if !ok {
+		known := knownVerbNames()
 		return d.writeVerbResponse(cs, &verbResponse{
-			ID:    req.ID,
-			Error: newVerbError(ErrVerbUnknownVerb, "unknown verb "+req.Verb),
+			ID: req.ID,
+			Error: hintedVerbError(ErrVerbUnknownVerb, "unknown verb "+req.Verb, &VerbHint{
+				Verb:       "list-verbs",
+				Command:    "tuios list-verbs",
+				DidYouMean: closestMatch(req.Verb, known),
+				Available:  known,
+				Detail:     "Call list-verbs for every verb with its parameter schema and examples.",
+			}),
 		})
 	}
 
@@ -300,20 +457,124 @@ func (d *Daemon) writeVerbResponse(cs *connState, resp *verbResponse) error {
 	return werr
 }
 
-// verbListVerbs implements the list-verbs introspection verb.
-func (d *Daemon) verbListVerbs(_ *connState, _ json.RawMessage) (any, *verbError) {
-	verbs := make([]map[string]string, 0, len(verbRegistry))
-	for name, entry := range verbRegistry {
-		verbs = append(verbs, map[string]string{
-			"verb":        name,
-			"description": entry.description,
-		})
+// verbListVerbs implements the list-verbs introspection verb. It reports every
+// verb with its parameter schema and examples, the protocol version range, and
+// the error-code catalog, which together are enough to drive the control plane
+// without reading the documentation. Naming a verb narrows the output to that
+// one verb.
+func (d *Daemon) verbListVerbs(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Verb string `json:"verb"`
 	}
-	// Stable order so output is deterministic.
-	sortVerbEntries(verbs)
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+
+	if p.Verb != "" {
+		entry, ok := verbRegistry[p.Verb]
+		if !ok {
+			known := knownVerbNames()
+			return nil, hintedVerbError(ErrVerbUnknownVerb, "unknown verb "+p.Verb, &VerbHint{
+				Param:      "verb",
+				DidYouMean: closestMatch(p.Verb, known),
+				Available:  known,
+			})
+		}
+		return map[string]any{
+			"type":           "verb_list",
+			"version":        VerbProtocolVersion,
+			"min_version":    MinVerbProtocolVersion,
+			"daemon_version": d.version,
+			"verbs":          []verbDoc{describeVerb(p.Verb, entry)},
+			"error_codes":    errorCodeCatalog,
+			"envelope":       verbEnvelopeDoc,
+		}, nil
+	}
+
+	names := knownVerbNames()
+	verbs := make([]verbDoc, 0, len(names))
+	for _, name := range names {
+		verbs = append(verbs, describeVerb(name, verbRegistry[name]))
+	}
 	return map[string]any{
-		"type":    "verb_list",
-		"version": VerbProtocolVersion,
-		"verbs":   verbs,
+		"type":           "verb_list",
+		"version":        VerbProtocolVersion,
+		"min_version":    MinVerbProtocolVersion,
+		"daemon_version": d.version,
+		"verbs":          verbs,
+		"error_codes":    errorCodeCatalog,
+		"envelope":       verbEnvelopeDoc,
+	}, nil
+}
+
+// verbEnvelopeDoc describes the request and response envelopes themselves, so a
+// caller that has only ever seen list-verbs knows how to frame a call.
+var verbEnvelopeDoc = map[string]any{
+	"transport": "One JSON object per line on the daemon socket; one response line per request line.",
+	"request":   `{"id":<any>,"verb":"<name>","params":{...}}`,
+	"success":   `{"id":<echoed>,"result":{"type":"<result type>",...}}`,
+	"failure":   `{"id":<echoed>,"error":{"code":"<stable code>","message":"...","hint":{...}}}`,
+	"hint":      "Present on most failures. Names the verb or CLI command that resolves it, the offending parameter and its accepted values, the closest matching name, and what does exist.",
+}
+
+// describeVerb renders one registry entry as its documented form.
+func describeVerb(name string, entry verbEntry) verbDoc {
+	params := entry.params
+	if params == nil {
+		params = []verbParam{}
+	}
+	return verbDoc{
+		Verb:        name,
+		Description: entry.description,
+		Params:      params,
+		Examples:    entry.examples,
+	}
+}
+
+// verbHello implements the handshake verb. It exists so a version mismatch is
+// reported as a protocol_mismatch error on a live connection rather than
+// surfacing as a framing failure or a reset connection several calls later.
+//
+// A daemon that predates this verb answers unknown_verb, which still identifies
+// it as a working but older daemon; a daemon that predates the whole JSON
+// protocol closes the connection, which the client reports as a mismatch too.
+func (d *Daemon) verbHello(cs *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Client   string `json:"client"`
+		Version  string `json:"version"`
+		Protocol int    `json:"protocol"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+
+	if p.Protocol > VerbProtocolVersion {
+		return nil, hintedVerbError(ErrVerbProtocolMismatch,
+			fmt.Sprintf("client speaks protocol %d but this daemon only speaks up to %d", p.Protocol, VerbProtocolVersion),
+			&VerbHint{
+				Command: "tuios kill-server",
+				Detail: fmt.Sprintf("The daemon (version %s) is older than the client (version %s) and was left running across an upgrade. Restarting it lets the newer client connect.",
+					d.version, p.Version),
+			})
+	}
+	if p.Protocol > 0 && p.Protocol < MinVerbProtocolVersion {
+		return nil, hintedVerbError(ErrVerbProtocolMismatch,
+			fmt.Sprintf("client speaks protocol %d but this daemon no longer serves anything below %d", p.Protocol, MinVerbProtocolVersion),
+			&VerbHint{
+				Detail: fmt.Sprintf("The client (version %s) is older than the daemon (version %s). Upgrade the client.", p.Version, d.version),
+			})
+	}
+
+	if p.Client != "" {
+		LogBasic("Client %s identified as %s %s (protocol %d)", cs.clientID, p.Client, p.Version, p.Protocol)
+	}
+
+	return map[string]any{
+		"type":           "hello",
+		"protocol":       VerbProtocolVersion,
+		"min_protocol":   MinVerbProtocolVersion,
+		"daemon_version": d.version,
+		"pid":            os.Getpid(),
+		"sessions":       len(d.manager.ListSessions()),
 	}, nil
 }

--- a/internal/session/verb_protocol.go
+++ b/internal/session/verb_protocol.go
@@ -1,0 +1,300 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net"
+	"time"
+)
+
+// This file implements the typed, line-delimited JSON verb protocol layered
+// additively on the existing daemon socket. One request per line:
+//
+//	{"id": 1, "verb": "list-windows", "params": {"session": "work"}}
+//
+// and one response per line, either
+//
+//	{"id": 1, "result": {"type": "window_list", ...}}
+//
+// or
+//
+//	{"id": 1, "error": {"code": "session_not_found", "message": "..."}}
+//
+// The envelope id is opaque and echoed back verbatim. Error codes are stable
+// strings so a caller never has to cross-reference a numeric table. The binary
+// gob/PTY fast path is untouched; a connection is detected as JSON or binary
+// from its first byte on accept (see detectJSONClient).
+
+// VerbProtocolVersion is the version of the JSON verb protocol. It is reported
+// by the list-verbs introspection verb so a client can gate on it. Bump it only
+// on an incompatible change to the envelope or to an existing verb's contract;
+// adding a new verb is backward compatible and does not require a bump.
+const VerbProtocolVersion = 1
+
+// Stable string error codes returned in the response error envelope. These are
+// part of the public protocol surface; keep the string values stable.
+const (
+	ErrVerbInvalidRequest  = "invalid_request"   // line was not a valid request envelope
+	ErrVerbUnknownVerb     = "unknown_verb"      // no such verb
+	ErrVerbInvalidParams   = "invalid_params"    // params failed to decode or a required field was missing
+	ErrVerbSessionNotFound = "session_not_found" // named session does not exist
+	ErrVerbWindowNotFound  = "window_not_found"  // window target did not resolve
+	ErrVerbNoWindows       = "no_windows"        // session has no windows to act on
+	ErrVerbPTYNotFound     = "pty_not_found"     // the target window has no live PTY
+	ErrVerbNeedsClient     = "needs_client"      // verb needs a live renderer that is not attached
+	ErrVerbOptionNotFound  = "option_not_found"  // get-option key was never set
+	ErrVerbCommandFailed   = "command_failed"    // a verb routed to the attached client came back failed
+	ErrVerbInternal        = "internal"          // unexpected server-side failure
+)
+
+// verbRequest is one decoded request line. ID is opaque (number, string, or
+// absent) and echoed back on the response.
+type verbRequest struct {
+	ID     json.RawMessage `json:"id,omitempty"`
+	Verb   string          `json:"verb"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// verbError is the error envelope with a stable string code.
+type verbError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *verbError) Error() string { return e.Code + ": " + e.Message }
+
+// newVerbError builds a *verbError with the given code and message.
+func newVerbError(code, message string) *verbError {
+	return &verbError{Code: code, Message: message}
+}
+
+// verbResponse is one response line. Exactly one of Result or Error is set.
+type verbResponse struct {
+	ID     json.RawMessage `json:"id,omitempty"`
+	Result any             `json:"result,omitempty"`
+	Error  *verbError      `json:"error,omitempty"`
+}
+
+// verbHandler executes one verb. params carries the raw JSON of the request's
+// params object (may be empty). It returns a result value to serialize, or a
+// *verbError describing why it failed.
+type verbHandler func(d *Daemon, cs *connState, params json.RawMessage) (any, *verbError)
+
+// verbEntry pairs a handler with a one-line description for list-verbs.
+type verbEntry struct {
+	description string
+	handler     verbHandler
+}
+
+// verbRegistry is the dispatch table for every JSON verb the daemon supports.
+// It is built once at package init so list-verbs and dispatch share one source
+// of truth. It is populated in init() to avoid a static initialization cycle
+// (list-verbs reads the registry).
+var verbRegistry map[string]verbEntry
+
+func init() {
+	verbRegistry = map[string]verbEntry{
+		"list-verbs": {
+			description: "List every supported verb and the protocol version.",
+			handler:     (*Daemon).verbListVerbs,
+		},
+		"list-sessions": {
+			description: "List all sessions the daemon holds.",
+			handler:     (*Daemon).verbListSessions,
+		},
+		"session-info": {
+			description: "Report details about one session (params: session).",
+			handler:     (*Daemon).verbSessionInfo,
+		},
+		"list-windows": {
+			description: "List the windows in a session (params: session).",
+			handler:     (*Daemon).verbListWindows,
+		},
+		"new-window": {
+			description: "Create a new window (params: session, name).",
+			handler:     (*Daemon).verbNewWindow,
+		},
+		"close-window": {
+			description: "Close a window (params: session, window).",
+			handler:     (*Daemon).verbCloseWindow,
+		},
+		"send-keys": {
+			description: "Send parsed key tokens to a window (params: session, window, keys, literal, raw).",
+			handler:     (*Daemon).verbSendKeys,
+		},
+		"send-text": {
+			description: "Send literal text to a window's PTY (params: session, window, text).",
+			handler:     (*Daemon).verbSendText,
+		},
+		"capture-pane": {
+			description: "Capture a pane's content (params: session, window, source, styled, lines, start, end).",
+			handler:     (*Daemon).verbCapturePane,
+		},
+		"resize": {
+			description: "Resize a window's PTY (params: session, window, width, height).",
+			handler:     (*Daemon).verbResize,
+		},
+		"kill-session": {
+			description: "Terminate a session (params: session).",
+			handler:     (*Daemon).verbKillSession,
+		},
+		"set-option": {
+			description: "Set a session option (params: session, key, value).",
+			handler:     (*Daemon).verbSetOption,
+		},
+		"get-option": {
+			description: "Read a session option (params: session, key).",
+			handler:     (*Daemon).verbGetOption,
+		},
+	}
+}
+
+// detectJSONClient inspects the first byte of the connection without consuming
+// it. A JSON verb-protocol client's first byte is '{' or leading whitespace; a
+// binary client's is the high byte of a big-endian length prefix (0x00/0x01 for
+// any sub-16MB frame), so the two never collide. It returns true when the
+// connection should be handled as JSON. On any read error it returns false and
+// lets the (short) binary path observe the same error and clean up.
+func (d *Daemon) detectJSONClient(cs *connState, br *bufio.Reader) bool {
+	conn := cs.conn
+	for {
+		select {
+		case <-d.ctx.Done():
+			return false
+		case <-cs.done:
+			return false
+		default:
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		peeked, err := br.Peek(1)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			// EOF or hard error: not JSON; the binary loop will re-observe it.
+			_ = conn.SetReadDeadline(time.Time{})
+			return false
+		}
+
+		_ = conn.SetReadDeadline(time.Time{})
+		switch peeked[0] {
+		case '{', ' ', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+// handleJSONConnection runs the read/dispatch/respond loop for a JSON client. It
+// reads newline-delimited request objects, dispatches each, and writes one
+// response line per request. It blocks until the connection closes (which
+// shutdown and drop both trigger, unblocking the read).
+func (d *Daemon) handleJSONConnection(cs *connState, br *bufio.Reader) {
+	// No aggressive read deadline: an idle JSON control connection should not be
+	// dropped mid-wait. Shutdown and drop close the connection, which unblocks
+	// the scan and ends the loop.
+	_ = cs.conn.SetReadDeadline(time.Time{})
+
+	LogBasic("Client %s using JSON verb protocol", cs.clientID)
+
+	sc := bufio.NewScanner(br)
+	// Cap a single request line at the same 16MB ceiling as a binary frame so a
+	// runaway client cannot exhaust memory.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for sc.Scan() {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-cs.done:
+			return
+		default:
+		}
+
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		// Copy the line: Scanner reuses its buffer on the next Scan, and a routed
+		// verb may block (routeToTUISync) while holding a reference to params.
+		lineCopy := make([]byte, len(line))
+		copy(lineCopy, line)
+
+		if err := d.dispatchVerbLine(cs, lineCopy); err != nil {
+			// A write failure means the connection is gone; stop.
+			return
+		}
+	}
+}
+
+// dispatchVerbLine parses one request line, runs its verb, and writes the
+// response. It returns an error only when writing the response fails (the
+// connection is unusable); verb-level failures are returned to the client as an
+// error envelope, not as a Go error.
+func (d *Daemon) dispatchVerbLine(cs *connState, line []byte) error {
+	var req verbRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return d.writeVerbResponse(cs, &verbResponse{
+			Error: newVerbError(ErrVerbInvalidRequest, "malformed JSON request: "+err.Error()),
+		})
+	}
+
+	if req.Verb == "" {
+		return d.writeVerbResponse(cs, &verbResponse{
+			ID:    req.ID,
+			Error: newVerbError(ErrVerbInvalidRequest, "request is missing the \"verb\" field"),
+		})
+	}
+
+	entry, ok := verbRegistry[req.Verb]
+	if !ok {
+		return d.writeVerbResponse(cs, &verbResponse{
+			ID:    req.ID,
+			Error: newVerbError(ErrVerbUnknownVerb, "unknown verb "+req.Verb),
+		})
+	}
+
+	result, verr := entry.handler(d, cs, req.Params)
+	if verr != nil {
+		return d.writeVerbResponse(cs, &verbResponse{ID: req.ID, Error: verr})
+	}
+	return d.writeVerbResponse(cs, &verbResponse{ID: req.ID, Result: result})
+}
+
+// writeVerbResponse serializes resp as one newline-terminated JSON line and
+// writes it under the connection's send mutex with a write deadline.
+func (d *Daemon) writeVerbResponse(cs *connState, resp *verbResponse) error {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		// Should not happen; fall back to a minimal internal error line.
+		data = []byte(`{"error":{"code":"internal","message":"failed to encode response"}}`)
+	}
+	data = append(data, '\n')
+
+	cs.sendMu.Lock()
+	defer cs.sendMu.Unlock()
+	_ = cs.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_, werr := cs.conn.Write(data)
+	return werr
+}
+
+// verbListVerbs implements the list-verbs introspection verb.
+func (d *Daemon) verbListVerbs(_ *connState, _ json.RawMessage) (any, *verbError) {
+	verbs := make([]map[string]string, 0, len(verbRegistry))
+	for name, entry := range verbRegistry {
+		verbs = append(verbs, map[string]string{
+			"verb":        name,
+			"description": entry.description,
+		})
+	}
+	// Stable order so output is deterministic.
+	sortVerbEntries(verbs)
+	return map[string]any{
+		"type":    "verb_list",
+		"version": VerbProtocolVersion,
+		"verbs":   verbs,
+	}, nil
+}

--- a/internal/session/verb_protocol.go
+++ b/internal/session/verb_protocol.go
@@ -45,6 +45,7 @@ const (
 	ErrVerbNeedsClient     = "needs_client"      // verb needs a live renderer that is not attached
 	ErrVerbOptionNotFound  = "option_not_found"  // get-option key was never set
 	ErrVerbCommandFailed   = "command_failed"    // a verb routed to the attached client came back failed
+	ErrVerbTimeout         = "timeout"           // a wait-for condition did not match before its timeout
 	ErrVerbInternal        = "internal"          // unexpected server-side failure
 )
 
@@ -146,6 +147,18 @@ func init() {
 		"get-option": {
 			description: "Read a session option (params: session, key).",
 			handler:     (*Daemon).verbGetOption,
+		},
+		"subscribe": {
+			description: "Open a long-lived event stream on this connection (params: session, window, types, queue).",
+			handler:     (*Daemon).verbSubscribe,
+		},
+		"unsubscribe": {
+			description: "Close this connection's event stream.",
+			handler:     (*Daemon).verbUnsubscribe,
+		},
+		"wait-for": {
+			description: "Block until a condition matches (params: condition, session, window, pattern, idle, timeout).",
+			handler:     (*Daemon).verbWaitFor,
 		},
 	}
 }
@@ -261,7 +274,13 @@ func (d *Daemon) dispatchVerbLine(cs *connState, line []byte) error {
 	if verr != nil {
 		return d.writeVerbResponse(cs, &verbResponse{ID: req.ID, Error: verr})
 	}
-	return d.writeVerbResponse(cs, &verbResponse{ID: req.ID, Result: result})
+	if err := d.writeVerbResponse(cs, &verbResponse{ID: req.ID, Result: result}); err != nil {
+		return err
+	}
+	// A subscribe verb stashes its fresh subscription for the streamer, which must
+	// start only after the ack line above is on the wire so no event precedes it.
+	d.startPendingStream(cs)
+	return nil
 }
 
 // writeVerbResponse serializes resp as one newline-terminated JSON line and

--- a/internal/session/verb_protocol_test.go
+++ b/internal/session/verb_protocol_test.go
@@ -1,0 +1,423 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// startTestDaemon starts a real daemon listening on an isolated unix socket in a
+// temp XDG_RUNTIME_DIR, so it does not touch the developer's live daemon, socket,
+// or pid file. It returns the daemon and the socket path.
+func startTestDaemon(t *testing.T) (*Daemon, string) {
+	t.Helper()
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
+	if err := d.Start(); err != nil {
+		t.Fatalf("daemon Start: %v", err)
+	}
+	t.Cleanup(d.Stop)
+
+	sp, err := GetSocketPath()
+	if err != nil {
+		t.Fatalf("GetSocketPath: %v", err)
+	}
+	return d, sp
+}
+
+// verbConn is a raw JSON line client for the daemon socket.
+type verbConn struct {
+	conn net.Conn
+	r    *bufio.Reader
+}
+
+func dialVerb(t *testing.T, socketPath string) *verbConn {
+	t.Helper()
+	conn, err := net.DialTimeout("unix", socketPath, 3*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &verbConn{conn: conn, r: bufio.NewReader(conn)}
+}
+
+// send writes a raw line (a newline is appended).
+func (c *verbConn) send(t *testing.T, line string) {
+	t.Helper()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	if _, err := c.conn.Write([]byte(line + "\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// readResp reads and decodes one response line.
+func (c *verbConn) readResp(t *testing.T) map[string]any {
+	t.Helper()
+	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	line, err := c.r.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read: %v (partial=%q)", err, string(line))
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(line, &resp); err != nil {
+		t.Fatalf("decode response %q: %v", string(line), err)
+	}
+	return resp
+}
+
+// call sends a request and returns the decoded response.
+func (c *verbConn) call(t *testing.T, line string) map[string]any {
+	t.Helper()
+	c.send(t, line)
+	return c.readResp(t)
+}
+
+// result extracts the result object, failing if the response carried an error.
+func result(t *testing.T, resp map[string]any) map[string]any {
+	t.Helper()
+	if e, ok := resp["error"]; ok && e != nil {
+		t.Fatalf("expected result, got error: %v", e)
+	}
+	res, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result object: %v", resp)
+	}
+	return res
+}
+
+// errCode extracts the error code, failing if the response carried a result.
+func errCode(t *testing.T, resp map[string]any) string {
+	t.Helper()
+	e, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error, got: %v", resp)
+	}
+	code, _ := e["code"].(string)
+	return code
+}
+
+// makeSessionWithWindow creates a session holding one live daemon-owned window.
+func makeSessionWithWindow(t *testing.T, d *Daemon, name string) *Session {
+	t.Helper()
+	sess, err := d.manager.CreateSession(name, &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := sess.AddDaemonWindow("Window", nil); err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+	return sess
+}
+
+func TestVerbListVerbs(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	resp := c.call(t, `{"id":1,"verb":"list-verbs"}`)
+	if resp["id"] != float64(1) {
+		t.Errorf("id not echoed: %v", resp["id"])
+	}
+	res := result(t, resp)
+	if res["type"] != "verb_list" {
+		t.Errorf("type = %v, want verb_list", res["type"])
+	}
+	if res["version"] != float64(VerbProtocolVersion) {
+		t.Errorf("version = %v, want %d", res["version"], VerbProtocolVersion)
+	}
+	verbs, ok := res["verbs"].([]any)
+	if !ok || len(verbs) != len(verbRegistry) {
+		t.Fatalf("verbs list wrong: %v", res["verbs"])
+	}
+}
+
+func TestVerbListSessions(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "alpha")
+	makeSessionWithWindow(t, d, "beta")
+
+	c := dialVerb(t, sp)
+	res := result(t, c.call(t, `{"id":"s","verb":"list-sessions"}`))
+	if res["type"] != "session_list" {
+		t.Errorf("type = %v", res["type"])
+	}
+	sessions, ok := res["sessions"].([]any)
+	if !ok || len(sessions) != 2 {
+		t.Fatalf("want 2 sessions, got %v", res["sessions"])
+	}
+}
+
+func TestVerbSessionInfoAndListWindows(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+
+	info := result(t, c.call(t, `{"verb":"session-info","params":{"session":"work"}}`))
+	if info["type"] != "session_info" || info["session_name"] != "work" {
+		t.Errorf("session-info wrong: %v", info)
+	}
+
+	wins := result(t, c.call(t, `{"verb":"list-windows","params":{"session":"work"}}`))
+	if wins["type"] != "window_list" {
+		t.Errorf("list-windows type = %v", wins["type"])
+	}
+	if wins["total"] != float64(1) {
+		t.Errorf("total windows = %v, want 1", wins["total"])
+	}
+}
+
+func TestVerbNewAndCloseWindowHeadless(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess, err := d.manager.CreateSession("empty", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	c := dialVerb(t, sp)
+
+	created := result(t, c.call(t, `{"verb":"new-window","params":{"session":"empty","name":"build"}}`))
+	if created["type"] != "window_created" {
+		t.Errorf("type = %v", created["type"])
+	}
+	winID, _ := created["window_id"].(string)
+	if winID == "" {
+		t.Fatalf("no window_id in %v", created)
+	}
+	if got := len(sess.GetState().Windows); got != 1 {
+		t.Fatalf("session window count = %d, want 1", got)
+	}
+
+	closed := result(t, c.call(t, fmt.Sprintf(`{"verb":"close-window","params":{"session":"empty","window":%q}}`, winID)))
+	if closed["type"] != "ok" {
+		t.Errorf("close type = %v", closed["type"])
+	}
+	if got := len(sess.GetState().Windows); got != 0 {
+		t.Fatalf("session window count after close = %d, want 0", got)
+	}
+}
+
+func TestVerbSendTextAndCapturePane(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "cap")
+
+	c := dialVerb(t, sp)
+
+	ok := result(t, c.call(t, `{"verb":"send-text","params":{"session":"cap","text":"echo tuios-marker\n"}}`))
+	if ok["type"] != "ok" {
+		t.Errorf("send-text type = %v", ok["type"])
+	}
+
+	// Poll capture-pane for the echoed marker; the shell echoes asynchronously.
+	found := false
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		res := result(t, c.call(t, `{"verb":"capture-pane","params":{"session":"cap","source":"recent"}}`))
+		if res["type"] != "pane_content" {
+			t.Fatalf("capture type = %v", res["type"])
+		}
+		content, _ := res["content"].(string)
+		if len(content) > 0 && containsMarker(content) {
+			found = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !found {
+		t.Error("capture-pane never returned the echoed marker")
+	}
+}
+
+func containsMarker(s string) bool {
+	for i := 0; i+len("tuios-marker") <= len(s); i++ {
+		if s[i:i+len("tuios-marker")] == "tuios-marker" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestVerbSendKeysHeadless(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "keys")
+
+	c := dialVerb(t, sp)
+	res := result(t, c.call(t, `{"verb":"send-keys","params":{"session":"keys","keys":"ctrl+c"}}`))
+	if res["type"] != "ok" {
+		t.Errorf("send-keys type = %v", res["type"])
+	}
+
+	// A missing keys field is an invalid_params error.
+	code := errCode(t, c.call(t, `{"verb":"send-keys","params":{"session":"keys"}}`))
+	if code != ErrVerbInvalidParams {
+		t.Errorf("missing keys code = %q, want %q", code, ErrVerbInvalidParams)
+	}
+}
+
+func TestVerbResize(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "rz")
+
+	c := dialVerb(t, sp)
+	res := result(t, c.call(t, `{"verb":"resize","params":{"session":"rz","width":100,"height":40}}`))
+	if res["type"] != "resized" || res["width"] != float64(100) || res["height"] != float64(40) {
+		t.Errorf("resize result = %v", res)
+	}
+
+	code := errCode(t, c.call(t, `{"verb":"resize","params":{"session":"rz","width":0,"height":40}}`))
+	if code != ErrVerbInvalidParams {
+		t.Errorf("bad resize code = %q", code)
+	}
+}
+
+func TestVerbOptionsRoundTrip(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "opt")
+
+	c := dialVerb(t, sp)
+
+	set := result(t, c.call(t, `{"verb":"set-option","params":{"session":"opt","key":"theme","value":"dracula"}}`))
+	if set["type"] != "option_set" || set["value"] != "dracula" {
+		t.Errorf("set-option result = %v", set)
+	}
+
+	get := result(t, c.call(t, `{"verb":"get-option","params":{"session":"opt","key":"theme"}}`))
+	if get["value"] != "dracula" {
+		t.Errorf("get-option value = %v", get["value"])
+	}
+
+	code := errCode(t, c.call(t, `{"verb":"get-option","params":{"session":"opt","key":"missing"}}`))
+	if code != ErrVerbOptionNotFound {
+		t.Errorf("missing option code = %q, want %q", code, ErrVerbOptionNotFound)
+	}
+}
+
+func TestVerbKillSession(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "doomed")
+
+	c := dialVerb(t, sp)
+	res := result(t, c.call(t, `{"verb":"kill-session","params":{"session":"doomed"}}`))
+	if res["type"] != "ok" {
+		t.Errorf("kill type = %v", res["type"])
+	}
+	if d.manager.GetSession("doomed") != nil {
+		t.Error("session still present after kill-session")
+	}
+
+	code := errCode(t, c.call(t, `{"verb":"kill-session","params":{"session":"doomed"}}`))
+	if code != ErrVerbSessionNotFound {
+		t.Errorf("kill missing code = %q", code)
+	}
+}
+
+func TestVerbErrorCases(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	cases := []struct {
+		name string
+		line string
+		code string
+	}{
+		{"malformed", `{"id":1,"verb":`, ErrVerbInvalidRequest},
+		{"not-json", `this is not json`, ErrVerbInvalidRequest},
+		{"missing-verb", `{"id":2}`, ErrVerbInvalidRequest},
+		{"unknown-verb", `{"id":3,"verb":"teleport"}`, ErrVerbUnknownVerb},
+		{"unknown-session", `{"verb":"list-windows","params":{"session":"nope"}}`, ErrVerbSessionNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code := errCode(t, c.call(t, tc.line))
+			if code != tc.code {
+				t.Errorf("code = %q, want %q", code, tc.code)
+			}
+		})
+	}
+}
+
+// TestVerbConnectionSurvivesBadLine verifies a malformed line does not desync or
+// close the connection: a following valid request still works.
+func TestVerbConnectionSurvivesBadLine(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	_ = errCode(t, c.call(t, `{"garbage`))
+	res := result(t, c.call(t, `{"id":9,"verb":"list-verbs"}`))
+	if res["type"] != "verb_list" {
+		t.Errorf("connection did not recover; got %v", res)
+	}
+}
+
+// TestVerbIDEchoTypes verifies both numeric and string ids echo back verbatim.
+func TestVerbIDEcho(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+
+	if got := c.call(t, `{"id":7,"verb":"list-verbs"}`)["id"]; got != float64(7) {
+		t.Errorf("numeric id = %v", got)
+	}
+	if got := c.call(t, `{"id":"req-42","verb":"list-verbs"}`)["id"]; got != "req-42" {
+		t.Errorf("string id = %v", got)
+	}
+	// An absent id yields no id field on the response.
+	if _, present := c.call(t, `{"verb":"list-verbs"}`)["id"]; present {
+		t.Error("id present on response when request omitted it")
+	}
+}
+
+// TestVerbConcurrentClients drives many independent JSON connections at once.
+func TestVerbConcurrentClients(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "shared")
+
+	const clients = 12
+	const iters = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, clients)
+	for i := 0; i < clients; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := dialVerb(t, sp)
+			for j := 0; j < iters; j++ {
+				resp := c.call(t, `{"verb":"list-windows","params":{"session":"shared"}}`)
+				res, ok := resp["result"].(map[string]any)
+				if !ok || res["type"] != "window_list" {
+					errs <- fmt.Errorf("bad response: %v", resp)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestBinaryClientStillWorks verifies the existing binary protocol keeps working
+// on the same daemon that now also speaks JSON (backward compatibility).
+func TestBinaryClientStillWorks(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "binary")
+
+	client := NewClient(&ClientConfig{Version: "test"})
+	if err := client.Connect(); err != nil {
+		t.Fatalf("binary Connect: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("binary ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Name != "binary" {
+		t.Fatalf("binary client got %v", sessions)
+	}
+}

--- a/internal/session/verb_protocol_test.go
+++ b/internal/session/verb_protocol_test.go
@@ -12,10 +12,16 @@ import (
 
 // startTestDaemon starts a real daemon listening on an isolated unix socket in a
 // temp XDG_RUNTIME_DIR, so it does not touch the developer's live daemon, socket,
-// or pid file. It returns the daemon and the socket path.
+// or pid file. Resurrection state is redirected to a temp directory too, because
+// the state dir is resolved at package init and cannot be redirected by setting
+// an environment variable; without this, every test that creates a session writes
+// a real state file into the developer's state directory. It returns the daemon
+// and the socket path.
 func startTestDaemon(t *testing.T) (*Daemon, string) {
 	t.Helper()
 	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	t.Cleanup(useResurrectionDir(t.TempDir()))
 
 	d := NewDaemon(&DaemonConfig{Version: "test", DisableAutoRestore: true})
 	if err := d.Start(); err != nil {

--- a/internal/session/verb_subscribe.go
+++ b/internal/session/verb_subscribe.go
@@ -1,0 +1,372 @@
+package session
+
+import (
+	"encoding/json"
+	"regexp"
+	"time"
+)
+
+// This file implements the subscribe and wait-for verbs on top of the event hub
+// (daemon_events.go). subscribe turns a JSON connection into a long-lived event
+// stream; wait-for is sugar over a short-lived internal subscription that blocks
+// until a condition matches or a timeout elapses, replacing a caller's
+// capture-pane polling loop.
+
+// defaultWaitTimeout bounds a wait-for verb that omits an explicit timeout.
+const defaultWaitTimeout = 30 * time.Second
+
+// defaultIdleWindow is the quiet period a window-idle wait uses when the request
+// omits an idle duration.
+const defaultIdleWindow = 500 * time.Millisecond
+
+// waitOutputRecheck is a cheap in-process backstop interval for wait-for-output.
+// The output events drive an immediate re-check; this ticker only guards the rare
+// case where the final matching output event was dropped by the slow-subscriber
+// policy, so the wait still resolves without a caller-side poll loop.
+const waitOutputRecheck = 200 * time.Millisecond
+
+// verbSubscribe opens a long-lived event stream on this connection. It registers
+// a hub subscription with the requested filter, returns a subscribed ack (with
+// the current sequence baseline), and hands the subscription to the dispatch loop
+// which starts the streamer after the ack is written. Only a connection that
+// issued this verb ever receives events.
+func (d *Daemon) verbSubscribe(cs *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string   `json:"session"`
+		Window  string   `json:"window"`
+		Types   []string `json:"types"`
+		Queue   int      `json:"queue"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+
+	cs.mu.Lock()
+	if cs.streaming {
+		cs.mu.Unlock()
+		return nil, newVerbError(ErrVerbInvalidRequest, "connection is already subscribed")
+	}
+	cs.mu.Unlock()
+
+	filter := eventFilter{session: p.Session, window: p.Window}
+	if len(p.Types) > 0 {
+		filter.types = make(map[string]bool, len(p.Types))
+		for _, t := range p.Types {
+			filter.types[t] = true
+		}
+	}
+
+	sub := d.events.subscribe(filter, p.Queue)
+
+	cs.mu.Lock()
+	cs.eventSub = sub
+	cs.pendingStream = sub
+	cs.streaming = true
+	cs.mu.Unlock()
+
+	return map[string]any{"type": EventSubscribed, "seq": d.events.currentSeq()}, nil
+}
+
+// verbUnsubscribe closes this connection's event stream. The streamer observes
+// the stop signal, clears the connection's stream state, and unsubscribes from
+// the hub.
+func (d *Daemon) verbUnsubscribe(cs *connState, _ json.RawMessage) (any, *verbError) {
+	cs.mu.Lock()
+	sub := cs.eventSub
+	cs.mu.Unlock()
+	if sub == nil {
+		return nil, newVerbError(ErrVerbInvalidRequest, "connection is not subscribed")
+	}
+	// Signal the streamer to exit; it clears cs.eventSub/streaming and removes the
+	// hub subscription on its way out.
+	sub.close()
+	return map[string]any{"type": "unsubscribed"}, nil
+}
+
+// startPendingStream launches the event streamer for a subscription handed over
+// by the subscribe handler, once its ack has been written. It is a no-op for
+// every other verb.
+func (d *Daemon) startPendingStream(cs *connState) {
+	cs.mu.Lock()
+	sub := cs.pendingStream
+	cs.pendingStream = nil
+	cs.mu.Unlock()
+	if sub == nil {
+		return
+	}
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.streamEvents(cs, sub)
+	}()
+}
+
+// streamEvents pushes events from a subscription to the connection until the
+// connection closes, the daemon shuts down, or the subscription is stopped. A
+// full subscriber queue drops events at publish time; the streamer surfaces those
+// drops as a gap marker written just before the next surviving event, so a slow
+// subscriber never blocks the daemon (the daemon_stream.go discipline).
+func (d *Daemon) streamEvents(cs *connState, sub *eventSub) {
+	defer d.events.unsubscribe(sub)
+	defer func() {
+		cs.mu.Lock()
+		if cs.eventSub == sub {
+			cs.eventSub = nil
+			cs.streaming = false
+		}
+		cs.mu.Unlock()
+	}()
+
+	for {
+		select {
+		case <-cs.done:
+			return
+		case <-d.ctx.Done():
+			return
+		case <-sub.stop:
+			return
+		case ev := <-sub.ch:
+			if dropped := sub.dropped.Swap(0); dropped > 0 {
+				if err := d.writeEventLine(cs, streamEvent{Type: EventGap, Dropped: dropped}); err != nil {
+					cs.drop()
+					return
+				}
+			}
+			if err := d.writeEventLine(cs, ev); err != nil {
+				cs.drop()
+				return
+			}
+		}
+	}
+}
+
+// writeEventLine serializes ev as one newline-terminated JSON line and writes it
+// under the connection's send mutex with a write deadline.
+func (d *Daemon) writeEventLine(cs *connState, ev streamEvent) error {
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	cs.sendMu.Lock()
+	defer cs.sendMu.Unlock()
+	_ = cs.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_, werr := cs.conn.Write(data)
+	return werr
+}
+
+// verbWaitFor blocks until a condition matches or a timeout elapses, returning a
+// wait_result on match and a timeout error otherwise. It is sugar over a
+// short-lived internal hub subscription, so a caller need not poll capture-pane.
+func (d *Daemon) verbWaitFor(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Condition string `json:"condition"`
+		Session   string `json:"session"`
+		Window    string `json:"window"`
+		Pattern   string `json:"pattern"`
+		Source    string `json:"source"`
+		Idle      int    `json:"idle"`
+		Timeout   int    `json:"timeout"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+
+	timeout := defaultWaitTimeout
+	if p.Timeout > 0 {
+		timeout = time.Duration(p.Timeout) * time.Millisecond
+	}
+	deadline := time.After(timeout)
+
+	switch p.Condition {
+	case "session-exists":
+		return d.waitSessionExists(p.Session, deadline)
+	case "window-output":
+		return d.waitWindowOutput(p.Session, p.Window, p.Pattern, p.Source, deadline)
+	case "window-exit":
+		return d.waitWindowExit(p.Session, p.Window, deadline)
+	case "window-idle":
+		return d.waitWindowIdle(p.Session, p.Window, p.Idle, deadline)
+	default:
+		return nil, newVerbError(ErrVerbInvalidParams,
+			"unknown condition "+p.Condition+" (want session-exists, window-output, window-exit, or window-idle)")
+	}
+}
+
+// waitMatched builds a successful wait_result for the given condition.
+func waitMatched(condition string, extra map[string]any) map[string]any {
+	res := map[string]any{"type": "wait_result", "condition": condition, "matched": true}
+	for k, v := range extra {
+		res[k] = v
+	}
+	return res
+}
+
+// waitSessionExists resolves when a session named name exists. It subscribes
+// before the initial check so a session created in the race window is not missed.
+func (d *Daemon) waitSessionExists(name string, deadline <-chan time.Time) (any, *verbError) {
+	if name == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "session is required for session-exists")
+	}
+	sub := d.events.subscribe(eventFilter{
+		session: name,
+		types:   map[string]bool{EventSessionCreated: true},
+	}, defaultEventQueue)
+	defer d.events.unsubscribe(sub)
+
+	if d.manager.GetSession(name) != nil {
+		return waitMatched("session-exists", map[string]any{"session": name}), nil
+	}
+	for {
+		select {
+		case <-deadline:
+			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for session "+name)
+		case <-d.ctx.Done():
+			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
+		case <-sub.ch:
+			if d.manager.GetSession(name) != nil {
+				return waitMatched("session-exists", map[string]any{"session": name}), nil
+			}
+		}
+	}
+}
+
+// waitWindowExit resolves when the target window's shell process exits.
+func (d *Daemon) waitWindowExit(sessionName, window string, deadline <-chan time.Time) (any, *verbError) {
+	sess, verr := d.resolveVerbSession(sessionName)
+	if verr != nil {
+		return nil, verr
+	}
+	pty, err := d.resolvePTYForTarget(sess, window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+
+	sub := d.events.subscribe(eventFilter{
+		session: sess.Name,
+		ptyID:   pty.ID,
+		types:   map[string]bool{EventWindowExit: true, EventWindowClosed: true},
+	}, defaultEventQueue)
+	defer d.events.unsubscribe(sub)
+
+	if pty.IsExited() {
+		return waitMatched("window-exit", map[string]any{"window": window}), nil
+	}
+	for {
+		select {
+		case <-deadline:
+			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to exit")
+		case <-d.ctx.Done():
+			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
+		case <-sub.ch:
+			return waitMatched("window-exit", map[string]any{"window": window}), nil
+		}
+	}
+}
+
+// waitWindowIdle resolves when the target window produces no output for idleMs
+// milliseconds. Each output event resets the idle timer.
+func (d *Daemon) waitWindowIdle(sessionName, window string, idleMs int, deadline <-chan time.Time) (any, *verbError) {
+	sess, verr := d.resolveVerbSession(sessionName)
+	if verr != nil {
+		return nil, verr
+	}
+	pty, err := d.resolvePTYForTarget(sess, window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+
+	idle := defaultIdleWindow
+	if idleMs > 0 {
+		idle = time.Duration(idleMs) * time.Millisecond
+	}
+
+	sub := d.events.subscribe(eventFilter{
+		session: sess.Name,
+		ptyID:   pty.ID,
+		types:   map[string]bool{EventOutput: true},
+	}, defaultEventQueue)
+	defer d.events.unsubscribe(sub)
+
+	timer := time.NewTimer(idle)
+	defer timer.Stop()
+	for {
+		select {
+		case <-deadline:
+			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to go idle")
+		case <-d.ctx.Done():
+			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
+		case <-sub.ch:
+			// Output arrived; restart the idle window.
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idle)
+		case <-timer.C:
+			return waitMatched("window-idle", map[string]any{"window": window, "idle_ms": int(idle / time.Millisecond)}), nil
+		}
+	}
+}
+
+// waitWindowOutput resolves when the target window's captured content matches
+// pattern. It subscribes and checks once before waiting (so already-present
+// output matches immediately), then re-checks on each output event; a gap marker
+// or dropped event cannot hang the wait because a low-rate backstop ticker also
+// re-checks.
+func (d *Daemon) waitWindowOutput(sessionName, window, pattern, source string, deadline <-chan time.Time) (any, *verbError) {
+	if pattern == "" {
+		return nil, newVerbError(ErrVerbInvalidParams, "pattern is required for window-output")
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, newVerbError(ErrVerbInvalidParams, "invalid pattern: "+err.Error())
+	}
+	sess, verr := d.resolveVerbSession(sessionName)
+	if verr != nil {
+		return nil, verr
+	}
+	pty, err := d.resolvePTYForTarget(sess, window)
+	if err != nil {
+		return nil, mapResolveErr(err)
+	}
+
+	// Default to matching recent (scrollback-inclusive) content so output that has
+	// already scrolled off the visible screen still matches; source "visible"
+	// restricts to the current screen.
+	scrollback := source != "visible"
+	matches := func() bool { return re.MatchString(pty.CaptureContent(scrollback, false)) }
+
+	sub := d.events.subscribe(eventFilter{
+		session: sess.Name,
+		ptyID:   pty.ID,
+		types:   map[string]bool{EventOutput: true},
+	}, defaultEventQueue)
+	defer d.events.unsubscribe(sub)
+
+	if matches() {
+		return waitMatched("window-output", map[string]any{"window": window, "pattern": pattern}), nil
+	}
+
+	backstop := time.NewTicker(waitOutputRecheck)
+	defer backstop.Stop()
+	for {
+		select {
+		case <-deadline:
+			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for output matching "+pattern)
+		case <-d.ctx.Done():
+			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
+		case <-sub.ch:
+			if matches() {
+				return waitMatched("window-output", map[string]any{"window": window, "pattern": pattern}), nil
+			}
+		case <-backstop.C:
+			if matches() {
+				return waitMatched("window-output", map[string]any{"window": window, "pattern": pattern}), nil
+			}
+		}
+	}
+}

--- a/internal/session/verb_subscribe.go
+++ b/internal/session/verb_subscribe.go
@@ -44,7 +44,10 @@ func (d *Daemon) verbSubscribe(cs *connState, params json.RawMessage) (any, *ver
 	cs.mu.Lock()
 	if cs.streaming {
 		cs.mu.Unlock()
-		return nil, newVerbError(ErrVerbInvalidRequest, "connection is already subscribed")
+		return nil, hintedVerbError(ErrVerbInvalidRequest, "connection is already subscribed", &VerbHint{
+			Verb:   "unsubscribe",
+			Detail: "One event stream per connection. Call unsubscribe first, or open a second connection for the second filter.",
+		})
 	}
 	cs.mu.Unlock()
 
@@ -75,7 +78,10 @@ func (d *Daemon) verbUnsubscribe(cs *connState, _ json.RawMessage) (any, *verbEr
 	sub := cs.eventSub
 	cs.mu.Unlock()
 	if sub == nil {
-		return nil, newVerbError(ErrVerbInvalidRequest, "connection is not subscribed")
+		return nil, hintedVerbError(ErrVerbInvalidRequest, "connection is not subscribed", &VerbHint{
+			Verb:   "subscribe",
+			Detail: "There is no event stream on this connection to close.",
+		})
 	}
 	// Signal the streamer to exit; it clears cs.eventSub/streaming and removes the
 	// hub subscription on its way out.
@@ -189,8 +195,15 @@ func (d *Daemon) verbWaitFor(_ *connState, params json.RawMessage) (any, *verbEr
 	case "window-idle":
 		return d.waitWindowIdle(p.Session, p.Window, p.Idle, deadline)
 	default:
-		return nil, newVerbError(ErrVerbInvalidParams,
-			"unknown condition "+p.Condition+" (want session-exists, window-output, window-exit, or window-idle)")
+		message := "unknown condition " + p.Condition
+		if p.Condition == "" {
+			message = "condition is required"
+		}
+		return nil, hintedVerbError(ErrVerbInvalidParams, message, &VerbHint{
+			Param:      "condition",
+			Accepted:   waitConditions,
+			DidYouMean: closestMatch(p.Condition, waitConditions),
+		})
 	}
 }
 
@@ -207,7 +220,7 @@ func waitMatched(condition string, extra map[string]any) map[string]any {
 // before the initial check so a session created in the race window is not missed.
 func (d *Daemon) waitSessionExists(name string, deadline <-chan time.Time) (any, *verbError) {
 	if name == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "session is required for session-exists")
+		return nil, invalidParam("session", "session is required for the session-exists condition")
 	}
 	sub := d.events.subscribe(eventFilter{
 		session: name,
@@ -221,7 +234,11 @@ func (d *Daemon) waitSessionExists(name string, deadline <-chan time.Time) (any,
 	for {
 		select {
 		case <-deadline:
-			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for session "+name)
+			return nil, hintedVerbError(ErrVerbTimeout, "timed out waiting for session "+name, &VerbHint{
+				Param:  "timeout",
+				Verb:   "list-sessions",
+				Detail: "The session was never created within the timeout. Check the name, or raise timeout (milliseconds).",
+			})
 		case <-d.ctx.Done():
 			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
 		case <-sub.ch:
@@ -240,7 +257,7 @@ func (d *Daemon) waitWindowExit(sessionName, window string, deadline <-chan time
 	}
 	pty, err := d.resolvePTYForTarget(sess, window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 
 	sub := d.events.subscribe(eventFilter{
@@ -256,7 +273,10 @@ func (d *Daemon) waitWindowExit(sessionName, window string, deadline <-chan time
 	for {
 		select {
 		case <-deadline:
-			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to exit")
+			return nil, hintedVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to exit", &VerbHint{
+				Param:  "timeout",
+				Detail: "The window's shell was still running when the timeout elapsed. Raise timeout (milliseconds), or send the command that ends it.",
+			})
 		case <-d.ctx.Done():
 			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
 		case <-sub.ch:
@@ -274,7 +294,7 @@ func (d *Daemon) waitWindowIdle(sessionName, window string, idleMs int, deadline
 	}
 	pty, err := d.resolvePTYForTarget(sess, window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 
 	idle := defaultIdleWindow
@@ -294,7 +314,10 @@ func (d *Daemon) waitWindowIdle(sessionName, window string, idleMs int, deadline
 	for {
 		select {
 		case <-deadline:
-			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to go idle")
+			return nil, hintedVerbError(ErrVerbTimeout, "timed out waiting for window "+window+" to go idle", &VerbHint{
+				Param:  "idle",
+				Detail: "The window never stayed quiet for the idle window. Raise timeout, or raise idle if the process outputs in bursts.",
+			})
 		case <-d.ctx.Done():
 			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
 		case <-sub.ch:
@@ -319,11 +342,14 @@ func (d *Daemon) waitWindowIdle(sessionName, window string, idleMs int, deadline
 // re-checks.
 func (d *Daemon) waitWindowOutput(sessionName, window, pattern, source string, deadline <-chan time.Time) (any, *verbError) {
 	if pattern == "" {
-		return nil, newVerbError(ErrVerbInvalidParams, "pattern is required for window-output")
+		return nil, invalidParam("pattern", "pattern is required for the window-output condition")
 	}
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, newVerbError(ErrVerbInvalidParams, "invalid pattern: "+err.Error())
+		return nil, hintedVerbError(ErrVerbInvalidParams, "invalid pattern: "+err.Error(), &VerbHint{
+			Param:  "pattern",
+			Detail: "pattern is a Go regular expression (RE2 syntax).",
+		})
 	}
 	sess, verr := d.resolveVerbSession(sessionName)
 	if verr != nil {
@@ -331,7 +357,7 @@ func (d *Daemon) waitWindowOutput(sessionName, window, pattern, source string, d
 	}
 	pty, err := d.resolvePTYForTarget(sess, window)
 	if err != nil {
-		return nil, mapResolveErr(err)
+		return nil, mapResolveErr(err, sess)
 	}
 
 	// Default to matching recent (scrollback-inclusive) content so output that has
@@ -356,7 +382,11 @@ func (d *Daemon) waitWindowOutput(sessionName, window, pattern, source string, d
 	for {
 		select {
 		case <-deadline:
-			return nil, newVerbError(ErrVerbTimeout, "timed out waiting for output matching "+pattern)
+			return nil, hintedVerbError(ErrVerbTimeout, "timed out waiting for output matching "+pattern, &VerbHint{
+				Param:  "pattern",
+				Verb:   "capture-pane",
+				Detail: "No output matched before the timeout. Capture the pane to see what it actually printed, then adjust the pattern or raise timeout.",
+			})
 		case <-d.ctx.Done():
 			return nil, newVerbError(ErrVerbInternal, "daemon is shutting down")
 		case <-sub.ch:

--- a/internal/session/verb_subscribe_test.go
+++ b/internal/session/verb_subscribe_test.go
@@ -1,0 +1,235 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSubscribeReceivesWindowLifecycle verifies a subscribed connection receives
+// a window-created event, carrying a sequence number, when a window is created.
+func TestSubscribeReceivesWindowLifecycle(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	ack := result(t, c.call(t, `{"id":1,"verb":"subscribe","params":{"session":"work","types":["window-created"]}}`))
+	if ack["type"] != EventSubscribed {
+		t.Fatalf("ack type = %v, want subscribed", ack["type"])
+	}
+
+	if _, err := sess.AddDaemonWindow("second", nil); err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+
+	ev := c.readResp(t)
+	if ev["type"] != EventWindowCreated {
+		t.Fatalf("event type = %v, want window-created", ev["type"])
+	}
+	if _, ok := ev["seq"].(float64); !ok {
+		t.Fatalf("event missing numeric seq: %v", ev["seq"])
+	}
+	if ev["session"] != "work" {
+		t.Fatalf("event session = %v, want work", ev["session"])
+	}
+}
+
+// TestSubscribeTwoSubscribersSameSequence verifies two independent connections
+// subscribed to the same events see identical sequence numbers over the wire.
+func TestSubscribeTwoSubscribersSameSequence(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+
+	a := dialVerb(t, sp)
+	b := dialVerb(t, sp)
+	result(t, a.call(t, `{"id":1,"verb":"subscribe","params":{"session":"work","types":["window-created"]}}`))
+	result(t, b.call(t, `{"id":1,"verb":"subscribe","params":{"session":"work","types":["window-created"]}}`))
+
+	if _, err := sess.AddDaemonWindow("x", nil); err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+
+	ea := a.readResp(t)
+	eb := b.readResp(t)
+	if ea["type"] != EventWindowCreated || eb["type"] != EventWindowCreated {
+		t.Fatalf("types = %v / %v, want window-created", ea["type"], eb["type"])
+	}
+	sa, _ := ea["seq"].(float64)
+	sb, _ := eb["seq"].(float64)
+	if sa == 0 || sa != sb {
+		t.Fatalf("subscribers saw different seq: a=%v b=%v", ea["seq"], eb["seq"])
+	}
+}
+
+// TestUnsubscribedConnectionReceivesNoEvents verifies a connection that never
+// subscribed is never sent events: it only ever gets its own verb responses.
+func TestUnsubscribedConnectionReceivesNoEvents(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	// A normal request/response works.
+	result(t, c.call(t, `{"id":1,"verb":"list-windows","params":{"session":"work"}}`))
+
+	// Cause events on the daemon.
+	if _, err := sess.AddDaemonWindow("noise", nil); err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+
+	// No event line should arrive; a short read must time out.
+	_ = c.conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, err := c.r.ReadBytes('\n'); err == nil {
+		t.Fatal("unsubscribed connection unexpectedly received an event line")
+	}
+}
+
+// TestWaitForOutputRacingPTY verifies wait-for window-output resolves the moment
+// a real PTY produces matching output, without the caller polling.
+func TestWaitForOutputRacingPTY(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"window-output","session":"work","pattern":"WAITMARK","timeout":8000}}`)
+	}()
+
+	// Give the wait a moment to subscribe, then race real output in.
+	time.Sleep(150 * time.Millisecond)
+	pty, err := d.resolvePTYForTarget(sess, "")
+	if err != nil {
+		t.Fatalf("resolvePTYForTarget: %v", err)
+	}
+	if _, err := pty.Write([]byte("echo WAITMARK\r")); err != nil {
+		t.Fatalf("pty write: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		res := result(t, resp)
+		if res["matched"] != true {
+			t.Fatalf("wait result not matched: %v", res)
+		}
+		if res["condition"] != "window-output" {
+			t.Fatalf("condition = %v, want window-output", res["condition"])
+		}
+	case <-time.After(12 * time.Second):
+		t.Fatal("wait-for window-output did not resolve")
+	}
+}
+
+// TestWaitForTimeout verifies a wait whose condition never matches returns the
+// stable timeout error code.
+func TestWaitForTimeout(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	resp := c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"window-output","session":"work","pattern":"NEVER_APPEARS_ZZZ_9137","timeout":300}}`)
+	if code := errCode(t, resp); code != ErrVerbTimeout {
+		t.Fatalf("error code = %q, want %q", code, ErrVerbTimeout)
+	}
+}
+
+// TestWaitForWindowExit verifies wait-for window-exit resolves when the target
+// window's shell process exits.
+func TestWaitForWindowExit(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"window-exit","session":"work","timeout":8000}}`)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	pty, err := d.resolvePTYForTarget(sess, "")
+	if err != nil {
+		t.Fatalf("resolvePTYForTarget: %v", err)
+	}
+	if _, err := pty.Write([]byte("exit\r")); err != nil {
+		t.Fatalf("pty write: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		res := result(t, resp)
+		if res["matched"] != true {
+			t.Fatalf("wait result not matched: %v", res)
+		}
+	case <-time.After(12 * time.Second):
+		t.Fatal("wait-for window-exit did not resolve")
+	}
+}
+
+// TestWaitForWindowIdle verifies wait-for window-idle resolves after a quiet
+// period with no output.
+func TestWaitForWindowIdle(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	start := time.Now()
+	resp := c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"window-idle","session":"work","idle":250,"timeout":8000}}`)
+	res := result(t, resp)
+	if res["matched"] != true {
+		t.Fatalf("wait result not matched: %v", res)
+	}
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("idle resolved too fast (%v); should wait out the idle window", elapsed)
+	}
+}
+
+// TestWaitForSessionExists verifies wait-for session-exists resolves when a
+// session with the requested name is created after the wait begins.
+func TestWaitForSessionExists(t *testing.T) {
+	d, sp := startTestDaemon(t)
+
+	c := dialVerb(t, sp)
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"session-exists","session":"later","timeout":8000}}`)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	if _, err := d.manager.CreateSession("later", &SessionConfig{}, 80, 24); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		res := result(t, resp)
+		if res["matched"] != true || res["session"] != "later" {
+			t.Fatalf("wait result = %v, want matched session later", res)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait-for session-exists did not resolve")
+	}
+}
+
+// TestWaitForSessionExistsAlreadyTrue verifies the wait returns immediately when
+// the session already exists.
+func TestWaitForSessionExistsAlreadyTrue(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	makeSessionWithWindow(t, d, "work")
+
+	c := dialVerb(t, sp)
+	resp := c.call(t, `{"id":1,"verb":"wait-for","params":{"condition":"session-exists","session":"work","timeout":8000}}`)
+	res := result(t, resp)
+	if res["matched"] != true {
+		t.Fatalf("wait result not matched: %v", res)
+	}
+}
+
+// TestSubscribeRejectsSecondSubscription verifies a connection cannot open two
+// event streams at once.
+func TestSubscribeRejectsSecondSubscription(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+	result(t, c.call(t, `{"id":1,"verb":"subscribe","params":{}}`))
+	resp := c.call(t, `{"id":2,"verb":"subscribe","params":{}}`)
+	if code := errCode(t, resp); code != ErrVerbInvalidRequest {
+		t.Fatalf("second subscribe error = %q, want %q", code, ErrVerbInvalidRequest)
+	}
+}


### PR DESCRIPTION
Third of four stacked branches. Targets `feat/session-resurrection`. This is the largest of the four and the one that adds new public surface, so it deserves the most review attention.

## What changed and why

Scripting tuios meant driving the TUI. There was no way to ask the daemon to do something and know whether it worked.

This adds a line-delimited JSON verb protocol on the daemon socket.

- Each request is one JSON object per line with a request id; each response carries that id back. `VerbClient` is the client half, and the existing remote commands now speak it instead of ad hoc messages.
- Mutating verbs run against daemon state when no client is attached, so scripts work headlessly. This is what the previous branch's daemon-side session construction bought us.
- `tuios new --detach` creates a session without attaching to it.
- A per-session option store lives on the daemon rather than in each client.

**Events and waiting**

- A control-plane event hub with session event sources, plus `subscribe` and `wait-for` verbs. Window lifecycle events are derived from state convergence rather than emitted by hand at each call site, so both mutation paths produce the same events. There is a test that asserts exactly that.
- `docs/protocol.md` documents the verb protocol, the handshake, the hint object, the event stream, and which events fire under which conditions.

**Diagnostics**

Degraded states used to surface as a bare error or a hang. Every one now explains a cause and a fix, including detection of a daemon that predates the control protocol, which is the failure people will actually hit when a new client meets an old running daemon.

**Shutdown ordering**

Several correctness fixes fell out of writing the e2e tests. `kill-server` now waits for the daemon to finish, socket removal is the last act of shutdown, and there is a documented completion contract with a test asserting `kill-server` returns only after state is saved. `capture-pane` rejects unknown sources instead of silently ignoring them.

## Behavior changes to be aware of

- An unexpected daemon EOF now quits the local client cleanly rather than leaving it spinning against a dead socket. An attached client also exits when its session is killed.
- Remote commands now go over the verb protocol. Output shapes should be unchanged, but this is the place to look if a script behaves differently.

## Design notes

Line-delimited JSON over the existing socket, rather than a second port or an RPC framework, keeps the transport and the auth story unchanged and stays greppable in a terminal.

Deriving lifecycle events from state convergence instead of emitting them at call sites is the decision the fourth branch depends on. If events are emitted by hand, every new mutation path is a chance to forget one.

## Verification

- `go build ./...` and `go vet ./...` clean on this branch.
- Full `go test -race -count=1 ./...` and `-tags e2e` green on the tip of the stack.
- New e2e coverage for headless control-plane operation, resurrection, the handshake, hints, and CLI failure messages. Resurrection state is isolated per test.
- The protocol-version mismatch path and the CLI failure messages are covered by the e2e tests rather than by interactive checks.
