### PR TITLE
Fix resize correctness and latency, and nested kitty graphics

### DIFF
--- a/internal/app/capabilities.go
+++ b/internal/app/capabilities.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,15 +15,26 @@ import (
 // These are used to determine which features TUIOS can use for rendering.
 type HostCapabilities struct {
 	KittyGraphics bool
-	SixelGraphics bool
-	TrueColor     bool
-	TerminalName  string
-	PixelWidth    int
-	PixelHeight   int
-	CellWidth     int
-	CellHeight    int
-	Cols          int
-	Rows          int
+	// KittyFileTransfer reports whether the host terminal can read a
+	// server-local path out of a kitty t=f / t=t / t=s transmission.
+	//
+	// A terminal sharing our filesystem (kitty, ghostty, wezterm) can, and
+	// forwarding the path is far cheaper than shipping the pixels. A browser
+	// client such as sip's cannot: it only ever sees the bytes we send it, so
+	// a forwarded path is silently dropped and the image never appears. When
+	// this is false the passthrough reads the file itself and re-encodes it as
+	// a direct (t=d) transmission, and tells guests that file media are
+	// unsupported so they stream instead.
+	KittyFileTransfer bool
+	SixelGraphics     bool
+	TrueColor         bool
+	TerminalName      string
+	PixelWidth        int
+	PixelHeight       int
+	CellWidth         int
+	CellHeight        int
+	Cols              int
+	Rows              int
 }
 
 var cachedCapabilities *HostCapabilities
@@ -149,12 +161,27 @@ func queryGraphicsSupport(caps *HostCapabilities) {
 	}
 	defer restoreTerminal(tty.Fd(), oldState)
 
-	// Send both queries at once
+	// Probe direct transmission (i=1) and, if we can stage a file for it,
+	// file transmission (i=2). The ids let the two answers be told apart; the
+	// spec requires a terminal to echo the id it was asked about.
+	probeFile, probeFileErr := writeGraphicsProbeFile()
+	if probeFileErr == nil {
+		defer func() { _ = os.Remove(probeFile) }()
+	}
+
+	terminators := 2                                                    // DA1 'c' plus the direct probe's ST
 	_, _ = tty.WriteString("\x1b[c")                                    // DA1 for sixel
 	_, _ = tty.WriteString("\x1b_Gi=1,a=q,t=d,f=24,s=1,v=1;AAAA\x1b\\") // Kitty graphics query
+	if probeFileErr == nil {
+		// t=f rather than t=t: a terminal that honours a temp-file
+		// transmission deletes the file, and this one is ours to clean up.
+		_, _ = fmt.Fprintf(tty, "\x1b_Gi=2,a=q,t=f,f=24,s=1,v=1;%s\x1b\\",
+			base64.StdEncoding.EncodeToString([]byte(probeFile)))
+		terminators++
+	}
 
 	// Read response with timeout (300ms to account for slower terminals)
-	response := readTTYResponse(tty, 300*time.Millisecond)
+	response := readTTYResponse(tty, 300*time.Millisecond, terminators)
 
 	// Parse DA1 response for sixel (look for "4" in params)
 	da1Re := regexp.MustCompile(`\x1b\[\?([0-9;]+)c`)
@@ -168,16 +195,56 @@ func queryGraphicsSupport(caps *HostCapabilities) {
 	if strings.Contains(response, "OK") {
 		caps.KittyGraphics = true
 	}
+	// File transfer is only claimed on an explicit OK for the i=2 probe. A
+	// terminal that ignores the probe, answers without an id, or reports an
+	// error leaves this false, and the passthrough re-encodes file
+	// transmissions as direct ones. That costs a copy but always renders;
+	// guessing the other way renders nothing at all.
+	caps.KittyFileTransfer = probeFileErr == nil && kittyProbeOK(response, 2)
+}
+
+// kittyProbeOK reports whether the host answered "OK" to the a=q probe sent
+// with the given image id.
+func kittyProbeOK(response string, id int) bool {
+	re := regexp.MustCompile(`\x1b_G([^;\x1b]*);([^\x1b]*)\x1b\\`)
+	want := fmt.Sprintf("i=%d", id)
+	for _, m := range re.FindAllStringSubmatch(response, -1) {
+		if !slices.Contains(strings.Split(m[1], ","), want) {
+			continue
+		}
+		return strings.HasPrefix(m[2], "OK")
+	}
+	return false
+}
+
+// writeGraphicsProbeFile stages a one-pixel RGB payload on disk for the
+// file-transmission capability probe.
+func writeGraphicsProbeFile() (string, error) {
+	f, err := os.CreateTemp("", "tuios-gfx-probe-*")
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	if _, err := f.Write([]byte{0, 0, 0}); err != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", err
+	}
+	return name, nil
 }
 
 // readTTYResponse reads from tty with a timeout using poll-based I/O
-func readTTYResponse(tty *os.File, timeout time.Duration) string {
+func readTTYResponse(tty *os.File, timeout time.Duration, wantTerminators int) string {
 	buf := make([]byte, 512)
 	var result strings.Builder
 	terminators := 0
 	deadline := time.Now().Add(timeout)
 
-	for terminators < 2 {
+	for terminators < wantTerminators {
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			break
@@ -245,7 +312,7 @@ func queryPixelDimensions(caps *HostCapabilities) {
 
 	// Query window size in pixels
 	_, _ = tty.WriteString("\x1b[14t")
-	response := readTTYResponse(tty, 100*time.Millisecond)
+	response := readTTYResponse(tty, 100*time.Millisecond, 2)
 	if re := regexp.MustCompile(`\x1b\[4;(\d+);(\d+)t`); response != "" {
 		if matches := re.FindStringSubmatch(response); len(matches) == 3 {
 			caps.PixelHeight, _ = strconv.Atoi(matches[1])
@@ -255,7 +322,7 @@ func queryPixelDimensions(caps *HostCapabilities) {
 
 	// Query cell size
 	_, _ = tty.WriteString("\x1b[16t")
-	response = readTTYResponse(tty, 100*time.Millisecond)
+	response = readTTYResponse(tty, 100*time.Millisecond, 2)
 	if re := regexp.MustCompile(`\x1b\[6;(\d+);(\d+)t`); response != "" {
 		if matches := re.FindStringSubmatch(response); len(matches) == 3 {
 			caps.CellHeight, _ = strconv.Atoi(matches[1])

--- a/internal/app/kitty_passthrough_forward.go
+++ b/internal/app/kitty_passthrough_forward.go
@@ -161,14 +161,58 @@ func (kp *KittyPassthrough) ForwardCommand(
 	return nil
 }
 
+// forwardQuery answers a guest's a=q capability probe.
+//
+// The answer has to be honest about the transmission medium, not just about
+// graphics in general. kitten icat opens with three probes - direct, temp file
+// and shared memory - and commits to whichever medium comes back OK. Answering
+// OK to all three makes it pick a file medium and send us a path, which we
+// forward to the host; a host that does not share our filesystem (sip's
+// browser client) drops it silently and no image is ever drawn. Reporting file
+// media unsupported when the host cannot read files makes the guest stream the
+// bytes instead, which passes through cleanly.
 func (kp *KittyPassthrough) forwardQuery(cmd *vt.KittyCommand, _ []byte, ptyInput func([]byte)) {
-	if ptyInput != nil && cmd.Quiet < 2 {
-		response := vt.BuildKittyResponse(true, cmd.ImageID, "")
-		kittyPassthroughLog("forwardQuery: sending response for imageID=%d, response=%q, ptyInput=%v", cmd.ImageID, response, ptyInput != nil)
-		ptyInput(response)
-	} else {
-		kittyPassthroughLog("forwardQuery: NOT sending response, ptyInput=%v, quiet=%d", ptyInput != nil, cmd.Quiet)
+	if ptyInput == nil {
+		kittyPassthroughLog("forwardQuery: NOT sending response, no ptyInput")
+		return
 	}
+
+	ok := true
+	errMsg := ""
+	if isFileMedium(cmd.Medium) && !kp.hostReadsFiles() {
+		ok = false
+		errMsg = "ENOTSUPPORTED:host terminal cannot read files from this machine"
+	}
+
+	// Quiet mode: q=1 suppresses successes, q=2 suppresses everything. An
+	// error still has to reach a guest that asked for q=1, or it waits out its
+	// timeout instead of moving on to the next medium.
+	if cmd.Quiet >= 2 || (cmd.Quiet >= 1 && ok) {
+		kittyPassthroughLog("forwardQuery: suppressed by quiet=%d (ok=%v)", cmd.Quiet, ok)
+		return
+	}
+
+	response := vt.BuildKittyResponse(ok, cmd.ImageID, errMsg)
+	kittyPassthroughLog("forwardQuery: imageID=%d medium=%c ok=%v response=%q", cmd.ImageID, cmd.Medium, ok, response)
+	ptyInput(response)
+}
+
+// isFileMedium reports whether a transmission medium names a path on this
+// machine rather than carrying the image bytes inline.
+func isFileMedium(medium vt.KittyGraphicsMedium) bool {
+	return medium == vt.KittyMediumFile ||
+		medium == vt.KittyMediumTempFile ||
+		medium == vt.KittyMediumSharedMemory
+}
+
+// hostReadsFiles reports whether a file path forwarded to the host terminal
+// will actually resolve there. False for a browser client, whose only view of
+// an image is the bytes we send it.
+func (kp *KittyPassthrough) hostReadsFiles() bool {
+	if kp.inlineGraphics {
+		return false
+	}
+	return GetHostCapabilities().KittyFileTransfer
 }
 
 func (kp *KittyPassthrough) forwardTransmit(cmd *vt.KittyCommand, rawData []byte, windowID string, andPlace bool, windowX, windowY, windowWidth, windowHeight, contentOffsetX, contentOffsetY, cursorX, cursorY, scrollbackLen int, isAltScreen bool) *PlacementResult {
@@ -419,13 +463,16 @@ func (kp *KittyPassthrough) forwardFileTransmit(cmd *vt.KittyCommand, windowID s
 
 	kittyPassthroughLog("forwardFileTransmit: file=%s, andPlace=%v, medium=%c", filePath, andPlace, cmd.Medium)
 
-	// In inline-graphics mode (tuios-web) the host terminal cannot read
-	// files on the server. Read the file ourselves and divert into the
-	// direct-transmission path so the bytes reach the browser over the
-	// sip PTY. This is critical for apps like youterm / mpv that use
-	// shared-memory frames (t=s, /dev/shm/...) and for any t=f / t=t
-	// transmission.
-	if kp.inlineGraphics {
+	// When the host terminal cannot read files on this machine, read the file
+	// ourselves and divert into the direct-transmission path so the bytes
+	// reach it inline. That is always the case for a browser target: the
+	// tuios-web build (inlineGraphics), and equally a native tuios whose own
+	// host happens to be a browser client such as sip's, which the capability
+	// probe reports through KittyFileTransfer. Critical for apps like youterm
+	// / mpv that use shared-memory frames (t=s, /dev/shm/...) and for any t=f
+	// / t=t transmission. Guests that honour our a=q answer stream directly
+	// and never reach this path; this covers the ones that do not ask.
+	if !kp.hostReadsFiles() {
 		kp.forwardFileTransmitInline(cmd, filePath, windowID, andPlace,
 			windowX, windowY, windowWidth, windowHeight,
 			contentOffsetX, contentOffsetY,

--- a/internal/app/kitty_query_medium_test.go
+++ b/internal/app/kitty_query_medium_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// newQueryTestPassthrough builds a passthrough whose host either can or cannot
+// read files from this machine, without going near a real terminal.
+func newQueryTestPassthrough(t *testing.T, hostReadsFiles bool) *KittyPassthrough {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = devnull.Close() })
+
+	// clientCapabilities takes precedence in GetHostCapabilities, so setting
+	// it keeps the test off the real terminal's detection path entirely.
+	previous := clientCapabilities
+	clientCapabilities = &HostCapabilities{
+		KittyGraphics:     true,
+		KittyFileTransfer: hostReadsFiles,
+		CellWidth:         9,
+		CellHeight:        20,
+	}
+	t.Cleanup(func() { clientCapabilities = previous })
+
+	kp := NewKittyPassthroughWithOptions(KittyPassthroughOptions{Output: devnull})
+	kp.enabled = true
+	// ForceEnable would also pin inlineGraphics; leave it off so the test
+	// exercises the capability rather than the tuios-web override.
+	kp.inlineGraphics = false
+	return kp
+}
+
+func queryResponse(kp *KittyPassthrough, cmd *vt.KittyCommand) string {
+	var got []byte
+	kp.forwardQuery(cmd, nil, func(response []byte) { got = append(got, response...) })
+	return string(got)
+}
+
+// TestForwardQueryReportsFileMediaUnsupported pins the fix for kitty graphics
+// failing when tuios runs inside a browser-backed terminal such as sip's.
+//
+// kitten icat probes direct, temp-file and shared-memory transmission and
+// commits to whichever comes back OK. Answering OK to a file medium the host
+// cannot read makes it send a path that the host silently drops, and no image
+// is ever drawn.
+func TestForwardQueryReportsFileMediaUnsupported(t *testing.T) {
+	kp := newQueryTestPassthrough(t, false)
+
+	if got := queryResponse(kp, &vt.KittyCommand{ImageID: 1, Medium: vt.KittyMediumDirect}); got != "\x1b_Gi=1;OK\x1b\\" {
+		t.Errorf("direct transmission should be supported, got %q", got)
+	}
+
+	for name, medium := range map[string]vt.KittyGraphicsMedium{
+		"temp file":     vt.KittyMediumTempFile,
+		"file":          vt.KittyMediumFile,
+		"shared memory": vt.KittyMediumSharedMemory,
+	} {
+		got := queryResponse(kp, &vt.KittyCommand{ImageID: 2, Medium: medium})
+		want := "\x1b_Gi=2;ENOTSUPPORTED:host terminal cannot read files from this machine\x1b\\"
+		if got != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestForwardQueryAllowsFileMediaOnCapableHost keeps the cheap path: a host
+// sharing our filesystem reads the file itself and we never copy the pixels.
+func TestForwardQueryAllowsFileMediaOnCapableHost(t *testing.T) {
+	kp := newQueryTestPassthrough(t, true)
+
+	for name, medium := range map[string]vt.KittyGraphicsMedium{
+		"temp file":     vt.KittyMediumTempFile,
+		"shared memory": vt.KittyMediumSharedMemory,
+	} {
+		if got := queryResponse(kp, &vt.KittyCommand{ImageID: 7, Medium: medium}); got != "\x1b_Gi=7;OK\x1b\\" {
+			t.Errorf("%s: got %q, want OK", name, got)
+		}
+	}
+}
+
+// TestForwardQueryQuietMode: q=1 drops successes only, q=2 drops everything.
+// An error has to survive q=1 or a guest waits out its timeout rather than
+// trying the next medium.
+func TestForwardQueryQuietMode(t *testing.T) {
+	kp := newQueryTestPassthrough(t, false)
+
+	if got := queryResponse(kp, &vt.KittyCommand{ImageID: 1, Medium: vt.KittyMediumDirect, Quiet: 1}); got != "" {
+		t.Errorf("q=1 should suppress a success, got %q", got)
+	}
+	if got := queryResponse(kp, &vt.KittyCommand{ImageID: 1, Medium: vt.KittyMediumTempFile, Quiet: 1}); got == "" {
+		t.Error("q=1 should still report an error")
+	}
+	if got := queryResponse(kp, &vt.KittyCommand{ImageID: 1, Medium: vt.KittyMediumTempFile, Quiet: 2}); got != "" {
+		t.Errorf("q=2 should suppress everything, got %q", got)
+	}
+}
+
+func TestKittyProbeOK(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+		id       int
+		want     bool
+	}{
+		{"ok for the asked id", "\x1b_Gi=2;OK\x1b\\", 2, true},
+		{"error for the asked id", "\x1b_Gi=2;ENOTSUPPORTED:no\x1b\\", 2, false},
+		{"another id's ok does not count", "\x1b_Gi=1;OK\x1b\\", 2, false},
+		{"picks its own id out of several", "\x1b_Gi=1;OK\x1b\\\x1b_Gi=2;EBADF:x\x1b\\", 2, false},
+		{"unanswered", "\x1b[?62;4c", 2, false},
+		{"id-less ok does not count", "\x1b_GOK\x1b\\", 2, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := kittyProbeOK(tc.response, tc.id); got != tc.want {
+				t.Errorf("kittyProbeOK(%q, %d) = %v, want %v", tc.response, tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -185,9 +185,13 @@ type OS struct {
 	cachedSeparator      string // Cached dock separator string
 	cachedSeparatorWidth int    // Width of cached separator
 	workspaceActiveStyle *lipgloss.Style
-	cachedViewContent    string           // Cached full View() output to skip rendering on idle ticks
-	renderSkipped        bool             // True when frame-skip fired; View() returns cached content
-	renderCanvas         *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
+	cachedViewContent    string // Cached full View() output to skip rendering on idle ticks
+	renderSkipped        bool   // True when frame-skip fired; View() returns cached content
+	// lastInteractionRender is when a drag/resize motion event last produced a
+	// frame. Motion events arrive faster than a frame can be composed, so this
+	// bounds how often they are allowed to redraw.
+	lastInteractionRender time.Time
+	renderCanvas          *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
 	// Reused per-frame scratch for graphics placement refresh (avoids per-frame allocs)
 	kittyPosMap     map[string]*WindowPositionInfo // Reused map for kitty placement refresh
 	kittyPosBacking []WindowPositionInfo           // Backing storage for kittyPosMap values

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -191,7 +191,13 @@ type OS struct {
 	// frame. Motion events arrive faster than a frame can be composed, so this
 	// bounds how often they are allowed to redraw.
 	lastInteractionRender time.Time
-	renderCanvas          *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
+	// pendingBSPSync is set when a resize motion changed window geometry and the
+	// BSP tree's ratios have not been re-derived from it yet. The sync exists so
+	// the shared-borders separator overlay follows the drag, so it only has to
+	// run on frames that are actually composed; it is whole-tree work and running
+	// it per motion event makes the drag cost scale with window count.
+	pendingBSPSync bool
+	renderCanvas   *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
 	// Reused per-frame scratch for graphics placement refresh (avoids per-frame allocs)
 	kittyPosMap     map[string]*WindowPositionInfo // Reused map for kitty placement refresh
 	kittyPosBacking []WindowPositionInfo           // Backing storage for kittyPosMap values

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -366,6 +366,17 @@ func (m *OS) View() tea.View {
 	if m.renderSkipped && m.cachedViewContent != "" {
 		view.SetContent(m.cachedViewContent)
 	} else {
+		// A resize drag applies the new geometry to the windows immediately but
+		// defers the matching BSP ratio sync, because the sync is whole-tree
+		// work and motion events outnumber frames. The separator overlay reads
+		// its positions from the tree and its highlight from live window
+		// geometry, so composing while the two disagree draws the divider at the
+		// position the drag has already left, in the unfocused color because it
+		// is no longer on the focused pane's perimeter. Flushing here rather
+		// than on the drag's own code path covers every way a frame can be
+		// composed mid-drag, including PTY output, which arrives on a path that
+		// knows nothing about the drag.
+		m.FlushPendingBSPSync()
 		content := m.composeFrame()
 		m.cachedViewContent = content
 		view.SetContent(content)

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -246,9 +246,13 @@ func (m *OS) MarkBSPSyncPending() {
 	m.pendingBSPSync = true
 }
 
-// FlushPendingBSPSync runs a deferred ratio sync if one is outstanding. Call it
-// immediately before composing a frame so the separator overlay is drawn from
-// ratios that match the geometry in that same frame.
+// FlushPendingBSPSync runs a deferred ratio sync if one is outstanding. Its one
+// caller is View, immediately before it composes, and that is the only correct
+// place for it: the overlay mixes tree ratios with live window geometry, so the
+// sync has to happen on every frame that is composed rather than on the paths
+// that change geometry. Frames arrive from elsewhere too, PTY output most of
+// all, and one composed between a motion event and its sync draws the divider
+// where the drag has already left.
 func (m *OS) FlushPendingBSPSync() {
 	if m.pendingBSPSync {
 		m.SyncBSPTreeFromGeometry()

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -229,9 +229,37 @@ func (m *OS) RemoveWindowFromBSPTree(window *terminal.Window) {
 	m.ApplyBSPLayout()
 }
 
+// MarkBSPSyncPending records that window geometry moved during a drag and the
+// BSP tree's ratios no longer match it. The sync itself is deferred to the next
+// composed frame by FlushPendingBSPSync, because its only job during a drag is
+// to keep the separator overlay under the pointer, and a frame that is never
+// drawn cannot show a stale separator.
+//
+// The deferral is only safe because it is bounded on both ends: the interaction
+// tick composes a frame for as long as a drag is live, so a pending sync is
+// never held for more than one frame interval, and mouse release calls
+// SyncBSPTreeFromGeometry unconditionally. That last one cannot be skipped -
+// the tree ratios, not the window rectangles, are what survives a retile, so a
+// drag that ended without a final sync would have its result discarded the next
+// time the layout was applied.
+func (m *OS) MarkBSPSyncPending() {
+	m.pendingBSPSync = true
+}
+
+// FlushPendingBSPSync runs a deferred ratio sync if one is outstanding. Call it
+// immediately before composing a frame so the separator overlay is drawn from
+// ratios that match the geometry in that same frame.
+func (m *OS) FlushPendingBSPSync() {
+	if m.pendingBSPSync {
+		m.SyncBSPTreeFromGeometry()
+	}
+}
+
 // SyncBSPTreeFromGeometry updates the BSP tree's split ratios to match current window positions.
 // This should be called after mouse resize operations complete.
 func (m *OS) SyncBSPTreeFromGeometry() {
+	m.pendingBSPSync = false
+
 	tree := m.WorkspaceTrees[m.CurrentWorkspace]
 	if tree == nil || tree.IsEmpty() {
 		return

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -325,14 +325,6 @@ func TickCmd() tea.Cmd {
 	})
 }
 
-// SlowTickCmd creates a command that generates tick messages at 30 FPS.
-// Used during user interactions to improve responsiveness.
-func SlowTickCmd() tea.Cmd {
-	return tea.Tick(time.Second/time.Duration(config.InteractionFPS), func(t time.Time) tea.Msg {
-		return TickerMsg(t)
-	})
-}
-
 // IdleTickCmd creates a command that generates tick messages at 10 FPS.
 // Used when the terminal has been idle for a sustained period to reduce CPU.
 func IdleTickCmd() tea.Cmd {
@@ -553,7 +545,12 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// Determine next tick rate
 		var nextTick tea.Cmd
 		if m.InteractionMode {
-			nextTick = SlowTickCmd() // 30 FPS during drag/resize
+			// Motion events are coalesced to a frame budget in the input path,
+			// so this tick is what flushes the most recent skipped position.
+			// It runs at the normal rate: dropping it to a lower one used to
+			// cost smoothness without limiting the motion flood, since motion
+			// events drove their own renders regardless of the tick rate.
+			nextTick = TickCmd()
 		} else if hasAnimations || m.PrefixActive || m.ScriptMode || needsDockTick {
 			nextTick = TickCmd() // Normal FPS when things need periodic updates
 		} else {
@@ -576,6 +573,12 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			return m, nextTick
 		}
 		m.renderSkipped = false
+		// This tick is about to draw, so it counts against the interaction frame
+		// budget too. Without this a motion event landing just after a tick
+		// would draw again immediately and the budget would not hold.
+		if m.InteractionMode {
+			m.lastInteractionRender = time.Now()
+		}
 		// Graphics refresh (kitty/sixel) happens in GetCanvas during View().
 
 		if len(cmds) > 1 {
@@ -660,10 +663,33 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// would not be drawn until some other redraw happened.
 		m.renderSkipped = false
 		// Delegate to the registered input handler
-		if inputHandler != nil {
-			return inputHandler(msg, m)
+		if inputHandler == nil {
+			return m, nil
 		}
-		return m, nil
+		newModel, cmd := inputHandler(msg, m)
+
+		// Motion events during a drag or resize arrive far faster than a frame
+		// can be composed: the pointer emits one per cell it crosses, while a
+		// frame costs milliseconds. Rendering every one builds a backlog that
+		// grows for as long as the drag lasts, which is why the layout trails
+		// the pointer instead of merely being a frame behind it.
+		//
+		// Only the redundant intermediate frames are dropped, never the input.
+		// The handler above has already applied this event's geometry, so the
+		// model always reflects the newest pointer position; skipping the draw
+		// just means the next draw shows a later position. The interaction tick
+		// forces a render while InteractionMode is set, so a skipped motion is
+		// always flushed within one tick, and mouse release is not a motion
+		// event so the final position is drawn unconditionally.
+		if _, isMotion := msg.(tea.MouseMotionMsg); isMotion && m.InteractionMode {
+			now := time.Now()
+			if now.Sub(m.lastInteractionRender) < time.Second/time.Duration(config.NormalFPS) {
+				m.renderSkipped = true
+			} else {
+				m.lastInteractionRender = now
+			}
+		}
+		return newModel, cmd
 
 	case tea.WindowSizeMsg:
 		oldWidth, oldHeight := m.Width, m.Height

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -578,9 +578,6 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// would draw again immediately and the budget would not hold.
 		if m.InteractionMode {
 			m.lastInteractionRender = time.Now()
-			// This is the tick that flushes a motion whose draw was coalesced
-			// away, so it has to carry that motion's ratio sync with it.
-			m.FlushPendingBSPSync()
 		}
 		// Graphics refresh (kitty/sixel) happens in GetCanvas during View().
 
@@ -691,11 +688,6 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			} else {
 				m.lastInteractionRender = now
 			}
-		}
-		// A frame is about to be composed for this event, so any ratio sync the
-		// handler deferred has to happen now, before View reads the tree.
-		if !m.renderSkipped {
-			m.FlushPendingBSPSync()
 		}
 		return newModel, cmd
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -578,6 +578,9 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// would draw again immediately and the budget would not hold.
 		if m.InteractionMode {
 			m.lastInteractionRender = time.Now()
+			// This is the tick that flushes a motion whose draw was coalesced
+			// away, so it has to carry that motion's ratio sync with it.
+			m.FlushPendingBSPSync()
 		}
 		// Graphics refresh (kitty/sixel) happens in GetCanvas during View().
 
@@ -688,6 +691,11 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			} else {
 				m.lastInteractionRender = now
 			}
+		}
+		// A frame is about to be composed for this event, so any ratio sync the
+		// handler deferred has to happen now, before View reads the tree.
+		if !m.renderSkipped {
+			m.FlushPendingBSPSync()
 		}
 		return newModel, cmd
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -83,10 +83,6 @@ var (
 	// this value) can take effect without a restart.
 	MaxFPSCap = 240
 
-	// InteractionFPS is the refresh rate during user interactions (drag/resize)
-	// Lower FPS during interactions improves mouse responsiveness
-	InteractionFPS = 30
-
 	// IdleFPS is the refresh rate when the terminal is idle (no output for ~500ms).
 	// Reduces CPU usage from ~10% to near-zero on idle.
 	IdleFPS = 10

--- a/internal/input/mouse_motion.go
+++ b/internal/input/mouse_motion.go
@@ -328,9 +328,12 @@ func handleMouseMotion(msg tea.MouseMotionMsg, o *app.OS) (*app.OS, tea.Cmd) {
 			// In tiling mode, update visual state but defer PTY resize until drag completes
 			// Store pending resizes for all affected windows
 			o.AdjustTilingNeighborsVisual(focusedWindow, newX, newY, newWidth, newHeight)
-			// Sync BSP ratios continuously so separator overlay follows the resize
+			// The separator overlay is drawn from the tree's ratios, so they have
+			// to catch up with the new geometry before the next frame. Mark it
+			// rather than syncing here: syncing walks every node in the tree and
+			// reapplies the layout, and motion events outnumber frames.
 			if config.SharedBorders {
-				o.SyncBSPTreeFromGeometry()
+				o.MarkBSPSyncPending()
 			}
 		} else if o.UseScrollingLayout {
 			// Scrolling mode: compute width from horizontal drag delta.

--- a/internal/input/resize_coalesce_test.go
+++ b/internal/input/resize_coalesce_test.go
@@ -1,0 +1,117 @@
+package input
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// releaseAt is the message bubbletea delivers when the drag ends.
+func releaseAt(x, y int) tea.MouseReleaseMsg {
+	return tea.MouseReleaseMsg(uv.MouseReleaseEvent{
+		X:      x,
+		Y:      y,
+		Button: uv.MouseButton(tea.MouseLeft),
+	})
+}
+
+// TestResizeMotionRendersAreBoundedAndKeepFinalFrame drives a burst of motion
+// events through the real Update path the way a fast drag does, then releases,
+// and inspects the frames that actually came out of View.
+//
+// Two things are checked. Frames composed during the drag must not exceed the
+// interaction frame budget, which is the property that stops a fast drag from
+// building a render backlog. And the frame after release must show the geometry
+// of the last pointer position: coalescing that dropped the final event would
+// leave the layout settled somewhere other than where the user let go.
+//
+// The frame bound is stated as a rate rather than as "some event was skipped"
+// so that it holds on slow builds too. Under the race detector a single frame
+// can cost more than the budget on its own, in which case no event needs
+// coalescing and the bound is satisfied trivially.
+func TestResizeMotionRendersAreBoundedAndKeepFinalFrame(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	m := benchResizeOS(t, 4)
+	startX, startY := m.ResizeStartX, m.ResizeStartY
+
+	// Prime the cache so the coalesced path has a frame to repeat.
+	prev := m.View().Content
+
+	const steps = 40
+	composed := 0
+	start := time.Now()
+	for i := 1; i <= steps; i++ {
+		_, _ = m.Update(motionAt(startX-i, startY))
+		got := m.View().Content
+		if got != prev {
+			composed++
+		}
+		prev = got
+	}
+	elapsed := time.Since(start)
+
+	budget := time.Second / time.Duration(config.NormalFPS)
+	// One frame of slack for the leading edge, one for scheduling jitter.
+	maxFrames := int(elapsed/budget) + 2
+	if composed > maxFrames {
+		t.Fatalf("drag composed %d frames in %v, more than the %d the %v interaction "+
+			"budget allows; motion events are still driving unbounded renders",
+			composed, elapsed, maxFrames, budget)
+	}
+
+	finalX := startX - steps
+	_, _ = m.Update(releaseAt(finalX, startY))
+	finalFrame := m.View().Content
+
+	// The geometry must reflect the last motion, not an earlier coalesced one.
+	focused := m.GetFocusedWindow()
+	if focused == nil {
+		t.Fatal("no focused window after drag")
+	}
+	if got := focused.X + focused.Width; got != finalX {
+		t.Fatalf("resized edge settled at %d, want the released pointer position %d", got, finalX)
+	}
+
+	// And that geometry must be what is on screen. Release is not a motion
+	// event, so it is never coalesced and always composes.
+	if finalFrame == prev {
+		t.Fatal("frame after mouse release repeated the cached mid-drag frame; " +
+			"the final position never reached the screen")
+	}
+}
+
+// TestResizeInteractionTickFlushesSkippedMotion checks the other half of the
+// contract: a motion event that was coalesced away is still guaranteed to reach
+// the screen, because the interaction tick forces a render while a drag is live.
+// Without that, a pointer that stops moving would leave the layout stale until
+// the user nudged it again.
+func TestResizeInteractionTickFlushesSkippedMotion(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	m := benchResizeOS(t, 4)
+	startX, startY := m.ResizeStartX, m.ResizeStartY
+	_ = m.View()
+
+	_, _ = m.Update(motionAt(startX-1, startY))
+	afterFirst := m.View().Content
+	_, _ = m.Update(motionAt(startX-2, startY))
+	afterSecond := m.View().Content
+
+	if afterSecond != afterFirst {
+		// The second event cleared the frame budget on its own and drew itself,
+		// so there is nothing pending for the tick to flush. That happens on
+		// slow builds where a frame costs more than the budget.
+		t.Skip("second motion event was not coalesced on this build; nothing to flush")
+	}
+
+	_, _ = m.Update(app.TickerMsg(time.Now()))
+	if afterTick := m.View().Content; afterTick == afterSecond {
+		t.Fatal("interaction tick did not compose the coalesced motion; " +
+			"a paused pointer would leave the layout stale")
+	}
+}

--- a/internal/input/resize_coalesce_test.go
+++ b/internal/input/resize_coalesce_test.go
@@ -115,3 +115,100 @@ func TestResizeInteractionTickFlushesSkippedMotion(t *testing.T) {
 			"a paused pointer would leave the layout stale")
 	}
 }
+
+// TestSharedBorderResizeSettlesAtRelease drives a shared-borders resize drag
+// through the real Update path and checks the two things deferring the ratio
+// sync could break: the layout has to settle where the pointer was released,
+// and it has to stay there when the workspace is retiled. The second check is
+// the one that matters, because a retile rebuilds geometry from the tree's
+// ratios, so a drag whose final sync was skipped would silently lose its result
+// the next time anything triggered a layout.
+func TestSharedBorderResizeSettlesAtRelease(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	prev := config.SharedBorders
+	config.SharedBorders = true
+	t.Cleanup(func() { config.SharedBorders = prev })
+
+	m := benchResizeOS(t, 4)
+	startX, startY := m.ResizeStartX, m.ResizeStartY
+	before := m.View().Content
+
+	const steps = 20
+	midDrag := ""
+	for i := 1; i <= steps; i++ {
+		_, _ = m.Update(motionAt(startX-i, startY))
+		// A real drag is interleaved with interaction ticks, which is what
+		// flushes a motion whose draw was coalesced away.
+		if i%4 == 0 {
+			_, _ = m.Update(app.TickerMsg(time.Now()))
+		}
+		midDrag = m.View().Content
+	}
+	// The separator has to track the pointer while the drag is in flight, not
+	// only once it ends. That is the whole reason the sync runs during a drag.
+	if midDrag == before {
+		t.Fatal("no frame during the drag differed from the pre-drag frame; the layout did not follow the pointer")
+	}
+
+	finalX := startX - steps
+	_, _ = m.Update(releaseAt(finalX, startY))
+	after := m.View().Content
+	if after == before {
+		t.Fatal("frame after release is identical to the frame before the drag; the resize never reached the screen")
+	}
+
+	focused := m.GetFocusedWindow()
+	if focused == nil {
+		t.Fatal("no focused window after drag")
+	}
+	settled := focused.X + focused.Width
+
+	// Retiling reapplies the layout from the tree's ratios. If the drag's final
+	// sync ran, the geometry is already what the ratios describe and nothing
+	// moves; if it was skipped, the window snaps back to its pre-drag size.
+	geom := make(map[string][4]int, len(m.Windows))
+	for _, w := range m.Windows {
+		geom[w.ID] = [4]int{w.X, w.Y, w.Width, w.Height}
+	}
+	m.TileAllWindows()
+	for _, w := range m.Windows {
+		if got, want := ([4]int{w.X, w.Y, w.Width, w.Height}), geom[w.ID]; got != want {
+			t.Fatalf("window %s moved on retile: got %v, want %v; the drag's ratios were not committed to the tree", w.ID, got, want)
+		}
+	}
+
+	if settled >= startX {
+		t.Fatalf("resized edge settled at %d, which is not left of the drag start %d", settled, startX)
+	}
+}
+
+// TestSharedBorderMotionCostDoesNotScaleWithWindowCount is the guard on the
+// property this optimisation exists for. The ratio sync is whole-tree work, so
+// running it per motion event made a shared-borders drag cost more the more
+// windows the workspace held, while the same drag without shared borders stayed
+// flat. Allocations stand in for cost here because they are deterministic.
+func TestSharedBorderMotionCostDoesNotScaleWithWindowCount(t *testing.T) {
+	prev := config.SharedBorders
+	config.SharedBorders = true
+	t.Cleanup(func() { config.SharedBorders = prev })
+
+	motionAllocs := func(n int) float64 {
+		m := benchResizeOS(t, n)
+		startX, startY := m.ResizeStartX, m.ResizeStartY
+		i := 0
+		return testing.AllocsPerRun(200, func() {
+			dx := i%6 - 3
+			_, _ = HandleInput(motionAt(startX+dx, startY), m)
+			i++
+		})
+	}
+
+	small, large := motionAllocs(4), motionAllocs(9)
+	// Slack for anything genuinely proportional to window count in the geometry
+	// adjust itself. The regression this catches more than quadrupled the count.
+	if large > small+4 {
+		t.Fatalf("motion event allocated %v times at 9 windows against %v at 4; "+
+			"per-event work is scaling with window count again", large, small)
+	}
+}

--- a/internal/input/resize_perf_bench_test.go
+++ b/internal/input/resize_perf_bench_test.go
@@ -1,0 +1,172 @@
+package input
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+const (
+	benchCols = 207
+	benchRows = 55
+)
+
+// benchResizeOS builds a tiled BSP workspace of n windows with painted content,
+// already in the middle of a bottom-right resize drag on the focused window.
+// This is the exact state the model is in between two motion events of a drag.
+func benchResizeOS(tb testing.TB, n int) *app.OS {
+	tb.Helper()
+
+	m := &app.OS{
+		NumWorkspaces:    9,
+		CurrentWorkspace: 1,
+		WorkspaceFocus:   make(map[int]int),
+		Width:            benchCols,
+		Height:           benchRows,
+		AutoTiling:       true,
+		UseBSPLayout:     true,
+		FocusedWindow:    0,
+		PendingResizes:   make(map[string][2]int),
+	}
+
+	for i := range n {
+		id := fmt.Sprintf("bench-resize-%d-%d", n, i)
+		ptyData := make(chan struct{}, 1)
+		done := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-ptyData:
+				case <-done:
+					return
+				}
+			}
+		}()
+		tb.Cleanup(func() { close(done) })
+
+		win := terminal.NewDaemonWindow(id, "test", 0, 0, benchCols, benchRows, 0, "pty-"+id, ptyData)
+		if win == nil {
+			tb.Fatal("NewDaemonWindow returned nil")
+		}
+		tb.Cleanup(win.Close)
+
+		win.LockIO()
+		for y := 1; y <= benchRows; y++ {
+			line := fmt.Sprintf("line %03d ", y)
+			for len(line) < benchCols-12 {
+				line += "content "
+			}
+			_, _ = win.Terminal.Write(fmt.Appendf(nil, "\x1b[%d;1H\x1b[38;5;%dm%s\x1b[m", y, 16+(y%200), line))
+		}
+		win.UnlockIO()
+
+		win.Workspace = 1
+		win.Tiled = true
+		m.Windows = append(m.Windows, win)
+	}
+
+	m.TileAllWindows()
+	tree := m.WorkspaceTrees[m.CurrentWorkspace]
+	if tree == nil {
+		tb.Fatal("benchResizeOS: no BSP tree")
+	}
+	for intID, rect := range tree.ApplyLayout(m.GetBSPBounds()) {
+		if win := m.GetWindowByIntID(intID); win != nil {
+			win.X, win.Y, win.Width, win.Height = rect.X, rect.Y, rect.W, rect.H
+		}
+	}
+
+	// Arm a bottom-right resize drag on the focused window, the way
+	// handleMouseClick would have on press.
+	focused := m.GetFocusedWindow()
+	m.Resizing = true
+	m.ResizeCorner = app.BottomRight
+	m.PreResizeState = terminal.Window{
+		Width:  focused.Width,
+		Height: focused.Height,
+		X:      focused.X,
+		Y:      focused.Y,
+		Z:      focused.Z,
+		ID:     focused.ID,
+	}
+	m.ResizeStartX = focused.X + focused.Width
+	m.ResizeStartY = focused.Y + focused.Height
+	m.InteractionMode = true
+
+	return m
+}
+
+// motionAt is the message bubbletea delivers for one pointer move during a drag.
+func motionAt(x, y int) tea.MouseMotionMsg {
+	return tea.MouseMotionMsg(uv.MouseMotionEvent{
+		X:      x,
+		Y:      y,
+		Button: uv.MouseButton(tea.MouseLeft),
+	})
+}
+
+// BenchmarkResizeMotionHandler measures just the Update side of one motion
+// event during a tiling resize: the layout adjust plus, in shared-borders mode,
+// the BSP ratio sync and layout reapply.
+func BenchmarkResizeMotionHandler(b *testing.B) {
+	for _, shared := range []bool{false, true} {
+		for _, n := range []int{2, 4, 9} {
+			name := fmt.Sprintf("windows-%d/shared-%v", n, shared)
+			b.Run(name, func(b *testing.B) {
+				prev := config.SharedBorders
+				config.SharedBorders = shared
+				b.Cleanup(func() { config.SharedBorders = prev })
+
+				m := benchResizeOS(b, n)
+				startX, startY := m.ResizeStartX, m.ResizeStartY
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				i := 0
+				for b.Loop() {
+					// Sweep the pointer back and forth by a cell so every event
+					// is a real geometry change, not a no-op.
+					dx := i%6 - 3
+					_, _ = HandleInput(motionAt(startX+dx, startY), m)
+					i++
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkResizeMotionFrame measures the whole per-event cost the user
+// actually pays, through the real loop: Update, which is where motion
+// coalescing lives, followed by the View bubbletea runs after every Update.
+func BenchmarkResizeMotionFrame(b *testing.B) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		for _, n := range []int{2, 4, 9} {
+			name := fmt.Sprintf("windows-%d/shared-%v", n, shared)
+			b.Run(name, func(b *testing.B) {
+				prev := config.SharedBorders
+				config.SharedBorders = shared
+				b.Cleanup(func() { config.SharedBorders = prev })
+
+				m := benchResizeOS(b, n)
+				startX, startY := m.ResizeStartX, m.ResizeStartY
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				i := 0
+				for b.Loop() {
+					dx := i%6 - 3
+					_, _ = m.Update(motionAt(startX+dx, startY))
+					_ = m.View()
+					i++
+				}
+			})
+		}
+	}
+}

--- a/internal/input/resize_separator_test.go
+++ b/internal/input/resize_separator_test.go
@@ -1,0 +1,184 @@
+package input
+
+import (
+	"fmt"
+	"image/color"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
+)
+
+// rgb is a truecolor foreground, or ok false for any other foreground.
+type rgb struct {
+	r, g, b uint8
+	ok      bool
+}
+
+func rgbOf(c color.Color) rgb {
+	r, g, b, _ := c.RGBA()
+	return rgb{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), true}
+}
+
+// frameFG walks one rendered frame and returns the truecolor foreground in
+// effect at every cell, indexed by row then column. Only foreground state is
+// tracked, which is all the separator check needs.
+func frameFG(frame string) []map[int]rgb {
+	var rows []map[int]rgb
+	for _, line := range strings.Split(frame, "\n") {
+		cells := map[int]rgb{}
+		var fg rgb
+		col := 0
+		runes := []rune(line)
+		for i := 0; i < len(runes); {
+			if runes[i] == 0x1b && i+1 < len(runes) && runes[i+1] == '[' {
+				j := i + 2
+				for j < len(runes) && runes[j] != 'm' && (runes[j] == ';' || (runes[j] >= '0' && runes[j] <= '9')) {
+					j++
+				}
+				if j < len(runes) && runes[j] == 'm' {
+					fg = applySGR(fg, string(runes[i+2:j]))
+					i = j + 1
+					continue
+				}
+				i = j + 1
+				continue
+			}
+			if fg.ok {
+				cells[col] = fg
+			}
+			col++
+			i++
+		}
+		rows = append(rows, cells)
+	}
+	return rows
+}
+
+// applySGR folds one SGR parameter string into the running foreground state.
+func applySGR(fg rgb, params string) rgb {
+	if params == "" {
+		return rgb{}
+	}
+	fields := strings.Split(params, ";")
+	for i := 0; i < len(fields); i++ {
+		n, err := strconv.Atoi(fields[i])
+		if err != nil {
+			continue
+		}
+		switch {
+		case n == 0 || n == 39:
+			fg = rgb{}
+		case n == 38 && i+4 < len(fields) && fields[i+1] == "2":
+			r, _ := strconv.Atoi(fields[i+2])
+			g, _ := strconv.Atoi(fields[i+3])
+			b, _ := strconv.Atoi(fields[i+4])
+			fg = rgb{uint8(r), uint8(g), uint8(b), true}
+			i += 4
+		case n == 38 && i+2 < len(fields) && fields[i+1] == "5":
+			fg = rgb{}
+			i += 2
+		case n == 38:
+			fg = rgb{}
+		}
+	}
+	return fg
+}
+
+// unfocusedColumns lists the columns of one row that carry the unfocused border
+// color. It only feeds the failure message, where the point is to show which
+// column the divider actually landed on when it was not the focused pane's edge.
+func unfocusedColumns(rows []map[int]rgb, y int, unfocused rgb) []int {
+	if y < 0 || y >= len(rows) {
+		return nil
+	}
+	var cols []int
+	for x, c := range rows[y] {
+		if c == unfocused {
+			cols = append(cols, x)
+		}
+	}
+	sort.Ints(cols)
+	return cols
+}
+
+// TestSharedBorderDragKeepsFocusedSeparatorHighlighted is the regression guard
+// for a visual artifact: during a shared-borders drag the focused pane's moving
+// divider briefly rendered in the unfocused border color, so a red separator
+// showed up beside the highlighted one and read as an afterimage.
+//
+// The overlay takes its two inputs from different places. Separator positions
+// are collected from the BSP tree, while the highlight is the focused window's
+// perimeter, taken from live window geometry. A frame composed while those two
+// disagree draws the divider at the tree's stale position, which is no longer on
+// the perimeter, so it loses the focus color.
+//
+// The drag is interleaved with PTY output because that is what makes the
+// disagreement observable: terminal output composes a frame on a path that knows
+// nothing about the drag, so it lands between a motion event and the ratio sync
+// that motion deferred.
+func TestSharedBorderDragKeepsFocusedSeparatorHighlighted(t *testing.T) {
+	// The composed frame is only colored when the writer has a color profile,
+	// and this check reads colors out of it.
+	prevProfile := lipgloss.Writer.Profile
+	lipgloss.Writer.Profile = colorprofile.TrueColor
+	t.Cleanup(func() { lipgloss.Writer.Profile = prevProfile })
+	app.SetInputHandler(HandleInput)
+
+	prev := config.SharedBorders
+	config.SharedBorders = true
+	t.Cleanup(func() { config.SharedBorders = prev })
+
+	m := benchResizeOS(t, 4)
+	startX, startY := m.ResizeStartX, m.ResizeStartY
+
+	unfocused := rgbOf(theme.BorderUnfocused())
+	focused := rgbOf(theme.BorderFocusedWindow())
+	if unfocused == focused {
+		t.Fatal("theme border colors are identical; the check cannot tell them apart")
+	}
+
+	_ = m.View()
+
+	var bad []string
+	const steps = 24
+	for i := 1; i <= steps; i++ {
+		_, _ = m.Update(motionAt(startX-i, startY))
+		// Terminal output during the drag: a frame the drag did not ask for.
+		_, _ = m.Update(app.PTYDataMsg{})
+
+		frame := m.View().Content
+		win := m.GetFocusedWindow()
+		if win == nil {
+			t.Fatal("no focused window mid-drag")
+		}
+		edge := win.X + win.Width
+		rows := frameFG(frame)
+
+		reds, cyans := 0, 0
+		for y := win.Y; y < win.Y+win.Height && y < len(rows); y++ {
+			switch rows[y][edge] {
+			case unfocused:
+				reds++
+			case focused:
+				cyans++
+			}
+		}
+		if reds > 0 || cyans == 0 {
+			bad = append(bad, fmt.Sprintf("frame %d (edge x=%d): %d unfocused cells, %d focused cells; unfocused columns on row %d: %v",
+				i, edge, reds, cyans, win.Y+1, unfocusedColumns(rows, win.Y+1, unfocused)))
+		}
+	}
+
+	if len(bad) > 0 {
+		t.Fatalf("the focused pane's divider was not drawn in the focus color on %d of %d frames:\n  %s",
+			len(bad), steps, strings.Join(bad, "\n  "))
+	}
+}

--- a/internal/layout/bsp.go
+++ b/internal/layout/bsp.go
@@ -520,6 +520,34 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		return
 	}
 
+	// Shared-border layouts reserve one cell for the separator, so the near edge
+	// of the right/bottom subtree sits one cell past the divider. Sync has to use
+	// the same model applyLayoutRecursive does; otherwise every ratio in the tree
+	// is re-derived one cell off on each sync, and a resize on one axis walks the
+	// dividers on the other axis. Nested bounds must account for it too.
+	gap := 0
+	if config.SharedBorders {
+		gap = 1
+	}
+
+	if node.SplitType == SplitStacked {
+		// Stacked nodes ignore SplitRatio; mirror applyLayoutRecursive's bounds so
+		// descendants still resolve against the rectangle they were laid out in.
+		const titleBarHeight = 1
+		content := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: bounds.H - titleBarHeight}
+		title := Rect{X: bounds.X, Y: bounds.Y + bounds.H - titleBarHeight, W: bounds.W, H: titleBarHeight}
+		if node.StackedActiveLeft {
+			t.syncRatiosRecursive(node.Left, content, windows)
+			t.syncRatiosRecursive(node.Right, title, windows)
+		} else {
+			title.Y = bounds.Y
+			content.Y = bounds.Y + titleBarHeight
+			t.syncRatiosRecursive(node.Left, title, windows)
+			t.syncRatiosRecursive(node.Right, content, windows)
+		}
+		return
+	}
+
 	// Calculate the actual split ratio from window geometry.
 	if node.SplitType == SplitVertical {
 		// The split boundary is the near edge of the right subtree's leftmost
@@ -531,7 +559,7 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		splitX, ok := -1, false
 		if id := t.findAnyWindowInSubtree(node.Right); id != -1 {
 			if r, found := windows[id]; found {
-				splitX, ok = r.X, true
+				splitX, ok = r.X-gap, true
 			}
 		}
 		if !ok {
@@ -549,7 +577,7 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		}
 		// Recurse with updated bounds
 		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
-		rightBounds := Rect{X: splitX, Y: bounds.Y, W: bounds.X + bounds.W - splitX, H: bounds.H}
+		rightBounds := Rect{X: splitX + gap, Y: bounds.Y, W: bounds.X + bounds.W - splitX - gap, H: bounds.H}
 		t.syncRatiosRecursive(node.Left, leftBounds, windows)
 		t.syncRatiosRecursive(node.Right, rightBounds, windows)
 	} else {
@@ -559,7 +587,7 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		splitY, ok := -1, false
 		if id := t.findAnyWindowInSubtree(node.Right); id != -1 {
 			if r, found := windows[id]; found {
-				splitY, ok = r.Y, true
+				splitY, ok = r.Y-gap, true
 			}
 		}
 		if !ok {
@@ -577,7 +605,7 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		}
 		// Recurse with updated bounds
 		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
-		rightBounds := Rect{X: bounds.X, Y: splitY, W: bounds.W, H: bounds.Y + bounds.H - splitY}
+		rightBounds := Rect{X: bounds.X, Y: splitY + gap, W: bounds.W, H: bounds.Y + bounds.H - splitY - gap}
 		t.syncRatiosRecursive(node.Left, leftBounds, windows)
 		t.syncRatiosRecursive(node.Right, rightBounds, windows)
 	}

--- a/internal/layout/bsp_resize_axis_test.go
+++ b/internal/layout/bsp_resize_axis_test.go
@@ -1,0 +1,328 @@
+package layout
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// edge identifies which side of a pane a resize drags.
+type edge int
+
+const (
+	edgeRight edge = iota
+	edgeLeft
+	edgeBottom
+	edgeTop
+)
+
+func (e edge) horizontal() bool { return e == edgeRight || e == edgeLeft }
+
+func (e edge) String() string {
+	switch e {
+	case edgeRight:
+		return "right"
+	case edgeLeft:
+		return "left"
+	case edgeBottom:
+		return "bottom"
+	default:
+		return "top"
+	}
+}
+
+// leaf builds a leaf and registers it with the tree.
+func (t *BSPTree) leaf(id int) *TileNode {
+	n := NewLeafNode(id)
+	t.WindowToNode[id] = n
+	return n
+}
+
+func treeOf(build func(t *BSPTree) *TileNode) *BSPTree {
+	t := NewBSPTree()
+	t.Root = build(t)
+	return t
+}
+
+// twoPanes: 1 | 2
+func twoPanes() *BSPTree {
+	return treeOf(func(t *BSPTree) *TileNode {
+		return NewInternalNode(SplitVertical, 0.5, t.leaf(1), t.leaf(2))
+	})
+}
+
+// tallLeft is the maintainer's layout: one full-height column on the left, the
+// right column split into top and bottom.
+func tallLeft() *BSPTree {
+	return treeOf(func(t *BSPTree) *TileNode {
+		right := NewInternalNode(SplitHorizontal, 0.5, t.leaf(2), t.leaf(3))
+		return NewInternalNode(SplitVertical, 0.5, t.leaf(1), right)
+	})
+}
+
+// tallRight is the mirror image: the stacked column is on the left.
+func tallRight() *BSPTree {
+	return treeOf(func(t *BSPTree) *TileNode {
+		left := NewInternalNode(SplitHorizontal, 0.5, t.leaf(1), t.leaf(2))
+		return NewInternalNode(SplitVertical, 0.5, left, t.leaf(3))
+	})
+}
+
+// grid is a 2x2 arrangement built from two horizontal splits under a vertical one.
+func grid() *BSPTree {
+	return treeOf(func(t *BSPTree) *TileNode {
+		left := NewInternalNode(SplitHorizontal, 0.5, t.leaf(1), t.leaf(2))
+		right := NewInternalNode(SplitHorizontal, 0.5, t.leaf(3), t.leaf(4))
+		return NewInternalNode(SplitVertical, 0.5, left, right)
+	})
+}
+
+// deepNest puts a pane three splits down so a resize has to survive several
+// levels of bounds narrowing.
+func deepNest() *BSPTree {
+	return treeOf(func(t *BSPTree) *TileNode {
+		inner := NewInternalNode(SplitVertical, 0.5, t.leaf(3), t.leaf(4))
+		mid := NewInternalNode(SplitHorizontal, 0.5, t.leaf(2), inner)
+		right := NewInternalNode(SplitHorizontal, 0.6, mid, t.leaf(5))
+		return NewInternalNode(SplitVertical, 0.4, t.leaf(1), right)
+	})
+}
+
+func sharedGap() int {
+	if config.SharedBorders {
+		return 1
+	}
+	return 0
+}
+
+// dragEdge moves one edge of the target pane and drags every pane that shares
+// that divider along with it, the way adjustTilingNeighborsGeneric does. It
+// returns false when the move would push any pane below the minimum size, so
+// callers can skip a case rather than assert against clamped geometry.
+func dragEdge(geo map[int]Rect, target int, e edge, delta int) (map[int]Rect, bool) {
+	gap := sharedGap()
+	r, ok := geo[target]
+	if !ok {
+		return nil, false
+	}
+
+	out := make(map[int]Rect, len(geo))
+	for id, g := range geo {
+		out[id] = g
+	}
+
+	if e.horizontal() {
+		old := r.X
+		if e == edgeRight {
+			old = r.X + r.W
+		}
+		moved := old + delta
+		for id, g := range out {
+			switch {
+			case g.X+g.W == old:
+				g.W = moved - g.X
+			case g.X == old+gap:
+				g.W = g.X + g.W - (moved + gap)
+				g.X = moved + gap
+			default:
+				continue
+			}
+			if g.W < config.DefaultWindowWidth {
+				return nil, false
+			}
+			out[id] = g
+		}
+		return out, true
+	}
+
+	old := r.Y
+	if e == edgeBottom {
+		old = r.Y + r.H
+	}
+	moved := old + delta
+	for id, g := range out {
+		switch {
+		case g.Y+g.H == old:
+			g.H = moved - g.Y
+		case g.Y == old+gap:
+			g.H = g.Y + g.H - (moved + gap)
+			g.Y = moved + gap
+		default:
+			continue
+		}
+		if g.H < config.DefaultWindowHeight {
+			return nil, false
+		}
+		out[id] = g
+	}
+	return out, true
+}
+
+// assertAxisIsolated checks the invariant: a horizontal resize may only change
+// X and W, a vertical resize may only change Y and H.
+func assertAxisIsolated(t *testing.T, label string, e edge, before, after map[int]Rect) {
+	t.Helper()
+	for id, b := range before {
+		a, ok := after[id]
+		if !ok {
+			t.Fatalf("%s: pane %d vanished from layout", label, id)
+		}
+		if e.horizontal() {
+			if a.Y != b.Y || a.H != b.H {
+				t.Errorf("%s: horizontal resize moved pane %d vertically: Y %d->%d, H %d->%d",
+					label, id, b.Y, a.Y, b.H, a.H)
+			}
+		} else if a.X != b.X || a.W != b.W {
+			t.Errorf("%s: vertical resize moved pane %d horizontally: X %d->%d, W %d->%d",
+				label, id, b.X, a.X, b.W, a.W)
+		}
+	}
+}
+
+// withSharedBorders runs fn with config.SharedBorders set, restoring it after.
+func withSharedBorders(t *testing.T, shared bool, fn func()) {
+	t.Helper()
+	prev := config.SharedBorders
+	config.SharedBorders = shared
+	defer func() { config.SharedBorders = prev }()
+	fn()
+}
+
+var resizeLayouts = []struct {
+	name  string
+	build func() *BSPTree
+	panes []int
+}{
+	{"two_panes", twoPanes, []int{1, 2}},
+	{"tall_left", tallLeft, []int{1, 2, 3}},
+	{"tall_right", tallRight, []int{1, 2, 3}},
+	{"grid", grid, []int{1, 2, 3, 4}},
+	{"deep_nest", deepNest, []int{1, 2, 3, 4, 5}},
+}
+
+// TestResizeKeepsOffAxisGeometry is the core property: dragging any edge of any
+// pane, then syncing the geometry back into the tree and re-applying the
+// layout, must leave the perpendicular axis of every pane untouched.
+func TestResizeKeepsOffAxisGeometry(t *testing.T) {
+	bounds := Rect{X: 0, Y: 1, W: 160, H: 48}
+	edges := []edge{edgeRight, edgeLeft, edgeBottom, edgeTop}
+
+	for _, shared := range []bool{false, true} {
+		withSharedBorders(t, shared, func() {
+			for _, lay := range resizeLayouts {
+				for _, pane := range lay.panes {
+					for _, e := range edges {
+						for _, delta := range []int{4, -4} {
+							tree := lay.build()
+							before := tree.ApplyLayout(bounds)
+							dragged, ok := dragEdge(before, pane, e, delta)
+							if !ok {
+								continue
+							}
+							tree.SyncRatiosFromGeometry(dragged, bounds)
+							after := tree.ApplyLayout(bounds)
+
+							label := lay.name + "/pane" + string(rune('0'+pane)) + "/" + e.String()
+							if shared {
+								label = "shared:" + label
+							}
+							assertAxisIsolated(t, label, e, before, after)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestRepeatedResizeDoesNotDrift checks that many small drags land in the same
+// place as one large drag and, more importantly, that the perpendicular axis
+// never accumulates drift across a long sequence.
+func TestRepeatedResizeDoesNotDrift(t *testing.T) {
+	bounds := Rect{X: 0, Y: 1, W: 160, H: 48}
+
+	for _, shared := range []bool{false, true} {
+		withSharedBorders(t, shared, func() {
+			for _, lay := range resizeLayouts {
+				tree := lay.build()
+				start := tree.ApplyLayout(bounds)
+				geo := start
+
+				const steps = 8
+				for i := 0; i < steps; i++ {
+					dragged, ok := dragEdge(geo, 1, edgeRight, 2)
+					if !ok {
+						break
+					}
+					tree.SyncRatiosFromGeometry(dragged, bounds)
+					geo = tree.ApplyLayout(bounds)
+				}
+
+				label := lay.name
+				if shared {
+					label = "shared:" + label
+				}
+				assertAxisIsolated(t, label+"/repeated", edgeRight, start, geo)
+			}
+		})
+	}
+}
+
+// TestSyncRoundTripIsStable checks that syncing an unmodified layout back into
+// the tree and re-applying it is a no-op. Any movement here is pure rounding
+// drift and would show up as panes creeping on every mouse motion event.
+func TestSyncRoundTripIsStable(t *testing.T) {
+	for _, shared := range []bool{false, true} {
+		withSharedBorders(t, shared, func() {
+			for _, lay := range resizeLayouts {
+				for _, w := range []int{80, 97, 120, 160, 201} {
+					for _, h := range []int{24, 31, 48, 60} {
+						bounds := Rect{X: 0, Y: 1, W: w, H: h}
+						tree := lay.build()
+						before := tree.ApplyLayout(bounds)
+						tree.SyncRatiosFromGeometry(before, bounds)
+						after := tree.ApplyLayout(bounds)
+						for id, b := range before {
+							if after[id] != b {
+								t.Errorf("shared=%v %s %dx%d: pane %d drifted on sync round trip: %+v -> %+v",
+									shared, lay.name, w, h, id, b, after[id])
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestHorizontalResizeKeepsRightColumnHeights is the maintainer's exact report,
+// pinned as a regression: a tall left pane plus a stacked right column, drag the
+// left pane wider, the two right panes must keep their heights.
+func TestHorizontalResizeKeepsRightColumnHeights(t *testing.T) {
+	withSharedBorders(t, true, func() {
+		bounds := Rect{X: 0, Y: 1, W: 80, H: 30}
+		tree := tallLeft()
+		before := tree.ApplyLayout(bounds)
+
+		geo := before
+		for i := 0; i < 4; i++ {
+			dragged, ok := dragEdge(geo, 1, edgeRight, 4)
+			if !ok {
+				t.Fatalf("drag %d hit the minimum size", i)
+			}
+			tree.SyncRatiosFromGeometry(dragged, bounds)
+			geo = tree.ApplyLayout(bounds)
+		}
+
+		if geo[2].H != before[2].H {
+			t.Errorf("top-right height changed: %d -> %d", before[2].H, geo[2].H)
+		}
+		if geo[3].H != before[3].H || geo[3].Y != before[3].Y {
+			t.Errorf("bottom-right moved: Y %d->%d H %d->%d",
+				before[3].Y, geo[3].Y, before[3].H, geo[3].H)
+		}
+		if geo[1].W <= before[1].W {
+			t.Errorf("left pane did not widen: %d -> %d", before[1].W, geo[1].W)
+		}
+	})
+}


### PR DESCRIPTION
Four fixes, each verified by reverting it and confirming the accompanying test fails.

## Resize moved geometry on the wrong axis

Dragging the divider of a tall left pane walked the horizontal split in the right column: the top-right pane gained a row per motion event and the bottom-right lost one.

`applyLayoutRecursive` reserves one cell for the separator when shared borders are on, placing the right or bottom child at `splitX+1`, but `syncRatiosRecursive` read that child's near edge back as the divider itself and recovered every boundary one cell off. Sync rewrites every ratio in the tree, not just the one being dragged, and the layout is reapplied on each motion event, so an untouched split was re-derived one cell low repeatedly.

Vertical drags had the identical defect bleeding into pane widths, which had not been reported yet.

`internal/layout/bsp_resize_axis_test.go` covers the invariant across five layouts, every pane, all four edges and both border modes, plus drift over successive drags and sync round-trip stability at odd terminal sizes.

## Resize trailed the mouse

A render backlog rather than a slow frame. Every motion event composed a full frame at 3.3 to 6.7 ms, capping the drain rate near 150 to 300 events per second while a drag emits one event per cell crossed.

Redraws are now bounded to one per frame interval during a drag. Every event's geometry is still applied before the draw decision, so no input is dropped and the layout settles where the mouse was released.

| windows | before | after |
| --- | --- | --- |
| 2 | 4070 us | 24 us |
| 4 | 5316 us | 42 us |
| 9 | 6663 us | 115 us |

## Shared borders cost more and scaled with window count

`SyncBSPTreeFromGeometry` ran on every motion event, rebuilding a geometry map over every window and re-deriving every ratio in the tree. Non-shared cost was flat as windows grew; shared more than doubled.

The sync is now deferred to the frame that draws. The drag-completion sync is unconditional, so the final position still commits to the tree.

| windows | shared off | shared on before | shared on after |
| --- | --- | --- | --- |
| 4 | 7.9 us | 12.6 us | 7.6 us |
| 9 | 7.6 us | 29.0 us | 7.3 us |

Allocations fell from 57 KB and 34 per event to 9.8 KB and 8, flat in window count.

## Nested kitty graphics drew nothing

`kitten icat` probes three transmission media and commits to whichever answers OK first. The passthrough answered OK to all three without asking the host, so icat chose a file medium and tuios forwarded a server-local path. That works when the host shares the filesystem and fails silently when it does not: running tuios inside sip, the browser client drops anything that is not `t=d`.

The host is now probed for file transmission and guests are answered honestly, so they stream instead. A file transmission arriving when the host cannot read files is re-encoded as direct. A file-capable host still gets the plain path with no extra copy. Quiet handling was also wrong: `q=1` suppressed errors it should have reported, leaving a guest waiting out its timeout instead of trying the next medium.

Nested icat and yazi go from zero images drawn to one.

## Known issue not addressed here

A separator afterimage during shared-border drags, where the unfocused red separator is briefly visible behind the focused one, is under investigation on a separate branch.