### PR TITLE
Fix three resize defects: unrelated panes moving, animation churn, and nested ratio drift

### DIFF
--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -197,7 +197,10 @@ type OS struct {
 	// run on frames that are actually composed; it is whole-tree work and running
 	// it per motion event makes the drag cost scale with window count.
 	pendingBSPSync bool
-	renderCanvas   *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
+	// bspResizeScratch holds the layout rebuilt on each resize step. It is
+	// reused so a mouse drag does not allocate a map per motion event.
+	bspResizeScratch map[int]layout.Rect
+	renderCanvas     *lipgloss.Canvas // Reused across frames; resized on change, cleared per frame
 	// Reused per-frame scratch for graphics placement refresh (avoids per-frame allocs)
 	kittyPosMap     map[string]*WindowPositionInfo // Reused map for kitty placement refresh
 	kittyPosBacking []WindowPositionInfo           // Backing storage for kittyPosMap values

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -130,11 +130,7 @@ func (m *OS) ApplyBSPLayout() {
 
 		// Cancel any existing snap animation for this window to prevent
 		// animation pileup during continuous resize.
-		for j := len(m.Animations) - 1; j >= 0; j-- {
-			if m.Animations[j].Window == win && m.Animations[j].Type == ui.AnimationSnap {
-				m.Animations = append(m.Animations[:j], m.Animations[j+1:]...)
-			}
-		}
+		m.CancelSnapAnimation(win)
 
 		// Create animation for smooth transition
 		anim := ui.NewSnapAnimation(
@@ -161,6 +157,25 @@ func (m *OS) ApplyBSPLayout() {
 			// the size instantly). SetTiled re-syncs the emulator for the new
 			// border deduction when the flag actually changes.
 			win.SetTiled(config.SharedBorders)
+		}
+	}
+}
+
+// CancelSnapAnimation drops any in-flight snap animation for win.
+//
+// A snap animation owns its window's geometry until it finishes: every tick it
+// writes an interpolated rectangle, ignoring whatever else has set X, Y, Width
+// or Height in the meantime. So anything that positions a window directly has
+// to retire the animation first, or the next tick will overwrite it with a
+// frame of a transition the user has already moved past. Starting a resize
+// drag while a window is still animating into place is the ordinary way to hit
+// that: the drag sets geometry per motion event, the animation stamps its own
+// back over all of it on the next tick, and the layout jumps to wherever the
+// old transition had got to.
+func (m *OS) CancelSnapAnimation(win *terminal.Window) {
+	for i := len(m.Animations) - 1; i >= 0; i-- {
+		if m.Animations[i].Window == win && m.Animations[i].Type == ui.AnimationSnap {
+			m.Animations = append(m.Animations[:i], m.Animations[i+1:]...)
 		}
 	}
 }

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -136,6 +136,38 @@ func (m *OS) ApplyBSPLayout() {
 			}
 		}
 
+		// A live resize drag reapplies this layout on every composed frame, to
+		// keep the separator overlay's ratios in step with the geometry the
+		// pointer is producing. Set that geometry directly.
+		//
+		// A resize is direct manipulation: the edge is where the pointer is,
+		// so there is nothing to ease toward. Animating instead built a fresh
+		// 300ms snap per window per frame, each one discarded and restarted by
+		// the next frame before it could finish, so the panes never arrived
+		// anywhere and trailed the cursor on a curve that kept resetting. That
+		// costs almost no CPU, which is why it read as mush rather than as a
+		// slow frame, and why no timing measurement found it.
+		//
+		// The normal path is also what tells the PTY, and in daemon mode the
+		// daemon over its socket, about the new size: one round trip per window
+		// per frame for a size the user is still in the middle of choosing.
+		// Resize visually instead and record it in PendingResizes, which mouse
+		// release already drains into one real resize per window.
+		if m.Resizing {
+			win.X, win.Y = rect.X, rect.Y
+			if win.Tiled != config.SharedBorders {
+				win.Tiled = config.SharedBorders
+				win.InvalidateCache()
+			}
+			if win.Width != rect.W || win.Height != rect.H {
+				win.ResizeVisual(rect.W, rect.H)
+				win.IsBeingManipulated = true
+				m.PendingResizes[win.ID] = [2]int{rect.W, rect.H}
+			}
+			win.MarkPositionDirty()
+			continue
+		}
+
 		// Create animation for smooth transition
 		anim := ui.NewSnapAnimation(
 			win,

--- a/internal/app/tiling_resize.go
+++ b/internal/app/tiling_resize.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/layout"
 	"github.com/Gaurav-Gosain/tuios/internal/terminal"
 )
 
@@ -273,6 +274,79 @@ func (m *OS) adjustTilingNeighborsGeneric(resized *terminal.Window, newX, newY, 
 	return newX, newY, newRight, newBottom
 }
 
+// applyBSPResize moves the dividers that own the edges the caller changed and
+// rebuilds every pane's geometry from the tree. It reports false when the
+// workspace is not on a BSP tree that holds this window, in which case the
+// caller falls back to the geometry scan, which is still what master-stack and
+// untracked windows need.
+//
+// Driving the resize through the tree rather than through the geometry scan is
+// what keeps unrelated panes still: the tree knows the divider separates
+// exactly two subtrees, while a geometry scan cannot tell the dragged divider
+// apart from another one that happens to sit on the same line. It also removes
+// a whole class of staleness, because the tree is updated first and the window
+// rectangles are derived from it, so there is never a window of time in which
+// the two disagree and a retile can throw the resize away.
+func (m *OS) applyBSPResize(resized *terminal.Window, newX, newY, newWidth, newHeight int, resize resizeOp) bool {
+	if !m.AutoTiling || !m.UseBSPLayout || m.UseScrollingLayout || resized.IsFloating {
+		return false
+	}
+
+	tree := m.WorkspaceTrees[m.CurrentWorkspace]
+	if tree == nil || tree.IsEmpty() {
+		return false
+	}
+
+	intID := m.getWindowIntID(resized.ID)
+	if !tree.HasWindow(intID) {
+		return false
+	}
+
+	bounds := m.GetBSPBounds()
+	moved := false
+	for _, edge := range []struct {
+		e   layout.ResizeEdge
+		old int
+		new int
+	}{
+		{layout.ResizeEdgeRight, resized.X + resized.Width, newX + newWidth},
+		{layout.ResizeEdgeLeft, resized.X, newX},
+		{layout.ResizeEdgeBottom, resized.Y + resized.Height, newY + newHeight},
+		{layout.ResizeEdgeTop, resized.Y, newY},
+	} {
+		if edge.old == edge.new {
+			continue
+		}
+		if tree.ResizeSplit(intID, edge.e, edge.new, bounds) {
+			moved = true
+		}
+	}
+	if !moved {
+		return false
+	}
+
+	// A pending deferred sync would re-derive ratios from geometry that has not
+	// been rebuilt yet, undoing the divider that was just moved.
+	m.pendingBSPSync = false
+
+	if m.bspResizeScratch == nil {
+		m.bspResizeScratch = make(map[int]layout.Rect, len(m.Windows))
+	}
+	for windowIntID, rect := range tree.ApplyLayoutInto(bounds, m.bspResizeScratch) {
+		win := m.getWindowByIntID(windowIntID)
+		if win == nil || win.Workspace != m.CurrentWorkspace || win.Minimized || win.IsFloating {
+			continue
+		}
+		if win.X == rect.X && win.Y == rect.Y && win.Width == rect.W && win.Height == rect.H {
+			continue
+		}
+		win.X, win.Y = rect.X, rect.Y
+		resize(m, win, rect.W, rect.H)
+		win.MarkPositionDirty()
+	}
+	return true
+}
+
 // constrainVerticalSplit calculates the valid position for a vertical split line
 func (m *OS) constrainVerticalSplit(requested int, leftWindows, rightWindows []*terminal.Window, minWidth, maxX int) int {
 	minValidX := 0
@@ -343,11 +417,13 @@ func (m *OS) applyTilingResult(resized *terminal.Window, finalX, finalY, finalRi
 // AdjustTilingNeighbors adjusts ALL windows on affected split lines with constraint-based positioning.
 // This is the core tiling resize algorithm used by both mouse and keyboard resize operations.
 func (m *OS) AdjustTilingNeighbors(resized *terminal.Window, newX, newY, newWidth, newHeight int) {
-	finalX, finalY, finalRight, finalBottom := m.adjustTilingNeighborsGeneric(resized, newX, newY, newWidth, newHeight, resizeImmediate)
-	m.applyTilingResult(resized, finalX, finalY, finalRight, finalBottom)
+	if !m.applyBSPResize(resized, newX, newY, newWidth, newHeight, resizeImmediate) {
+		finalX, finalY, finalRight, finalBottom := m.adjustTilingNeighborsGeneric(resized, newX, newY, newWidth, newHeight, resizeImmediate)
+		m.applyTilingResult(resized, finalX, finalY, finalRight, finalBottom)
 
-	resized.Resize(resized.Width, resized.Height)
-	resized.MarkPositionDirty()
+		resized.Resize(resized.Width, resized.Height)
+		resized.MarkPositionDirty()
+	}
 	m.MarkLayoutCustom()
 
 	// This is the keyboard resize path, where every press is a finished resize.
@@ -359,13 +435,23 @@ func (m *OS) AdjustTilingNeighbors(resized *terminal.Window, newX, newY, newWidt
 // AdjustTilingNeighborsVisual is like AdjustTilingNeighbors but uses visual-only resize.
 // This defers PTY resize operations until the drag completes, improving responsiveness
 // during mouse resize operations while still constraining window sizes appropriately.
-func (m *OS) AdjustTilingNeighborsVisual(resized *terminal.Window, newX, newY, newWidth, newHeight int) {
+//
+// It reports whether the BSP tree already describes the resulting geometry. When
+// it does, the caller must not ask for a ratio sync: the tree led and the
+// windows followed, so re-deriving ratios from geometry would be work at best
+// and would undo the divider that was just moved at worst.
+func (m *OS) AdjustTilingNeighborsVisual(resized *terminal.Window, newX, newY, newWidth, newHeight int) (treeInSync bool) {
+	if m.applyBSPResize(resized, newX, newY, newWidth, newHeight, resizeVisual) {
+		return true
+	}
+
 	finalX, finalY, finalRight, finalBottom := m.adjustTilingNeighborsGeneric(resized, newX, newY, newWidth, newHeight, resizeVisual)
 	m.applyTilingResult(resized, finalX, finalY, finalRight, finalBottom)
 
 	resized.ResizeVisual(resized.Width, resized.Height)
 	m.PendingResizes[resized.ID] = [2]int{resized.Width, resized.Height}
 	resized.MarkPositionDirty()
+	return false
 }
 
 // findWindowsOnVerticalSplitAll finds all windows on a vertical split line (not excluding any window)

--- a/internal/app/tiling_resize.go
+++ b/internal/app/tiling_resize.go
@@ -337,6 +337,12 @@ func (m *OS) applyBSPResize(resized *terminal.Window, newX, newY, newWidth, newH
 		if win == nil || win.Workspace != m.CurrentWorkspace || win.Minimized || win.IsFloating {
 			continue
 		}
+		// Unconditionally, before the unchanged-geometry check below: a window
+		// this resize leaves alone can still be mid-snap from an earlier
+		// layout change, and that animation would go on stamping its own
+		// rectangles over the drag on every tick.
+		m.CancelSnapAnimation(win)
+
 		if win.X == rect.X && win.Y == rect.Y && win.Width == rect.W && win.Height == rect.H {
 			continue
 		}

--- a/internal/input/mouse_motion.go
+++ b/internal/input/mouse_motion.go
@@ -327,12 +327,14 @@ func handleMouseMotion(msg tea.MouseMotionMsg, o *app.OS) (*app.OS, tea.Cmd) {
 
 			// In tiling mode, update visual state but defer PTY resize until drag completes
 			// Store pending resizes for all affected windows
-			o.AdjustTilingNeighborsVisual(focusedWindow, newX, newY, newWidth, newHeight)
+			treeInSync := o.AdjustTilingNeighborsVisual(focusedWindow, newX, newY, newWidth, newHeight)
 			// The separator overlay is drawn from the tree's ratios, so they have
 			// to catch up with the new geometry before the next frame. Mark it
 			// rather than syncing here: syncing walks every node in the tree and
-			// reapplies the layout, and motion events outnumber frames.
-			if config.SharedBorders {
+			// reapplies the layout, and motion events outnumber frames. A resize
+			// the BSP tree drove needs none of this - the ratios are already what
+			// the geometry was built from.
+			if config.SharedBorders && !treeInSync {
 				o.MarkBSPSyncPending()
 			}
 		} else if o.UseScrollingLayout {

--- a/internal/input/resize_isolation_test.go
+++ b/internal/input/resize_isolation_test.go
@@ -3,11 +3,13 @@ package input
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Gaurav-Gosain/tuios/internal/app"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
 	"github.com/Gaurav-Gosain/tuios/internal/layout"
 	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/ui"
 )
 
 // Resizing a divider in a BSP layout may only move the two subtrees that
@@ -370,5 +372,102 @@ func TestMouseResizeMovesOnlyTheDividersSubtrees(t *testing.T) {
 				checkSurvivesRetile(t, label, m, after)
 			})
 		}
+	}
+}
+
+// TestResizeSurvivesAnInFlightSnapAnimation pins the other way a pane can move
+// on its own. A snap animation writes an interpolated rectangle to its window
+// on every tick and does not care what else has set the geometry since, so a
+// drag that begins while windows are still animating into place gets stamped
+// over on the next tick and the layout jumps back to a frame of the transition
+// the user had already moved past.
+//
+// Windows animate on any layout change - opening a pane, closing one,
+// switching workspace, applying a template - so starting a drag on top of one
+// is ordinary, not a corner case.
+func TestResizeSurvivesAnInFlightSnapAnimation(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared=%v", shared), func(t *testing.T) {
+			prev := config.SharedBorders
+			config.SharedBorders = shared
+			t.Cleanup(func() { config.SharedBorders = prev })
+
+			m := isoOS(t, 4)
+			// isoOS turns animations off for the other tests; this one is about
+			// what happens when they are on.
+			config.AnimationsEnabled = true
+			buildTree(m, func(leaf func(int) *layout.TileNode) *layout.TileNode {
+				return v(0.5, h(0.5, leaf(1), leaf(2)), h(0.5, leaf(3), leaf(4)))
+			})
+
+			// Nudge the panes off their tiled positions so the retile below has
+			// somewhere to animate from; a window already at its target gets no
+			// animation. The offset is deliberately small: displacing them to
+			// full screen would park the dragged edge on the screen boundary,
+			// where the resize is blocked outright and the test would pass
+			// without ever exercising a resize.
+			for _, w := range m.Windows {
+				w.X, w.Y = w.X+3, w.Y+2
+			}
+
+			// Retiling queues a snap animation per window, which is the state a
+			// user drags on top of when they resize right after a layout change.
+			m.TileAllWindows()
+			if !m.HasActiveAnimations() {
+				t.Fatal("no snap animations queued; this test needs some in flight to be meaningful")
+			}
+
+			win := m.Windows[0]
+			startX, startY := win.X+win.Width, win.Y+win.Height
+			m.Resizing = true
+			m.InteractionMode = true
+			m.ResizeCorner = app.BottomRight
+			m.PreResizeState = terminal.Window{
+				ID: win.ID, X: win.X, Y: win.Y, Z: win.Z,
+				Width: win.Width, Height: win.Height,
+			}
+			m.ResizeStartX, m.ResizeStartY = startX, startY
+
+			// One motion event, deliberately. Asserting on geometry after a run
+			// of ticks would be a race against the animation's 300ms wall clock
+			// rather than a statement about the resize: on a slow enough run the
+			// animations finish on their own and the test passes for the wrong
+			// reason. Retiring them is the contract, so assert exactly that.
+			preDrag := geomOf(m)
+			_, _ = m.Update(motionAt(startX-6, startY))
+			if geomOf(m)[win.ID] == preDrag[win.ID] {
+				t.Fatal("the motion event did not resize anything, so this test would " +
+					"pass whether or not animations are retired")
+			}
+
+			for _, w := range m.Windows {
+				for _, a := range m.Animations {
+					if a.Window == w && a.Type == ui.AnimationSnap {
+						t.Fatalf("pane %s still has a snap animation after a resize motion; "+
+							"it will overwrite the drag on the next tick", w.ID)
+					}
+				}
+			}
+
+			// And the user-visible consequence: ticking now moves nothing.
+			settled := geomOf(m)
+			for range 5 {
+				_, _ = m.Update(app.TickerMsg(time.Now()))
+			}
+			for id, want := range settled {
+				var got [4]int
+				for _, w := range m.Windows {
+					if w.ID == id {
+						got = [4]int{w.X, w.Y, w.Width, w.Height}
+					}
+				}
+				if got != want {
+					t.Errorf("pane %s moved after the gesture ended: %v -> %v; "+
+						"an in-flight snap animation overwrote the resize", id, want, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/input/resize_isolation_test.go
+++ b/internal/input/resize_isolation_test.go
@@ -1,0 +1,374 @@
+package input
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/layout"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// Resizing a divider in a BSP layout may only move the two subtrees that
+// divider separates. Everything else on screen has to stay exactly where it
+// was, and it has to stay there through a retile as well, because a retile
+// rebuilds every pane from the tree's ratios and is triggered by ordinary
+// things: opening a window, closing one, switching workspace, a terminal
+// resize.
+//
+// Two separate defects broke that. Resizes were matched to neighbours by
+// geometry, collecting every pane whose edge fell on the dragged line, so a
+// divider in one column dragged the identically-placed divider in another
+// column with it - and fresh splits are all 0.5, so dividers line up by
+// default. And the keyboard path never wrote its result back into the tree, so
+// the next retile discarded the resize and snapped every pane back.
+
+// isoOS builds an auto-tiling model with n real windows and no layout yet.
+func isoOS(tb testing.TB, n int) *app.OS {
+	tb.Helper()
+
+	// Snap animations apply their target over the following frames, so with them
+	// on a retile leaves geometry untouched at the instant it returns and the
+	// snap-back this test is looking for would land after the assertions rather
+	// than before them.
+	prevAnim := config.AnimationsEnabled
+	config.AnimationsEnabled = false
+	tb.Cleanup(func() { config.AnimationsEnabled = prevAnim })
+
+	m := &app.OS{
+		NumWorkspaces:    9,
+		CurrentWorkspace: 1,
+		WorkspaceFocus:   make(map[int]int),
+		Width:            160,
+		Height:           48,
+		AutoTiling:       true,
+		UseBSPLayout:     true,
+		FocusedWindow:    0,
+		PendingResizes:   make(map[string][2]int),
+
+		WorkspaceHasCustom:   make(map[int]bool),
+		WorkspaceLayouts:     make(map[int][]app.WindowLayout),
+		WorkspaceMasterRatio: make(map[int]float64),
+	}
+
+	for i := range n {
+		id := fmt.Sprintf("iso-%d-%d", n, i+1)
+		ptyData := make(chan struct{}, 1)
+		done := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-ptyData:
+				case <-done:
+					return
+				}
+			}
+		}()
+		tb.Cleanup(func() { close(done) })
+
+		win := terminal.NewDaemonWindow(id, "test", 0, 0, 40, 12, 0, "pty-"+id, ptyData)
+		if win == nil {
+			tb.Fatal("NewDaemonWindow returned nil")
+		}
+		tb.Cleanup(win.Close)
+		win.Workspace = 1
+		win.Tiled = config.SharedBorders
+		m.Windows = append(m.Windows, win)
+	}
+
+	return m
+}
+
+// buildTree installs a hand-built topology, mapping the small integer IDs the
+// topology uses onto the model's windows in order, then lays it out.
+func buildTree(m *app.OS, build func(leaf func(int) *layout.TileNode) *layout.TileNode) {
+	tree := layout.NewBSPTree()
+	leaf := func(i int) *layout.TileNode {
+		intID := m.GetWindowIntID(m.Windows[i-1].ID)
+		n := layout.NewLeafNode(intID)
+		tree.WindowToNode[intID] = n
+		return n
+	}
+	tree.Root = build(leaf)
+	if m.WorkspaceTrees == nil {
+		m.WorkspaceTrees = make(map[int]*layout.BSPTree)
+	}
+	m.WorkspaceTrees[1] = tree
+
+	for intID, r := range tree.ApplyLayout(m.GetBSPBounds()) {
+		if win := m.GetWindowByIntID(intID); win != nil {
+			win.X, win.Y = r.X, r.Y
+			win.Resize(r.W, r.H)
+		}
+	}
+}
+
+func v(ratio float64, l, r *layout.TileNode) *layout.TileNode {
+	return layout.NewInternalNode(layout.SplitVertical, ratio, l, r)
+}
+
+func h(ratio float64, l, r *layout.TileNode) *layout.TileNode {
+	return layout.NewInternalNode(layout.SplitHorizontal, ratio, l, r)
+}
+
+type isoCase struct {
+	name  string
+	count int
+	build func(leaf func(int) *layout.TileNode) *layout.TileNode
+	// pane and edge name the divider to drag, in 1-based topology IDs.
+	pane int
+	edge layout.ResizeEdge
+	// affected lists every pane the divider legitimately owns. Panes outside
+	// this set must not move by a single cell.
+	affected []int
+}
+
+var isoCases = []isoCase{
+	{
+		// A 2x2 grid: the two columns each have their own horizontal divider,
+		// and at the default 0.5 ratios the two sit on the same screen row.
+		// Dragging the left one must not touch the right column.
+		name:  "grid/left_column_divider",
+		count: 4,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.5, h(0.5, leaf(1), leaf(2)), h(0.5, leaf(3), leaf(4)))
+		},
+		pane: 1, edge: layout.ResizeEdgeBottom,
+		affected: []int{1, 2},
+	},
+	{
+		name:  "grid/right_column_divider",
+		count: 4,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.5, h(0.5, leaf(1), leaf(2)), h(0.5, leaf(3), leaf(4)))
+		},
+		pane: 4, edge: layout.ResizeEdgeTop,
+		affected: []int{3, 4},
+	},
+	{
+		// The root divider does separate both columns, so every pane moving is
+		// correct here. This case guards the other direction: the fix must not
+		// have made resizes stop propagating.
+		name:  "grid/root_divider",
+		count: 4,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.5, h(0.5, leaf(1), leaf(2)), h(0.5, leaf(3), leaf(4)))
+		},
+		pane: 1, edge: layout.ResizeEdgeRight,
+		affected: []int{1, 2, 3, 4},
+	},
+	{
+		// The maintainer's layout: one tall pane on the left, two stacked on
+		// the right.
+		name:  "tall_left/right_column_divider",
+		count: 3,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.5, leaf(1), h(0.5, leaf(2), leaf(3)))
+		},
+		pane: 2, edge: layout.ResizeEdgeBottom,
+		affected: []int{2, 3},
+	},
+	{
+		// Three columns, each split in two, all dividers at the same rows.
+		name:  "three_columns/middle_divider",
+		count: 6,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.34, h(0.5, leaf(1), leaf(2)),
+				v(0.5, h(0.5, leaf(3), leaf(4)), h(0.5, leaf(5), leaf(6))))
+		},
+		pane: 3, edge: layout.ResizeEdgeBottom,
+		affected: []int{3, 4},
+	},
+	{
+		name:  "three_columns/inner_column_divider",
+		count: 6,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.34, h(0.5, leaf(1), leaf(2)),
+				v(0.5, h(0.5, leaf(3), leaf(4)), h(0.5, leaf(5), leaf(6))))
+		},
+		pane: 5, edge: layout.ResizeEdgeLeft,
+		affected: []int{3, 4, 5, 6},
+	},
+	{
+		// A pane three levels down, so the divider's rectangle is narrowed by
+		// several ancestors before the ratio is derived against it.
+		name:  "deep_nest/innermost_divider",
+		count: 5,
+		build: func(leaf func(int) *layout.TileNode) *layout.TileNode {
+			return v(0.4, leaf(1), h(0.6, h(0.5, leaf(2), v(0.5, leaf(3), leaf(4))), leaf(5)))
+		},
+		pane: 3, edge: layout.ResizeEdgeRight,
+		affected: []int{3, 4},
+	},
+}
+
+type geom map[string][4]int
+
+func geomOf(m *app.OS) geom {
+	g := make(geom, len(m.Windows))
+	for _, w := range m.Windows {
+		g[w.ID] = [4]int{w.X, w.Y, w.Width, w.Height}
+	}
+	return g
+}
+
+// checkIsolation is the invariant: nothing outside the divider's own two
+// subtrees moved, and at least one pane inside them did.
+func checkIsolation(t *testing.T, label string, c isoCase, m *app.OS, before, after geom) {
+	t.Helper()
+
+	inSubtree := make(map[string]bool, len(c.affected))
+	for _, p := range c.affected {
+		inSubtree[m.Windows[p-1].ID] = true
+	}
+
+	changed := false
+	for id, b := range before {
+		a := after[id]
+		if inSubtree[id] {
+			if a != b {
+				changed = true
+			}
+			continue
+		}
+		if a != b {
+			t.Errorf("%s: pane %s is outside the dragged divider's subtrees but moved: %v -> %v",
+				label, id, b, a)
+		}
+	}
+	if !changed {
+		t.Errorf("%s: the resize did not move any pane; the drag was a no-op", label)
+	}
+}
+
+// checkSurvivesRetile is the second half: a retile rebuilds every pane from the
+// tree's ratios, so anything the resize failed to write into the tree is thrown
+// away here.
+func checkSurvivesRetile(t *testing.T, label string, m *app.OS, after geom) {
+	t.Helper()
+
+	frameBefore := m.View().Content
+	m.TileAllWindows()
+	for id, want := range after {
+		var got [4]int
+		for _, w := range m.Windows {
+			if w.ID == id {
+				got = [4]int{w.X, w.Y, w.Width, w.Height}
+			}
+		}
+		if got != want {
+			t.Errorf("%s: retile moved pane %s: %v -> %v; the resize was not committed to the tree",
+				label, id, want, got)
+		}
+	}
+	if frameAfter := m.View().Content; frameAfter != frameBefore {
+		t.Errorf("%s: the composed frame changed across a retile that should have been a no-op", label)
+	}
+}
+
+// TestKeyboardResizeMovesOnlyTheDividersSubtrees drives the keyboard path.
+func TestKeyboardResizeMovesOnlyTheDividersSubtrees(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		for _, c := range isoCases {
+			label := fmt.Sprintf("shared=%v/%s/keyboard", shared, c.name)
+			t.Run(label, func(t *testing.T) {
+				prev := config.SharedBorders
+				config.SharedBorders = shared
+				t.Cleanup(func() { config.SharedBorders = prev })
+
+				m := isoOS(t, c.count)
+				buildTree(m, c.build)
+				m.FocusedWindow = c.pane - 1
+
+				before := geomOf(m)
+				const delta = 4
+				switch c.edge {
+				case layout.ResizeEdgeRight:
+					m.ResizeFocusedWindowWidth(delta)
+				case layout.ResizeEdgeLeft:
+					m.ResizeFocusedWindowWidthLeft(delta)
+				case layout.ResizeEdgeBottom:
+					m.ResizeFocusedWindowHeight(-delta)
+				case layout.ResizeEdgeTop:
+					m.ResizeFocusedWindowHeightTop(delta)
+				}
+				after := geomOf(m)
+
+				checkIsolation(t, label, c, m, before, after)
+				checkSurvivesRetile(t, label, m, after)
+			})
+		}
+	}
+}
+
+// TestMouseResizeMovesOnlyTheDividersSubtrees drives the same layouts through
+// the real mouse path: press state, a run of motion events, then release.
+func TestMouseResizeMovesOnlyTheDividersSubtrees(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		for _, c := range isoCases {
+			label := fmt.Sprintf("shared=%v/%s/mouse", shared, c.name)
+			t.Run(label, func(t *testing.T) {
+				prev := config.SharedBorders
+				config.SharedBorders = shared
+				t.Cleanup(func() { config.SharedBorders = prev })
+
+				m := isoOS(t, c.count)
+				buildTree(m, c.build)
+				m.FocusedWindow = c.pane - 1
+
+				win := m.Windows[c.pane-1]
+				// Grab the corner that owns the edge under test, then move the
+				// pointer along that one axis only, so exactly one divider is
+				// dragged.
+				var startX, startY int
+				switch c.edge {
+				case layout.ResizeEdgeRight:
+					m.ResizeCorner, startX, startY = app.BottomRight, win.X+win.Width, win.Y+win.Height
+				case layout.ResizeEdgeBottom:
+					m.ResizeCorner, startX, startY = app.BottomRight, win.X+win.Width, win.Y+win.Height
+				case layout.ResizeEdgeLeft:
+					m.ResizeCorner, startX, startY = app.TopLeft, win.X, win.Y
+				case layout.ResizeEdgeTop:
+					m.ResizeCorner, startX, startY = app.TopLeft, win.X, win.Y
+				}
+				m.Resizing = true
+				m.InteractionMode = true
+				m.PreResizeState = terminal.Window{
+					ID: win.ID, X: win.X, Y: win.Y, Z: win.Z,
+					Width: win.Width, Height: win.Height,
+				}
+				m.ResizeStartX, m.ResizeStartY = startX, startY
+
+				before := geomOf(m)
+
+				const steps = 4
+				for i := 1; i <= steps; i++ {
+					x, y := startX, startY
+					switch c.edge {
+					case layout.ResizeEdgeRight, layout.ResizeEdgeLeft:
+						x = startX - i
+					case layout.ResizeEdgeBottom, layout.ResizeEdgeTop:
+						y = startY - i
+					}
+					_, _ = m.Update(motionAt(x, y))
+					_ = m.View()
+				}
+				switch c.edge {
+				case layout.ResizeEdgeRight, layout.ResizeEdgeLeft:
+					_, _ = m.Update(releaseAt(startX-steps, startY))
+				default:
+					_, _ = m.Update(releaseAt(startX, startY-steps))
+				}
+				after := geomOf(m)
+
+				checkIsolation(t, label, c, m, before, after)
+				checkSurvivesRetile(t, label, m, after)
+			})
+		}
+	}
+}

--- a/internal/input/resize_output_bench_test.go
+++ b/internal/input/resize_output_bench_test.go
@@ -1,0 +1,200 @@
+package input
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/ui"
+)
+
+// countDaemonResizes wires every window's daemon resize callback to a counter.
+//
+// The windows a benchmark builds are daemon windows with no daemon behind them,
+// so DaemonResizeFunc is nil and a resize that would be a socket round trip in
+// the real client costs a nil check here. That is precisely the gap that let a
+// per-frame PTY resize during shared-border drags ship unnoticed, so the drag
+// benchmarks below install a callback and report how often it fires.
+func countDaemonResizes(m *app.OS) *atomic.Int64 {
+	var n atomic.Int64
+	for _, win := range m.Windows {
+		win.DaemonResizeFunc = func(_, _ int) error {
+			n.Add(1)
+			return nil
+		}
+	}
+	return &n
+}
+
+// feedOutput writes a line of fresh output into every window's emulator, the
+// way a build log or a tailing process would while the user drags a divider.
+func feedOutput(m *app.OS, seq int) {
+	for _, win := range m.Windows {
+		if win.Terminal == nil {
+			continue
+		}
+		win.LockIO()
+		_, _ = win.Terminal.Write(fmt.Appendf(nil, "output line %d\r\n", seq))
+		win.UnlockIO()
+	}
+}
+
+// BenchmarkResizeDragWithOutput measures one drag frame in the regime the user
+// is actually in: terminals producing output while a divider is dragged.
+//
+// This is the case BenchmarkResizeMotionFrame cannot see. Motion renders are
+// coalesced to one per frame interval, so in a tight loop with no output almost
+// every motion event has its render skipped and View returns cached content,
+// which makes that benchmark mostly a measurement of the cache hit. PTYDataMsg
+// clears renderSkipped, so a single byte of output anywhere forces the next
+// View to compose for real. One motion event plus one PTY wakeup per iteration
+// is one composed frame per iteration, which is the unit that decides whether a
+// drag feels smooth.
+//
+// ptyResizes/frame is reported alongside the timing because the expensive part
+// of the frame was invisible to a benchmark's nil daemon callback.
+func BenchmarkResizeDragWithOutput(b *testing.B) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		for _, n := range []int{2, 4, 9} {
+			name := fmt.Sprintf("windows-%d/shared-%v", n, shared)
+			b.Run(name, func(b *testing.B) {
+				prev := config.SharedBorders
+				config.SharedBorders = shared
+				b.Cleanup(func() { config.SharedBorders = prev })
+
+				m := benchResizeOS(b, n)
+				resizes := countDaemonResizes(m)
+				startX, startY := m.ResizeStartX, m.ResizeStartY
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				i := 0
+				for b.Loop() {
+					dx := i%6 - 3
+					_, _ = m.Update(motionAt(startX+dx, startY))
+					_ = m.View()
+
+					feedOutput(m, i)
+					_, _ = m.Update(app.PTYDataMsg{})
+					_ = m.View()
+					i++
+				}
+				b.StopTimer()
+				b.ReportMetric(float64(resizes.Load())/float64(b.N), "ptyResizes/frame")
+			})
+		}
+	}
+}
+
+// TestSharedBorderDragTracksPointerAndDoesNotAnimate pins the other half of the
+// same bug, the half no timing measurement can see.
+//
+// A resize is direct manipulation. The edge belongs to the pointer and follows
+// it cell for cell, with nothing easing toward it. The shared
+// border ratio sync used to reapply the whole BSP layout on every composed
+// frame, and that path builds a snap animation per window, each easing over
+// 300ms toward a target the next frame would replace. The animations were
+// discarded and rebuilt roughly every frame, so the panes never arrived at
+// anything; they trailed the cursor on a curve that restarted continuously.
+// That reads as mush, and it costs almost no CPU time, which is why it hid from
+// every benchmark. It was shared-borders-only because only that mode reapplies
+// the layout from the sync, which matches where the slowness was reported.
+//
+// Ticks are delivered here because animations advance on the tick, so a test
+// that only sends motion would never see one move a window.
+func TestSharedBorderDragTracksPointerAndDoesNotAnimate(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared-%v", shared), func(t *testing.T) {
+			prev := config.SharedBorders
+			config.SharedBorders = shared
+			t.Cleanup(func() { config.SharedBorders = prev })
+
+			m := benchResizeOS(t, 9)
+			focused := m.GetFocusedWindow()
+			startX, startY := m.ResizeStartX, m.ResizeStartY
+
+			// Retire what tiling the workspace left in flight, so what this
+			// loop observes was created by the drag.
+			m.Animations = nil
+
+			const maxTrackingSlack = 2
+			for i := 1; i <= 20; i++ {
+				_, _ = m.Update(motionAt(startX+i, startY))
+				_, _ = m.Update(app.TickerMsg(time.Now()))
+				_ = m.View()
+
+				for _, anim := range m.Animations {
+					if anim.Type == ui.AnimationSnap {
+						t.Fatalf("motion %d: a snap animation is easing a pane toward a target while the pointer owns it", i)
+					}
+				}
+
+				// The edge stays with the pointer. It does not land exactly on it:
+				// with shared borders the pointer is on the separator and the pane
+				// ends the cell before, and the layout rounds ratios to whole
+				// cells, so the gap breathes by a cell as the ratio crosses a
+				// boundary. What must not happen is the edge falling steadily
+				// behind, which is what easing toward a moving target looks like
+				// over a drag this long.
+				if offset := (startX + i) - (focused.X + focused.Width); offset < 0 || offset > maxTrackingSlack {
+					t.Fatalf("motion %d: edge is %d cells from the pointer, more than the %d cells grid rounding accounts for",
+						i, offset, maxTrackingSlack)
+				}
+			}
+		})
+	}
+}
+
+// TestResizeDragDefersPTYResizeUntilRelease pins the reason shared-border drags
+// became expensive. The drag path resizes windows visually and records the new
+// sizes in PendingResizes so mouse release can apply them once. The shared
+// border ratio sync reapplies the whole BSP layout on every composed frame to
+// keep the separator overlay in step, and that reapply used to go through the
+// normal layout path, which resizes the emulator and notifies the daemon. With
+// output flowing, frames compose as fast as output arrives, so the user paid a
+// socket round trip per window per frame for a size they were still choosing.
+//
+// Not one PTY resize may escape before release, in either border mode.
+func TestResizeDragDefersPTYResizeUntilRelease(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared-%v", shared), func(t *testing.T) {
+			prev := config.SharedBorders
+			config.SharedBorders = shared
+			t.Cleanup(func() { config.SharedBorders = prev })
+
+			m := benchResizeOS(t, 9)
+			resizes := countDaemonResizes(m)
+			startX, startY := m.ResizeStartX, m.ResizeStartY
+
+			for i := range 30 {
+				dx := i%6 - 3
+				_, _ = m.Update(motionAt(startX+dx, startY))
+				// PTY output forces a real compose, the way a busy terminal does.
+				_, _ = m.Update(app.PTYDataMsg{})
+				_ = m.View()
+			}
+
+			if got := resizes.Load(); got != 0 {
+				t.Fatalf("drag issued %d PTY resizes before release, want 0", got)
+			}
+			if len(m.PendingResizes) == 0 {
+				t.Fatal("drag recorded no pending resizes, so release has nothing to apply")
+			}
+
+			// Release drains the pending resizes into one real resize per window.
+			_, _ = m.Update(releaseAt(startX, startY))
+			if got := resizes.Load(); got == 0 {
+				t.Fatal("release applied no PTY resize, so the drag result never reached the daemon")
+			}
+		})
+	}
+}

--- a/internal/input/resize_ratio_test.go
+++ b/internal/input/resize_ratio_test.go
@@ -1,0 +1,163 @@
+package input
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/layout"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// Resizing one divider changes the rectangle every split below it is laid out
+// in. Those splits were not dragged, so their proportions have to survive the
+// change: a nested pair that was even stays even as the region it lives in
+// grows or shrinks, and a drag that returns to where it began leaves the whole
+// layout where it began.
+//
+// The failure this pins is not a single wrong frame. Every path that changes
+// geometry without going through the tree asks for a ratio sync, and the sync
+// re-derives every split in the tree from integer geometry. Integer geometry
+// cannot represent most ratios, so each pass rounds the ratio towards the cell
+// boundary below it, and the loss is in the same direction every time. Over one
+// drag that is dozens of passes, and the nested pair walks off centre and stays
+// there.
+
+// ratioOS is the maintainer's layout: a full-width pane across the top, and
+// below it a left pane beside a right column split into two. Dragging the
+// divider under the top pane resizes the lower region, which is the parent of
+// the nested pair nobody touched.
+func ratioOS(t *testing.T) *app.OS {
+	t.Helper()
+
+	m := isoOS(t, 4)
+	buildTree(m, func(leaf func(int) *layout.TileNode) *layout.TileNode {
+		return h(0.35, leaf(1), v(0.5, leaf(2), h(0.5, leaf(3), leaf(4))))
+	})
+	return m
+}
+
+// nestedRatio returns the stored ratio of the split between the two panes in
+// the right column, which is the one no drag in these tests targets.
+func nestedRatio(m *app.OS) float64 {
+	return m.WorkspaceTrees[1].Root.Right.Right.SplitRatio
+}
+
+// pair returns the heights of the two panes in the right column.
+func pair(m *app.OS) (int, int) {
+	return m.Windows[2].Height, m.Windows[3].Height
+}
+
+// startDrag puts the model into the state a mouse press on the bottom edge of
+// the top pane leaves behind, so the motion events that follow are the real
+// drag path rather than a direct call into the resize code.
+func startDrag(m *app.OS) (startX, startY int) {
+	win := m.Windows[0]
+	m.FocusedWindow = 0
+	m.Resizing = true
+	m.InteractionMode = true
+	m.ResizeCorner = app.BottomRight
+	m.PreResizeState = terminal.Window{
+		ID: win.ID, X: win.X, Y: win.Y, Z: win.Z,
+		Width: win.Width, Height: win.Height,
+	}
+	startX, startY = win.X+win.Width, win.Y+win.Height
+	m.ResizeStartX, m.ResizeStartY = startX, startY
+	return startX, startY
+}
+
+// TestNestedRatioSurvivesAnOutAndBackDrag is the strongest statement of the
+// bug: a drag that ends where it started must be a no-op, in the geometry the
+// user sees and in the ratios a later retile rebuilds it from.
+func TestNestedRatioSurvivesAnOutAndBackDrag(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared=%v", shared), func(t *testing.T) {
+			prev := config.SharedBorders
+			config.SharedBorders = shared
+			t.Cleanup(func() { config.SharedBorders = prev })
+
+			m := ratioOS(t)
+			wantRatio := nestedRatio(m)
+			wantGeom := geomOf(m)
+
+			startX, startY := startDrag(m)
+			const reach = 6
+			for y := startY; y >= startY-reach; y-- {
+				_, _ = m.Update(motionAt(startX, y))
+				_ = m.View()
+			}
+			for y := startY - reach; y <= startY; y++ {
+				_, _ = m.Update(motionAt(startX, y))
+				_ = m.View()
+			}
+			_, _ = m.Update(releaseAt(startX, startY))
+
+			if got := nestedRatio(m); got != wantRatio {
+				t.Errorf("the untouched nested split moved: ratio %.6f -> %.6f", wantRatio, got)
+			}
+			for id, want := range wantGeom {
+				if got := geomOf(m)[id]; got != want {
+					t.Errorf("pane %s did not return to where the drag started: %v -> %v", id, want, got)
+				}
+			}
+
+			// A retile rebuilds every pane from the ratios, so a ratio that drifted
+			// shows up here even when the geometry happened to land back on its
+			// starting cells.
+			m.TileAllWindows()
+			for id, want := range wantGeom {
+				if got := geomOf(m)[id]; got != want {
+					t.Errorf("pane %s moved on the retile after the drag: %v -> %v", id, want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestGrowingARegionDistributesItAcrossTheNestedSplit is the direct property:
+// the two panes in the right column start even, so as the region they sit in
+// grows they have to stay even. One of them absorbing the whole change is the
+// user-visible form of the bug.
+func TestGrowingARegionDistributesItAcrossTheNestedSplit(t *testing.T) {
+	app.SetInputHandler(HandleInput)
+
+	for _, shared := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shared=%v", shared), func(t *testing.T) {
+			prev := config.SharedBorders
+			config.SharedBorders = shared
+			t.Cleanup(func() { config.SharedBorders = prev })
+
+			m := ratioOS(t)
+			startTop, startBottom := pair(m)
+			if startTop != startBottom {
+				t.Fatalf("the nested pair is not even to begin with (%d, %d); "+
+					"this test has nothing to measure", startTop, startBottom)
+			}
+
+			startX, startY := startDrag(m)
+			grew := false
+			for y := startY; y >= startY-8; y-- {
+				_, _ = m.Update(motionAt(startX, y))
+				_ = m.View()
+
+				top, bottom := pair(m)
+				if top+bottom > startTop+startBottom {
+					grew = true
+				}
+				// An even split of an odd number of rows is off by one and cannot be
+				// anything else. More than that is the region being handed to one
+				// pane rather than shared.
+				if d := top - bottom; d > 1 || d < -1 {
+					t.Fatalf("region grown to %d rows was not shared: top=%d bottom=%d",
+						top+bottom, top, bottom)
+				}
+			}
+			if !grew {
+				t.Fatal("the drag never grew the region, so nothing was measured")
+			}
+		})
+	}
+}

--- a/internal/layout/bsp.go
+++ b/internal/layout/bsp.go
@@ -715,6 +715,22 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		return
 	}
 
+	// A split whose divider already sits where its stored ratio puts it has
+	// nothing to learn from the geometry, and re-deriving it is not free: the
+	// ratio is a float, the geometry is whole cells, and applyLayoutRecursive
+	// truncates. Reading a truncated divider back as line/extent therefore
+	// rounds the ratio down every time, never up, so a split nobody dragged
+	// walks off centre one pass at a time. An exact 0.5 in a 29-row region comes
+	// back as 0.482759 after a single pass, and the next region size that ratio
+	// is applied at hands the extra rows to one child instead of sharing them.
+	//
+	// So the rule is: sync may only move the ratios whose geometry actually
+	// disagrees with the tree. That is exactly the set the paths this function
+	// exists for change - master-stack, floating windows, windows outside the
+	// tree, and the geometry-scan fallback - and it leaves every other split
+	// holding the value a resize deliberately put there.
+	expectedLeft, expectedRight := childBounds(node, bounds)
+
 	// Calculate the actual split ratio from window geometry.
 	if node.SplitType == SplitVertical {
 		// The split boundary is the near edge of the right subtree's leftmost
@@ -739,12 +755,15 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		if !ok {
 			return
 		}
-		if bounds.W > 0 {
-			node.SplitRatio = float64(splitX-bounds.X) / float64(bounds.W)
+		leftBounds, rightBounds := expectedLeft, expectedRight
+		if splitX != expectedLeft.X+expectedLeft.W {
+			if bounds.W > 0 {
+				node.SplitRatio = float64(splitX-bounds.X) / float64(bounds.W)
+			}
+			// Recurse with updated bounds
+			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
+			rightBounds = Rect{X: splitX + gap, Y: bounds.Y, W: bounds.X + bounds.W - splitX - gap, H: bounds.H}
 		}
-		// Recurse with updated bounds
-		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
-		rightBounds := Rect{X: splitX + gap, Y: bounds.Y, W: bounds.X + bounds.W - splitX - gap, H: bounds.H}
 		t.syncRatiosRecursive(node.Left, leftBounds, windows)
 		t.syncRatiosRecursive(node.Right, rightBounds, windows)
 	} else {
@@ -767,12 +786,15 @@ func (t *BSPTree) syncRatiosRecursive(node *TileNode, bounds Rect, windows map[i
 		if !ok {
 			return
 		}
-		if bounds.H > 0 {
-			node.SplitRatio = float64(splitY-bounds.Y) / float64(bounds.H)
+		leftBounds, rightBounds := expectedLeft, expectedRight
+		if splitY != expectedLeft.Y+expectedLeft.H {
+			if bounds.H > 0 {
+				node.SplitRatio = float64(splitY-bounds.Y) / float64(bounds.H)
+			}
+			// Recurse with updated bounds
+			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
+			rightBounds = Rect{X: bounds.X, Y: splitY + gap, W: bounds.W, H: bounds.Y + bounds.H - splitY - gap}
 		}
-		// Recurse with updated bounds
-		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
-		rightBounds := Rect{X: bounds.X, Y: splitY + gap, W: bounds.W, H: bounds.Y + bounds.H - splitY - gap}
 		t.syncRatiosRecursive(node.Left, leftBounds, windows)
 		t.syncRatiosRecursive(node.Right, rightBounds, windows)
 	}

--- a/internal/layout/bsp.go
+++ b/internal/layout/bsp.go
@@ -793,41 +793,6 @@ func (t *BSPTree) findAnyWindowInSubtree(node *TileNode) int {
 	return t.findAnyWindowInSubtree(node.Right)
 }
 
-// nodeRect computes the actual rectangle a node occupies by walking up from
-// the node to the root and applying split ratios along the way.
-func (t *BSPTree) nodeRect(node *TileNode, bounds Rect) Rect {
-	if node == nil {
-		return bounds
-	}
-	// Collect ancestors from root to node's parent
-	var ancestors []*TileNode
-	for cur := node; cur.Parent != nil; cur = cur.Parent {
-		ancestors = append(ancestors, cur)
-	}
-	// Walk from root down, narrowing bounds at each split
-	rect := bounds
-	for i := len(ancestors) - 1; i >= 0; i-- {
-		child := ancestors[i]
-		parent := child.Parent
-		if parent.SplitType == SplitVertical {
-			splitX := rect.X + int(float64(rect.W)*parent.SplitRatio)
-			if child.IsLeftChild() {
-				rect = Rect{X: rect.X, Y: rect.Y, W: splitX - rect.X, H: rect.H}
-			} else {
-				rect = Rect{X: splitX, Y: rect.Y, W: rect.X + rect.W - splitX, H: rect.H}
-			}
-		} else {
-			splitY := rect.Y + int(float64(rect.H)*parent.SplitRatio)
-			if child.IsLeftChild() {
-				rect = Rect{X: rect.X, Y: rect.Y, W: rect.W, H: splitY - rect.Y}
-			} else {
-				rect = Rect{X: rect.X, Y: splitY, W: rect.W, H: rect.Y + rect.H - splitY}
-			}
-		}
-	}
-	return rect
-}
-
 // determineAutoSplit determines the split direction based on the auto scheme
 func (t *BSPTree) determineAutoSplit(targetNode *TileNode, bounds Rect) SplitType {
 	switch t.AutoScheme {
@@ -862,7 +827,13 @@ func (t *BSPTree) determineAutoSplit(targetNode *TileNode, bounds Rect) SplitTyp
 
 	case SchemeSmartSplit:
 		// Compute the focused window's actual rect from the BSP tree
-		r := t.nodeRect(targetNode, bounds)
+		// nodeBounds mirrors the layout exactly, separator gap and stacked
+		// title bars included, so the aspect ratio this heuristic reads is the
+		// one on screen.
+		r, ok := t.nodeBounds(targetNode, bounds)
+		if !ok {
+			r = bounds
+		}
 		w, h := r.W, r.H
 		if w > h*2 {
 			// Very wide window: split vertically (side by side)
@@ -983,43 +954,36 @@ func (t *BSPTree) collectSplitsRecursive(node *TileNode, bounds Rect, splits *[]
 		return
 	}
 
-	if node.SplitType == SplitVertical {
-		splitX := bounds.X + int(float64(bounds.W)*node.SplitRatio)
-		if splitX <= bounds.X {
-			splitX = bounds.X + 1
+	// The separator the user sees and grabs has to be the one the layout
+	// actually put there, so the position comes from childBounds rather than
+	// from a second copy of the split arithmetic. A separator drawn where no
+	// divider is means the pointer offers a resize cursor over a line that
+	// dragging will not move.
+	leftBounds, rightBounds := childBounds(node, bounds)
+
+	// A stacked node splits by raising one child's title bar, not by a
+	// separator, and ResizeSplit will not move one. Emitting a line for it
+	// would advertise a divider that cannot be dragged.
+	if node.SplitType != SplitStacked {
+		if node.SplitType == SplitVertical {
+			*splits = append(*splits, SplitLine{
+				Vertical: true,
+				Pos:      bounds.X + leftBounds.W,
+				From:     bounds.Y,
+				To:       bounds.Y + bounds.H - 1,
+			})
+		} else {
+			*splits = append(*splits, SplitLine{
+				Vertical: false,
+				Pos:      bounds.Y + leftBounds.H,
+				From:     bounds.X,
+				To:       bounds.X + bounds.W - 1,
+			})
 		}
-		if splitX >= bounds.X+bounds.W-1 {
-			splitX = bounds.X + bounds.W - 2
-		}
-		*splits = append(*splits, SplitLine{
-			Vertical: true,
-			Pos:      splitX,
-			From:     bounds.Y,
-			To:       bounds.Y + bounds.H - 1,
-		})
-		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
-		rightBounds := Rect{X: splitX + 1, Y: bounds.Y, W: bounds.X + bounds.W - splitX - 1, H: bounds.H}
-		t.collectSplitsRecursive(node.Left, leftBounds, splits)
-		t.collectSplitsRecursive(node.Right, rightBounds, splits)
-	} else {
-		splitY := bounds.Y + int(float64(bounds.H)*node.SplitRatio)
-		if splitY <= bounds.Y {
-			splitY = bounds.Y + 1
-		}
-		if splitY >= bounds.Y+bounds.H-1 {
-			splitY = bounds.Y + bounds.H - 2
-		}
-		*splits = append(*splits, SplitLine{
-			Vertical: false,
-			Pos:      splitY,
-			From:     bounds.X,
-			To:       bounds.X + bounds.W - 1,
-		})
-		leftBounds := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
-		rightBounds := Rect{X: bounds.X, Y: splitY + 1, W: bounds.W, H: bounds.Y + bounds.H - splitY - 1}
-		t.collectSplitsRecursive(node.Left, leftBounds, splits)
-		t.collectSplitsRecursive(node.Right, rightBounds, splits)
 	}
+
+	t.collectSplitsRecursive(node.Left, leftBounds, splits)
+	t.collectSplitsRecursive(node.Right, rightBounds, splits)
 }
 
 // GetAllWindowIDs returns all window IDs in the tree (in-order traversal)

--- a/internal/layout/bsp.go
+++ b/internal/layout/bsp.go
@@ -404,6 +404,16 @@ func (t *BSPTree) RemoveWindow(windowID int) {
 // Returns a map of windowID -> Rect with the calculated layout.
 func (t *BSPTree) ApplyLayout(bounds Rect) map[int]Rect {
 	result := make(map[int]Rect)
+	t.ApplyLayoutInto(bounds, result)
+	return result
+}
+
+// ApplyLayoutInto is ApplyLayout writing into a caller-owned map. A mouse drag
+// reapplies the layout on every motion event, and allocating a fresh map each
+// time makes the cost of a single event scale with how many panes the workspace
+// holds; reusing one keeps it flat.
+func (t *BSPTree) ApplyLayoutInto(bounds Rect, result map[int]Rect) map[int]Rect {
+	clear(result)
 	if t.Root == nil {
 		return result
 	}
@@ -439,71 +449,228 @@ func (t *BSPTree) applyLayoutRecursive(node *TileNode, bounds Rect, result map[i
 		return
 	}
 
-	// Internal node - split the bounds
-	var leftBounds, rightBounds Rect
-
-	if config.SharedBorders {
-		// Shared borders mode: reserve 1 cell for separator line between panes
-		if node.SplitType == SplitVertical {
-			// Vertical split: left | separator | right
-			splitX := bounds.X + int(float64(bounds.W)*node.SplitRatio)
-			// Clamp so separator stays within bounds
-			if splitX <= bounds.X {
-				splitX = bounds.X + 1
-			}
-			if splitX >= bounds.X+bounds.W-1 {
-				splitX = bounds.X + bounds.W - 2
-			}
-			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
-			rightBounds = Rect{X: splitX + 1, Y: bounds.Y, W: bounds.X + bounds.W - splitX - 1, H: bounds.H}
-		} else {
-			// Horizontal split: top / separator / bottom
-			splitY := bounds.Y + int(float64(bounds.H)*node.SplitRatio)
-			// Clamp so separator stays within bounds
-			if splitY <= bounds.Y {
-				splitY = bounds.Y + 1
-			}
-			if splitY >= bounds.Y+bounds.H-1 {
-				splitY = bounds.Y + bounds.H - 2
-			}
-			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
-			rightBounds = Rect{X: bounds.X, Y: splitY + 1, W: bounds.W, H: bounds.Y + bounds.H - splitY - 1}
-		}
-	} else {
-		if node.SplitType == SplitVertical {
-			// Vertical split: left | right
-			splitX := bounds.X + int(float64(bounds.W)*node.SplitRatio)
-			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
-			rightBounds = Rect{X: splitX, Y: bounds.Y, W: bounds.X + bounds.W - splitX, H: bounds.H}
-		} else {
-			// Horizontal split: top / bottom
-			splitY := bounds.Y + int(float64(bounds.H)*node.SplitRatio)
-			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
-			rightBounds = Rect{X: bounds.X, Y: splitY, W: bounds.W, H: bounds.Y + bounds.H - splitY}
-		}
-	}
-
-	if node.SplitType == SplitStacked {
-		// Stacked: active child gets full bounds minus 1 row for inactive child's title bar
-		titleBarHeight := 1
-		if node.StackedActiveLeft {
-			// Left is active: gets content area, right gets title bar at bottom
-			activeBounds := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: bounds.H - titleBarHeight}
-			inactiveBounds := Rect{X: bounds.X, Y: bounds.Y + bounds.H - titleBarHeight, W: bounds.W, H: titleBarHeight}
-			t.applyLayoutRecursive(node.Left, activeBounds, result)
-			t.applyLayoutRecursive(node.Right, inactiveBounds, result)
-		} else {
-			// Right is active: left gets title bar at top, right gets content area
-			inactiveBounds := Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: titleBarHeight}
-			activeBounds := Rect{X: bounds.X, Y: bounds.Y + titleBarHeight, W: bounds.W, H: bounds.H - titleBarHeight}
-			t.applyLayoutRecursive(node.Left, inactiveBounds, result)
-			t.applyLayoutRecursive(node.Right, activeBounds, result)
-		}
-		return
-	}
-
+	leftBounds, rightBounds := childBounds(node, bounds)
 	t.applyLayoutRecursive(node.Left, leftBounds, result)
 	t.applyLayoutRecursive(node.Right, rightBounds, result)
+}
+
+// childBounds divides an internal node's rectangle between its two children.
+// It is the single definition of the split model: every other part of the
+// layout that needs to know where a divider sits, or what rectangle a node was
+// laid out in, has to derive it from here rather than reimplement it. Resizing
+// in particular depends on that, because a ratio computed against a rectangle
+// the layout does not agree with puts the divider somewhere the drag did not
+// ask for.
+func childBounds(node *TileNode, bounds Rect) (leftBounds, rightBounds Rect) {
+	if node.SplitType == SplitStacked {
+		// Stacked: the active child gets the content area, the inactive one is
+		// reduced to a single title bar row.
+		const titleBarHeight = 1
+		if node.StackedActiveLeft {
+			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: bounds.H - titleBarHeight}
+			rightBounds = Rect{X: bounds.X, Y: bounds.Y + bounds.H - titleBarHeight, W: bounds.W, H: titleBarHeight}
+		} else {
+			leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: titleBarHeight}
+			rightBounds = Rect{X: bounds.X, Y: bounds.Y + titleBarHeight, W: bounds.W, H: bounds.H - titleBarHeight}
+		}
+		return leftBounds, rightBounds
+	}
+
+	// Shared borders reserve one cell between the two children for the drawn
+	// separator, so the far child starts one past the divider line.
+	gap := 0
+	if config.SharedBorders {
+		gap = 1
+	}
+
+	if node.SplitType == SplitVertical {
+		splitX := bounds.X + int(float64(bounds.W)*node.SplitRatio)
+		if gap > 0 {
+			// Keep the separator cell inside the node's own rectangle.
+			splitX = max(bounds.X+1, min(splitX, bounds.X+bounds.W-2))
+		}
+		leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: splitX - bounds.X, H: bounds.H}
+		rightBounds = Rect{X: splitX + gap, Y: bounds.Y, W: bounds.X + bounds.W - splitX - gap, H: bounds.H}
+		return leftBounds, rightBounds
+	}
+
+	splitY := bounds.Y + int(float64(bounds.H)*node.SplitRatio)
+	if gap > 0 {
+		splitY = max(bounds.Y+1, min(splitY, bounds.Y+bounds.H-2))
+	}
+	leftBounds = Rect{X: bounds.X, Y: bounds.Y, W: bounds.W, H: splitY - bounds.Y}
+	rightBounds = Rect{X: bounds.X, Y: splitY + gap, W: bounds.W, H: bounds.Y + bounds.H - splitY - gap}
+	return leftBounds, rightBounds
+}
+
+// ResizeEdge names the side of a pane that a resize gesture drags.
+type ResizeEdge int
+
+const (
+	ResizeEdgeRight ResizeEdge = iota
+	ResizeEdgeLeft
+	ResizeEdgeBottom
+	ResizeEdgeTop
+)
+
+func (e ResizeEdge) vertical() bool {
+	return e == ResizeEdgeRight || e == ResizeEdgeLeft
+}
+
+// far reports whether the edge is on the high side of the pane, which is the
+// side the divider sits on when the pane's subtree is the near child.
+func (e ResizeEdge) far() bool {
+	return e == ResizeEdgeRight || e == ResizeEdgeBottom
+}
+
+// ResizeSplit moves the divider that owns one edge of a window to pos, given in
+// the same coordinate space as bounds. It reports whether a divider was found:
+// an edge that lies on the outer boundary of the whole layout has none, and the
+// caller should leave the geometry alone rather than invent one.
+//
+// This is the only correct way to resize a BSP layout. Matching panes by
+// geometry instead - collecting every window whose edge happens to fall on the
+// dragged line - sweeps in panes from unrelated subtrees whenever two dividers
+// coincide, which they do by default because fresh splits are all 0.5. The tree
+// says exactly which two subtrees the divider separates, and nothing outside
+// them may move.
+func (t *BSPTree) ResizeSplit(windowID int, e ResizeEdge, pos int, bounds Rect) bool {
+	leaf := t.WindowToNode[windowID]
+	if leaf == nil {
+		return false
+	}
+
+	// Walk up to the nearest ancestor that splits on this axis with the window's
+	// subtree on the near side of the divider. Stacked ancestors have no
+	// draggable divider, so they are skipped rather than treated as the split.
+	var node *TileNode
+	for cur := leaf; cur.Parent != nil; cur = cur.Parent {
+		p := cur.Parent
+		if p.SplitType == SplitStacked {
+			continue
+		}
+		if (p.SplitType == SplitVertical) != e.vertical() {
+			continue
+		}
+		if e.far() == cur.IsLeftChild() {
+			node = p
+			break
+		}
+	}
+	if node == nil {
+		return false
+	}
+
+	rect, ok := t.nodeBounds(node, bounds)
+	if !ok {
+		return false
+	}
+
+	gap := 0
+	if config.SharedBorders {
+		gap = 1
+	}
+
+	// The near child's far edge is the divider line itself; the far child's near
+	// edge sits one separator cell past it.
+	line := pos
+	if !e.far() {
+		line -= gap
+	}
+
+	origin, extent := rect.X, rect.W
+	if !e.vertical() {
+		origin, extent = rect.Y, rect.H
+	}
+	if extent <= 0 {
+		return false
+	}
+
+	// Neither subtree may be squeezed below what its own leaves need, and a
+	// subtree split along the same axis needs the sum of its children.
+	lo := origin + minExtent(node.Left, e.vertical())
+	hi := origin + extent - gap - minExtent(node.Right, e.vertical())
+	if lo > hi {
+		return false
+	}
+	line = max(lo, min(line, hi))
+
+	// Aim at the middle of the target cell. applyLayoutRecursive truncates
+	// ratio*extent, so a ratio derived from the cell's left edge can round down
+	// to the previous cell and make a drag lose a step, or creep on re-apply.
+	node.SplitRatio = (float64(line-origin) + 0.5) / float64(extent)
+	return true
+}
+
+// minExtent is the smallest width (or height) a subtree can be laid out in
+// without pushing one of its leaves under the minimum window size.
+func minExtent(node *TileNode, vertical bool) int {
+	if node == nil {
+		return 0
+	}
+	if node.IsLeaf() {
+		if vertical {
+			return config.DefaultWindowWidth
+		}
+		return config.DefaultWindowHeight
+	}
+
+	left := minExtent(node.Left, vertical)
+	right := minExtent(node.Right, vertical)
+
+	if node.SplitType == SplitStacked {
+		if vertical {
+			return max(left, right)
+		}
+		// The inactive child is collapsed to a title bar row on top of the
+		// active child's content.
+		return max(left, right) + 1
+	}
+
+	if (node.SplitType == SplitVertical) != vertical {
+		// Split runs the other way: both children span the full extent.
+		return max(left, right)
+	}
+
+	gap := 0
+	if config.SharedBorders {
+		gap = 1
+	}
+	return left + right + gap
+}
+
+// nodeBounds returns the rectangle applyLayoutRecursive would hand to target.
+// It descends from the root through childBounds rather than recomputing the
+// split model, so a ratio derived from it lands the divider where the caller
+// asked.
+func (t *BSPTree) nodeBounds(target *TileNode, bounds Rect) (Rect, bool) {
+	if target == nil || t.Root == nil {
+		return Rect{}, false
+	}
+
+	// Path from the root down to target, collected by walking parent links up.
+	var path []*TileNode
+	for cur := target; cur != nil; cur = cur.Parent {
+		path = append(path, cur)
+	}
+	if path[len(path)-1] != t.Root {
+		return Rect{}, false
+	}
+
+	rect := bounds
+	for i := len(path) - 1; i > 0; i-- {
+		node := path[i]
+		if node.IsLeaf() {
+			return Rect{}, false
+		}
+		leftBounds, rightBounds := childBounds(node, rect)
+		if path[i-1] == node.Left {
+			rect = leftBounds
+		} else {
+			rect = rightBounds
+		}
+	}
+	return rect, true
 }
 
 // SyncRatiosFromGeometry updates the tree's split ratios based on actual window positions.


### PR DESCRIPTION
Three defects on the resize path, found by tracing a real drag rather than by benchmarking. All three were confirmed by reverting the fix and watching the accompanying test fail.

## Unrelated panes moved

Dragging one divider moved windows in unrelated subtrees. A trace of a real drag showed one grab moving five windows, two of them in a different part of the layout entirely.

`adjustTilingNeighborsGeneric` found neighbours by geometry, scanning every window in the workspace for an edge within one cell of the dragged line. Two dividers in different subtrees are the same line whenever their ratios agree, and fresh splits are all 0.5, so they agree by default. That is why it was intermittent: it fired only when two dividers happened to be collinear.

Resize is now tree-driven. `BSPTree.ResizeSplit` walks up from the leaf to the nearest ancestor splitting on the drag axis with the pane's subtree on the near side, and moves that node's ratio. The tree names exactly the two subtrees a divider separates, so there is no interval where the tree and the geometry disagree.

`childBounds` becomes the single definition of the split model, covering the shared-border gap and stacked title bars, and is now used by layout application, node lookup, resize, and `CollectSplits`. `nodeRect` is deleted. `CollectSplits` had been a third copy of that arithmetic and was emitting a separator for stacked nodes, which have no draggable divider, so the cursor advertised a resize that dragging could not perform.

A second mechanism was found in the same area: snap animations own a window's geometry until they finish, rewriting it every tick. The old code was immune only by accident, because reapplying the whole layout per motion event cancelled those animations as a side effect. Windows animate on every layout change, so starting a drag on top of one is ordinary.

## Shared-border drags churned animations and hit the daemon

`SyncBSPTreeFromGeometry` calls `ApplyBSPLayout` only when shared borders are on, on every composed frame during a drag. Counted rather than inferred, at nine windows:

- 52 snap animations created over 20 drag frames, against 0 with plain borders. Each cancelled and restarted the previous, so panes never arrived at the pointer.
- 205 PTY resizes over 30 frames, against 0 plain. The already-at-target branch calls `Resize()`, which reflows the emulator and makes a daemon socket round trip.

Both gated on shared borders, which matches where the problem was reported.

That per-frame cost predates this work. What changed is that raising the drag tick from a fixed 30 FPS to `NormalFPS` made the same work happen two to eight times more often. A resize is direct manipulation, so geometry is now set directly during a drag and animation is left to the layout changes it exists for.

Wall clock does not improve, and the benchmark is not the right instrument: `DaemonResizeFunc` is nil under test, so 205 socket round trips cost a nil check, and driving motion into idle terminals makes nearly every frame a cache hit. Animations 52 to 0 and PTY resizes 6.83 per frame to 0 are the measurements that matter.

## Nested splits drifted

Resizing a pane vertically walked the ratio of an untouched split below it. One sync pass takes 0.500 to 0.482759, which is exactly 14/29: `applyLayoutRecursive` truncates `int(ratio*extent)` and `SyncRatiosFromGeometry` reads the truncated divider back as `line/extent`. The loss is one-way.

It is then a fixed point, which is why `TestSyncRoundTripIsStable` never saw it: syncing a pristine layout at a fixed size cannot observe the first pass's loss. A 1.7 percent loss is enough to matter, since growing the pair from 28 to 36 rows then yields 17/19 instead of 18/18.

The trigger is any motion event where the tree-driven resize declines, such as a zero-delta event or an edge blocked at a boundary. That path marks a pending sync, and the sync re-derived every split in the tree rather than the one that moved. It now rewrites a ratio only when the observed divider disagrees with what the stored ratio would produce, so the geometry-scan fallback still corrects the paths that need it.

## Tests

`resize_isolation_test.go` asserts that nothing outside the dragged divider's two subtrees moves, across seven topologies, both border modes, and both the mouse and keyboard paths, and that a subsequent retile moves nothing and leaves the composed frame unchanged.

`resize_ratio_test.go` asserts that a drag out and back leaves every untouched ratio where it started, and that growing a region distributes the new rows across a nested split rather than giving them to one pane.

Plus assertions that no snap animation survives a resize motion, and that shared-border motion does not scale with window count.

## Verification

Full packages unfiltered in both plain and `-race` modes. Both matter: one failure in this area passed under `-race` and failed without it, because `-race` slows execution enough for stale animations to retire before the assertion.

`go build`, `go vet`, `gofmt`, `go test ./...` and `go test -race ./...` all clean. The PTY-driven e2e suite passes under `TUIOS_E2E=1`.