### PR TITLE
Fit the UI to small terminals, and stop a lost mouse release wedging the session

### DIFF
--- a/internal/app/command_palette_nav.go
+++ b/internal/app/command_palette_nav.go
@@ -17,7 +17,7 @@ func (m *OS) PaletteMove(delta int) {
 		return
 	}
 	m.CommandPaletteSelected = clampInt(m.CommandPaletteSelected+delta, 0, n-1)
-	_, visible := m.paletteLayout()
+	_, visible, _ := m.paletteLayout()
 	if m.CommandPaletteSelected < m.CommandPaletteScroll {
 		m.CommandPaletteScroll = m.CommandPaletteSelected
 	}

--- a/internal/app/command_palette_nav.go
+++ b/internal/app/command_palette_nav.go
@@ -17,11 +17,12 @@ func (m *OS) PaletteMove(delta int) {
 		return
 	}
 	m.CommandPaletteSelected = clampInt(m.CommandPaletteSelected+delta, 0, n-1)
+	_, visible := m.paletteLayout()
 	if m.CommandPaletteSelected < m.CommandPaletteScroll {
 		m.CommandPaletteScroll = m.CommandPaletteSelected
 	}
-	if m.CommandPaletteSelected >= m.CommandPaletteScroll+paletteMaxVisible {
-		m.CommandPaletteScroll = m.CommandPaletteSelected - paletteMaxVisible + 1
+	if m.CommandPaletteSelected >= m.CommandPaletteScroll+visible {
+		m.CommandPaletteScroll = m.CommandPaletteSelected - visible + 1
 	}
 }
 

--- a/internal/app/dock_helpers.go
+++ b/internal/app/dock_helpers.go
@@ -45,8 +45,11 @@ func (m *OS) CalculateDockLayout() DockLayout {
 	// Build left side text (compact format)
 	layout.LeftText, layout.LeftWidth, layout.ModeInfo = m.buildDockLeftText()
 
-	// Calculate right side width
-	layout.RightWidth = m.calculateDockRightWidth()
+	// Calculate right side width. The estimate below is what the right block
+	// would like; on a narrow screen it is capped at what the left block leaves,
+	// otherwise the two together are wider than the dock and the right-hand end
+	// (the system stats, or the copy-mode help) is drawn off the screen.
+	layout.RightWidth = min(m.calculateDockRightWidth(), max(m.GetRenderWidth()-layout.LeftWidth, 0))
 
 	// Get all dock items
 	allItems := m.getDockItems()

--- a/internal/app/dock_helpers.go
+++ b/internal/app/dock_helpers.go
@@ -176,26 +176,51 @@ func (m *OS) buildDockLeftText() (string, int, ModeInfo) {
 	return leftText, width, modeInfo
 }
 
+// copyModeHelpTexts returns the dock's copy-mode help line for a sub-state,
+// longest first. The renderer takes the longest one that fits the room the dock
+// has; on a narrow screen that is the shortest of them, which still names the
+// keys that matter. Shared with the width calculation so the space reserved
+// matches the line actually drawn.
+func copyModeHelpTexts(state terminal.CopyModeState) []string {
+	switch state {
+	case terminal.CopyModeNormal:
+		return []string{
+			"hjkl:move w/b/e:word f/F/t/T:char /:search n/N:next/prev C-l:clear ;,:repeat v:visual y:yank i:term q:quit",
+			"hjkl:move w/b/e:word /:search v:visual y:yank q:quit",
+			"hjkl /:search v y q",
+		}
+	case terminal.CopyModeSearch:
+		return []string{
+			"Type to search  n/N:next/prev  Enter:done  Esc:cancel",
+			"n/N:next  Enter:done  Esc:cancel",
+		}
+	case terminal.CopyModeVisualChar:
+		return []string{
+			"hjkl:extend w/b/e:word f/F/t/T:char ;,:repeat {/}:para %:bracket y:yank Esc:cancel",
+			"hjkl:extend w/b/e:word y:yank Esc:cancel",
+			"hjkl y:yank Esc",
+		}
+	case terminal.CopyModeVisualLine:
+		return []string{"jk:extend  y:yank  Esc:cancel", "jk y Esc"}
+	}
+	return nil
+}
+
 // calculateDockRightWidth calculates the width of the right side of the dock
 func (m *OS) calculateDockRightWidth() int {
 	focusedWindow := m.GetFocusedWindow()
 	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
 
 	if inCopyMode {
-		// In copy mode, help text can be very long - estimate based on copy mode state
-		// These widths match the actual help text lengths in render.go
-		switch focusedWindow.CopyMode.State {
-		case terminal.CopyModeNormal:
-			return 110 // Length of normal mode help text + padding
-		case terminal.CopyModeSearch:
-			return 60 // Length of search mode help text + padding
-		case terminal.CopyModeVisualChar:
-			return 90 // Length of visual char mode help text + padding
-		case terminal.CopyModeVisualLine:
-			return 35 // Length of visual line mode help text + padding
-		default:
+		// In copy mode the help line is the right-hand block. Measure the
+		// longest variant rather than guessing at it, so a terminal with room
+		// for it reserves exactly enough and one without falls to a shorter
+		// line instead of being one cell short of the full one.
+		texts := copyModeHelpTexts(focusedWindow.CopyMode.State)
+		if len(texts) == 0 {
 			return 32
 		}
+		return lipgloss.Width(texts[0]) + 2 // the help style's own padding
 	}
 
 	return 32 // CPU graph (~19 chars) + space + RAM (~11 chars) = ~31 chars

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -329,11 +329,18 @@ func SearchBindings(query string, categories []HelpCategory) []HelpBinding {
 	return results
 }
 
-// Help overlay layout constants.
+// Help overlay layout constants. These are the preferred sizes; a screen
+// narrower or shorter than the panel prefers gets a panel fitted to it (see
+// overlay_fit.go).
 const (
 	helpPanelInnerWidth = 74
 	helpVisibleRows     = 14
 	helpKeyColMax       = 30
+
+	// helpCategoryTagWidth is the narrowest inner width that still has room for
+	// the right-aligned category tag next to a search result. Below it the tag
+	// is dropped so the description keeps the space.
+	helpCategoryTagWidth = 48
 )
 
 // helpTabNames maps full category names to short tab labels.
@@ -395,20 +402,38 @@ func (m *OS) RenderHelpMenu() (string, overlay.Geometry) {
 		bindings = categories[m.HelpCategory].Bindings
 	}
 
-	body := m.renderHelpBody(bindings, inSearch, showCategoryTag, pal)
+	var tabs []string
+	if !inSearch {
+		tabs = make([]string, len(categories))
+		for i, cat := range categories {
+			tabs[i] = helpTabLabel(cat.Name)
+		}
+	}
+
+	width := m.panelWidth(helpPanelInnerWidth)
+	hints := helpHints(inSearch)
+	// Body lines that are not binding rows: the scroll indicator, plus the
+	// search prompt and its rule when searching.
+	extra := 1
+	if inSearch {
+		extra += 2
+	}
+	rows := m.panelBodyRows(helpVisibleRows, extra, width, tabs, hints)
+	if width < helpCategoryTagWidth {
+		showCategoryTag = false
+	}
+
+	body := m.renderHelpBody(bindings, inSearch, showCategoryTag, pal, width, rows)
 
 	panel := overlay.Panel{
 		Glyph: "", // keyboard
 		Title: "Keybindings",
-		Width: helpPanelInnerWidth,
+		Width: width,
 		Body:  body,
-		Hints: helpHints(inSearch),
+		Hints: hints,
 	}
 	if !inSearch {
-		panel.Tabs = make([]string, len(categories))
-		for i, cat := range categories {
-			panel.Tabs[i] = helpTabLabel(cat.Name)
-		}
+		panel.Tabs = tabs
 		panel.ActiveTab = m.HelpCategory
 	}
 
@@ -418,7 +443,7 @@ func (m *OS) RenderHelpMenu() (string, overlay.Geometry) {
 // renderHelpBody builds the multi-line body: an optional search box, the
 // scrolling list of binding rows, and a scroll indicator, padded to a fixed
 // height so the panel never jumps.
-func (m *OS) renderHelpBody(bindings []HelpBinding, inSearch, showCategoryTag bool, pal overlay.Palette) string {
+func (m *OS) renderHelpBody(bindings []HelpBinding, inSearch, showCategoryTag bool, pal overlay.Palette, width, visibleRows int) string {
 	bg := pal.Surface
 	var lines []string
 
@@ -426,21 +451,23 @@ func (m *OS) renderHelpBody(bindings []HelpBinding, inSearch, showCategoryTag bo
 		cursor := overlay.Style(bg).Foreground(pal.Accent).Render("█")
 		prompt := overlay.Style(bg).Foreground(pal.AccentBright).Bold(true).Render("Search ") +
 			overlay.Style(bg).Foreground(pal.Fg).Render(m.HelpSearchQuery) + cursor
-		lines = append(lines, prompt, overlay.Rule(helpPanelInnerWidth, bg, pal))
+		lines = append(lines, prompt, overlay.Rule(width, bg, pal))
 	}
 
 	// Clamp scroll to the row count.
-	maxScroll := max(len(bindings)-helpVisibleRows, 0)
+	maxScroll := max(len(bindings)-visibleRows, 0)
 	m.HelpScrollOffset = max(0, min(m.HelpScrollOffset, maxScroll))
 
-	// Compute a stable key column width from the visible window.
+	// Compute a stable key column width from the visible window. On a narrow
+	// panel the badges may not leave a usable description column, so the key
+	// column never takes more than half the width.
 	keyColW := 0
-	end := min(m.HelpScrollOffset+helpVisibleRows, len(bindings))
+	end := min(m.HelpScrollOffset+visibleRows, len(bindings))
 	for i := m.HelpScrollOffset; i < end; i++ {
 		w := lipgloss.Width(overlay.KeyBadges(bindings[i].Keys, bg, pal))
 		keyColW = max(keyColW, w)
 	}
-	keyColW = min(keyColW, helpKeyColMax)
+	keyColW = min(keyColW, min(helpKeyColMax, max(width/2, 6)))
 
 	if len(bindings) == 0 {
 		msg := "No matching keybindings"
@@ -452,17 +479,17 @@ func (m *OS) renderHelpBody(bindings []HelpBinding, inSearch, showCategoryTag bo
 
 	rowCount := 0
 	for i := m.HelpScrollOffset; i < end; i++ {
-		lines = append(lines, helpBindingRow(bindings[i], keyColW, showCategoryTag, pal))
+		lines = append(lines, helpBindingRow(bindings[i], keyColW, showCategoryTag, pal, width))
 		rowCount++
 	}
 	// Pad to a fixed number of rows so the panel height is stable.
-	for rowCount < helpVisibleRows {
+	for rowCount < visibleRows {
 		lines = append(lines, overlay.Style(bg).Render(" "))
 		rowCount++
 	}
 
 	// Scroll indicator.
-	if len(bindings) > helpVisibleRows {
+	if len(bindings) > visibleRows {
 		info := fmt.Sprintf("%d-%d of %d", m.HelpScrollOffset+1, end, len(bindings))
 		lines = append(lines, overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  "+info))
 	} else {
@@ -474,9 +501,20 @@ func (m *OS) renderHelpBody(bindings []HelpBinding, inSearch, showCategoryTag bo
 
 // helpBindingRow renders one keybinding row: key badges in a fixed-width gutter,
 // the description, and an optional right-aligned category tag (in search view).
-func helpBindingRow(b HelpBinding, keyColW int, showCategoryTag bool, pal overlay.Palette) string {
+func helpBindingRow(b HelpBinding, keyColW int, showCategoryTag bool, pal overlay.Palette, width int) string {
 	bg := pal.Surface
-	badges := overlay.KeyBadges(b.Keys, bg, pal)
+	// A binding with more key combos than the column can hold drops the extra
+	// combos, then shortens the last one, rather than pushing the description
+	// off the panel.
+	keys := b.Keys
+	badges := overlay.KeyBadges(keys, bg, pal)
+	for len(keys) > 1 && lipgloss.Width(badges) > keyColW {
+		keys = keys[:len(keys)-1]
+		badges = overlay.KeyBadges(keys, bg, pal)
+	}
+	if len(keys) == 1 && lipgloss.Width(badges) > keyColW {
+		badges = overlay.KeyBadge(overlay.Truncate(keys[0], max(keyColW-2, 1)), pal)
+	}
 	bw := lipgloss.Width(badges)
 	if bw < keyColW {
 		badges += overlay.Style(bg).Render(strings.Repeat(" ", keyColW-bw))
@@ -491,16 +529,16 @@ func helpBindingRow(b HelpBinding, keyColW int, showCategoryTag bool, pal overla
 		tagW = lipgloss.Width(label) + 2
 	}
 
-	descMax := helpPanelInnerWidth - keyColW - 2 - tagW
+	descMax := width - keyColW - 2 - tagW
 	desc := b.Description
-	if descMax > 1 && lipgloss.Width(desc) > descMax {
+	if lipgloss.Width(desc) > descMax {
 		desc = overlay.Truncate(desc, descMax)
 	}
 
 	line := badges + overlay.Style(bg).Render("  ") + overlay.Style(bg).Foreground(pal.Fg).Render(desc)
 	if tag != "" {
 		used := lipgloss.Width(line)
-		gap := helpPanelInnerWidth - used - lipgloss.Width(tag)
+		gap := width - used - lipgloss.Width(tag)
 		if gap > 0 {
 			line += overlay.Style(bg).Render(strings.Repeat(" ", gap)) + tag
 		}

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -418,7 +418,7 @@ func (m *OS) RenderHelpMenu() (string, overlay.Geometry) {
 	if inSearch {
 		extra += 2
 	}
-	rows := m.panelBodyRows(helpVisibleRows, extra, width, tabs, hints)
+	rows, hints := m.panelBody(helpVisibleRows, extra, width, tabs, hints)
 	if width < helpCategoryTagWidth {
 		showCategoryTag = false
 	}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -191,6 +191,26 @@ type OS struct {
 	// frame. Motion events arrive faster than a frame can be composed, so this
 	// bounds how often they are allowed to redraw.
 	lastInteractionRender time.Time
+	// viewportResizing is set while terminal sizes are still arriving. A retile
+	// it drives places panes directly instead of easing them into position, and
+	// resizes them visually only, exactly as a mouse resize drag does: a resize
+	// is not a transition to be animated, and telling every PTY and backend
+	// about a size the user is still choosing is the single most expensive thing
+	// in the path.
+	viewportResizing bool
+	// viewportResizeGen counts terminal resizes so a settle armed by an earlier
+	// one can be recognised as stale and ignored.
+	viewportResizeGen uint64
+	// viewportResizeAt is when the last terminal size arrived, and
+	// lastPointerAt when the last mouse event did. They are what make the two
+	// deferrals above expire on their own: see resizeDeferralActive. A flag that
+	// is only ever cleared by a message arriving is a flag that stays set
+	// forever the one time that message does not arrive, and there is no way to
+	// guarantee it does - a panic recovered in Update drops the command that
+	// would have armed the settle, and a mouse release is lost whenever the
+	// pointer leaves the surface the events come from.
+	viewportResizeAt time.Time
+	lastPointerAt    time.Time
 	// pendingBSPSync is set when a resize motion changed window geometry and the
 	// BSP tree's ratios have not been re-derived from it yet. The sync exists so
 	// the shared-borders separator overlay follows the drag, so it only has to

--- a/internal/app/os_layout.go
+++ b/internal/app/os_layout.go
@@ -178,7 +178,13 @@ func (m *OS) ToggleLayoutMode() {
 // resetTiledFlags clears the Tiled flag on all current workspace windows
 // and invalidates caches. Call when switching layout modes to prevent
 // stale shared-border state from bleeding between modes.
+// Its callers are the layout-mode switches, every one of them a structural
+// change whose result is final, so this is also where a resize deferral that is
+// still in flight gets finished rather than being allowed to make the new
+// layout visual-only. See resize_deferral.go.
 func (m *OS) resetTiledFlags() {
+	m.requireRealLayout()
+
 	for i := range m.Windows {
 		if m.Windows[i].Workspace == m.CurrentWorkspace {
 			m.Windows[i].Tiled = false

--- a/internal/app/os_render.go
+++ b/internal/app/os_render.go
@@ -96,6 +96,33 @@ func (m *OS) MarkTerminalsWithNewContent() bool {
 	return hasChanges
 }
 
+// ApplyPendingResizes performs the deferred half of every resize recorded while
+// a drag or a terminal-resize storm was in progress: the emulator's real
+// resize, the PTY's TIOCSWINSZ and SIGWINCH, the daemon notification and the
+// backend's own resize, followed by a full repaint so the guests' answers are
+// picked up.
+//
+// The visual half already happened, per step, through ResizeVisual. Everything
+// here is the part whose cost scales with the number of panes and with what is
+// running in them, which is why it waits for the size to stop moving.
+func (m *OS) ApplyPendingResizes() {
+	if len(m.PendingResizes) == 0 {
+		m.FlushPTYBuffersAfterResize()
+		return
+	}
+	for i := range m.Windows {
+		win := m.Windows[i]
+		if win == nil {
+			continue
+		}
+		if dims, ok := m.PendingResizes[win.ID]; ok {
+			win.Resize(dims[0], dims[1])
+		}
+	}
+	m.PendingResizes = make(map[string][2]int)
+	m.FlushPTYBuffersAfterResize()
+}
+
 // FlushPTYBuffersAfterResize flushes buffered PTY content and forces content polling
 // after a resize operation completes. This ensures that shell prompt redraws in response
 // to SIGWINCH are properly processed and displayed.

--- a/internal/app/overlay_box.go
+++ b/internal/app/overlay_box.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The bordered dialogs (logs, cache stats, tape manager, tape review) predate
+// the panel grammar and size themselves from their own content. The helpers
+// here fit them to the screen the same way overlay_fit.go fits the panels.
+
+// dialogChrome is what a bordered dialog spends on its own frame: a border cell
+// and two padding cells on each side.
+const dialogChrome = 6
+
+// dialogWidth returns the total width to draw a centered bordered dialog at,
+// given the width it would prefer. Never wider than the screen.
+func (m *OS) dialogWidth(preferred int) int {
+	rw := m.GetRenderWidth()
+	if rw <= 0 {
+		return preferred // size not known yet; the caller's preference stands
+	}
+	return max(min(preferred, rw), dialogChrome+2)
+}
+
+// dialogRows returns how many scrolling content rows a centered dialog can show
+// given the rows it spends on everything else.
+func (m *OS) dialogRows(preferred, chrome int) int {
+	rh := m.GetRenderHeight()
+	if rh <= 0 {
+		return preferred
+	}
+	return max(min(preferred, rh-chrome), minPanelRows)
+}
+
+// dialogTextWidth is the widest a line of a content-sized dialog may be before
+// the box around it would reach past the edge of the screen.
+func (m *OS) dialogTextWidth() int {
+	rw := m.GetRenderWidth()
+	if rw <= 0 {
+		return 1 << 20 // size not known yet; do not clip anything
+	}
+	return max(rw-dialogChrome, 8)
+}
+
+// clipStyled cuts an already-styled line to at most width cells, keeping its
+// escape sequences intact. Used where the text being fitted has colors baked in
+// and cannot be re-measured as plain runes.
+func clipStyled(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= width {
+		return s
+	}
+	return ansi.Truncate(s, width, "")
+}
+
+// clipStyledLines applies clipStyled to every line of a multi-line block.
+func clipStyledLines(s string, width int) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		lines[i] = clipStyled(ln, width)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/app/overlay_box.go
+++ b/internal/app/overlay_box.go
@@ -3,6 +3,7 @@ package app
 import (
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -42,6 +43,51 @@ func (m *OS) dialogTextWidth() int {
 		return 1 << 20 // size not known yet; do not clip anything
 	}
 	return max(rw-dialogChrome, 8)
+}
+
+// dialogContentRows is the tallest a content-sized dialog's body may be before
+// the box around it would reach past the top or bottom of the screen.
+func (m *OS) dialogContentRows() int {
+	rh := m.GetRenderHeight()
+	if rh <= 0 {
+		return 1 << 20 // size not known yet; do not drop anything
+	}
+	return max(rh-4, 1) // border and padding, top and bottom
+}
+
+// squeezeLines shortens a dialog body to rows lines. The blank spacer lines go
+// first, since a dialog that reads a little tighter is better than one whose
+// last rows are off the bottom of the screen; only if that is not enough does
+// it drop content, keeping the last line (which is where the key hints live).
+func squeezeLines(lines []string, rows int) []string {
+	// An entry can itself be several lines tall (a bordered input field, say),
+	// so the budget is measured in rendered lines, not in entries.
+	height := func(ls []string) int {
+		n := 0
+		for _, ln := range ls {
+			n += lipgloss.Height(ln)
+		}
+		return n
+	}
+	if rows < 1 || height(lines) <= rows {
+		return lines
+	}
+
+	out := make([]string, 0, len(lines))
+	drop := height(lines) - rows
+	for i, ln := range lines {
+		if drop > 0 && i > 0 && i < len(lines)-1 && strings.TrimSpace(ln) == "" {
+			drop--
+			continue
+		}
+		out = append(out, ln)
+	}
+	// Still too tall: keep the top and the last line, which is where a dialog
+	// puts its key hints.
+	for len(out) > 1 && height(out) > rows {
+		out = append(out[:len(out)-2], out[len(out)-1])
+	}
+	return out
 }
 
 // clipStyled cuts an already-styled line to at most width cells, keeping its

--- a/internal/app/overlay_fit.go
+++ b/internal/app/overlay_fit.go
@@ -1,0 +1,64 @@
+package app
+
+import "github.com/Gaurav-Gosain/tuios/internal/overlay"
+
+// Overlay panels are laid out at a preferred size that suits a desktop terminal
+// and then fitted to the screen they are actually drawn on. A small terminal,
+// 51x37 say, is narrower and shorter than every panel wants to be, and a panel
+// that ignores that draws its right-hand side off the edge of the screen where
+// it cannot be read or scrolled to.
+//
+// The helpers here are the single place that arithmetic lives. Every panel asks
+// for the width and row count it prefers and takes what fits; at a desktop size
+// the preference always wins, so nothing about the desktop rendering changes.
+const (
+	// minPanelRows is the fewest body rows a scrolling panel is squeezed to.
+	// Below this the panel stops being a list and the user cannot tell where
+	// they are in it.
+	minPanelRows = 3
+
+	// panelChromeRows counts the rows an overlay panel always spends on chrome:
+	// the top pad, the title, the blank below it, and the bottom pad.
+	panelChromeRows = 4
+)
+
+// panelWidth returns the inner content width to build a panel at, given the
+// width it would prefer. The screen wins when it is narrower.
+func (m *OS) panelWidth(preferred int) int {
+	return overlay.FitWidth(preferred, m.GetRenderWidth())
+}
+
+// panelBodyRows returns how many scrolling body rows a panel can show. extra is
+// the number of body lines the panel spends on things that are not rows (a
+// search input, a rule, a scroll indicator, a description line); tabs and hints
+// are measured from the panel itself so their wrapped height is accounted for.
+func (m *OS) panelBodyRows(preferred, extra, width int, tabs []string, hints []overlay.Hint) int {
+	rh := m.GetRenderHeight()
+	if rh <= 0 {
+		return preferred // size not known yet; the caller's preference stands
+	}
+	chrome := panelChromeRows + extra
+	if len(tabs) > 0 {
+		chrome += overlay.TabRowCount(tabs, width) + 2 // rule + blank
+	}
+	if len(hints) > 0 {
+		chrome += 2 + overlay.HintRowCount(hints, width) // blank + rule + hints
+	}
+	return max(min(preferred, rh-chrome), minPanelRows)
+}
+
+// scrollWindow clamps a scroll offset so that a list of count items showing
+// visible rows keeps selected in view, and returns the offset to render from.
+func scrollWindow(scroll, selected, count, visible int) int {
+	if count <= visible {
+		return 0
+	}
+	scroll = clampInt(scroll, 0, count-visible)
+	if selected < scroll {
+		scroll = selected
+	}
+	if selected >= scroll+visible {
+		scroll = selected - visible + 1
+	}
+	return clampInt(scroll, 0, count-visible)
+}

--- a/internal/app/overlay_fit.go
+++ b/internal/app/overlay_fit.go
@@ -37,6 +37,11 @@ func (m *OS) panelBodyRows(preferred, extra, width int, tabs []string, hints []o
 	if rh <= 0 {
 		return preferred // size not known yet; the caller's preference stands
 	}
+	return max(min(preferred, rh-panelChrome(extra, width, tabs, hints)), minPanelRows)
+}
+
+// panelChrome is every row of a panel that is not a body row.
+func panelChrome(extra, width int, tabs []string, hints []overlay.Hint) int {
 	chrome := panelChromeRows + extra
 	if len(tabs) > 0 {
 		chrome += overlay.TabRowCount(tabs, width) + 2 // rule + blank
@@ -44,7 +49,20 @@ func (m *OS) panelBodyRows(preferred, extra, width int, tabs []string, hints []o
 	if len(hints) > 0 {
 		chrome += 2 + overlay.HintRowCount(hints, width) // blank + rule + hints
 	}
-	return max(min(preferred, rh-chrome), minPanelRows)
+	return chrome
+}
+
+// panelBody fits both the row count and the footer to the screen height. On a
+// screen too short to hold the minimum body and the footer both, the footer
+// goes: the keys it names are still on the keyboard, whereas a body squeezed
+// below three rows stops being a list.
+func (m *OS) panelBody(preferred, extra, width int, tabs []string, hints []overlay.Hint) (int, []overlay.Hint) {
+	rows := m.panelBodyRows(preferred, extra, width, tabs, hints)
+	rh := m.GetRenderHeight()
+	if rh <= 0 || len(hints) == 0 || rows+panelChrome(extra, width, tabs, hints) <= rh {
+		return rows, hints
+	}
+	return m.panelBodyRows(preferred, extra, width, tabs, nil), nil
 }
 
 // scrollWindow clamps a scroll offset so that a list of count items showing

--- a/internal/app/overlay_narrow_test.go
+++ b/internal/app/overlay_narrow_test.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
 )
 
 // narrowScreens are the sizes the overlays have to survive: a tall narrow
@@ -20,6 +21,7 @@ var narrowScreens = []struct {
 	{"tall-narrow", 51, 37},
 	{"short-wide", 90, 20},
 	{"very-narrow", 30, 24},
+	{"very-short", 100, 12},
 	{"desktop", 120, 40},
 }
 
@@ -128,7 +130,16 @@ func TestOverlayPanelsFitNarrowScreens(t *testing.T) {
 			m.LayoutPickerMode = ""
 
 			out, _, _ = m.renderAggregateView()
+			assertFitsScreen(t, "aggregate (empty)", out, sc.w, sc.h)
+
+			m.Windows = []*terminal.Window{
+				{ID: "a", CustomName: "a-window-title-far-too-long-for-a-narrow-screen", Width: 100, Height: 40, Workspace: 1},
+				{ID: "b", CustomName: "second", Width: 80, Height: 24, Workspace: 1, Minimized: true},
+			}
+			m.CurrentWorkspace = 1
+			out, _, _ = m.renderAggregateView()
 			assertFitsScreen(t, "aggregate", out, sc.w, sc.h)
+			m.Windows = nil
 
 			quit, _, _ := m.renderQuitConfirmDialog()
 			assertFitsScreen(t, "quit", quit, sc.w, sc.h)
@@ -192,10 +203,10 @@ func TestOverlayDesktopSizesUnchanged(t *testing.T) {
 	if got := m.panelWidth(helpPanelInnerWidth); got != helpPanelInnerWidth {
 		t.Errorf("help width = %d, want %d", got, helpPanelInnerWidth)
 	}
-	if w, rows := m.paletteLayout(); w != paletteInnerWidth || rows != paletteMaxVisible {
+	if w, rows, _ := m.paletteLayout(); w != paletteInnerWidth || rows != paletteMaxVisible {
 		t.Errorf("palette layout = %d x %d, want %d x %d", w, rows, paletteInnerWidth, paletteMaxVisible)
 	}
-	if w, rows := m.themePickerLayout(); w != themePickerInnerWidth || rows != themePickerVisibleRows {
+	if w, rows, _ := m.themePickerLayout(); w != themePickerInnerWidth || rows != themePickerVisibleRows {
 		t.Errorf("theme picker layout = %d x %d, want %d x %d", w, rows, themePickerInnerWidth, themePickerVisibleRows)
 	}
 	if got := m.dialogWidth(80); got != 80 {
@@ -208,7 +219,7 @@ func TestOverlayDesktopSizesUnchanged(t *testing.T) {
 	cats := m.settingsCategories()
 	for i, cat := range cats {
 		m.SettingsCategory = i
-		w, rows := m.settingsLayout([]string{"Appearance", "Dock", "Behavior"}, len(cat.Items))
+		w, rows, _ := m.settingsLayout([]string{"Appearance", "Dock", "Behavior"}, len(cat.Items))
 		if w != settingsInnerWidth {
 			t.Errorf("settings[%s] width = %d, want %d", cat.Name, w, settingsInnerWidth)
 		}
@@ -326,6 +337,25 @@ func TestDockFitsNarrowScreens(t *testing.T) {
 			m := newNarrowOS(t, sc.w, sc.h)
 			dock, _ := m.renderDockString()
 			assertFitsScreen(t, "dock", dock, sc.w, sc.h)
+
+			// With the system readouts on, the right-hand block asks for 32
+			// columns; in copy mode its help line asks for 110.
+			config.ShowCPU, config.ShowRAM = true, true
+			defer func() { config.ShowCPU, config.ShowRAM = false, false }()
+			dock, _ = m.renderDockString()
+			assertFitsScreen(t, "dock with stats", dock, sc.w, sc.h)
+
+			m.Windows = []*terminal.Window{{ID: "a", Width: sc.w, Height: sc.h, Workspace: 1}}
+			m.CurrentWorkspace, m.FocusedWindow = 1, 0
+			for _, state := range []terminal.CopyModeState{
+				terminal.CopyModeNormal, terminal.CopyModeSearch,
+				terminal.CopyModeVisualChar, terminal.CopyModeVisualLine,
+			} {
+				m.Windows[0].CopyMode = &terminal.CopyMode{Active: true, State: state}
+				dock, _ = m.renderDockString()
+				assertFitsScreen(t, fmt.Sprintf("dock in copy mode %d", state), dock, sc.w, sc.h)
+			}
+			m.Windows = nil
 		})
 	}
 }

--- a/internal/app/overlay_narrow_test.go
+++ b/internal/app/overlay_narrow_test.go
@@ -1,0 +1,349 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// narrowScreens are the sizes the overlays have to survive: a tall narrow
+// terminal, a short wide one, the narrowest viewport worth supporting, and a
+// normal terminal as a control.
+var narrowScreens = []struct {
+	name string
+	w, h int
+}{
+	{"tall-narrow", 51, 37},
+	{"short-wide", 90, 20},
+	{"very-narrow", 30, 24},
+	{"desktop", 120, 40},
+}
+
+// assertFitsScreen fails if any line of out is wider than w or the block is
+// taller than h. An overlay wider than the screen has its right-hand side drawn
+// off the edge, where it cannot be read or scrolled to.
+func assertFitsScreen(t *testing.T, name, out string, w, h int) {
+	t.Helper()
+	if out == "" {
+		return
+	}
+	lines := strings.Split(out, "\n")
+	for i, ln := range lines {
+		if lw := lipgloss.Width(ln); lw > w {
+			t.Errorf("%s: line %d is %d cells wide, screen is %d: %q", name, i, lw, w, ln)
+			return
+		}
+	}
+	if len(lines) > h {
+		t.Errorf("%s: %d lines tall, screen is %d", name, len(lines), h)
+	}
+}
+
+// newNarrowOS builds an OS sized to a given screen with every overlay's state
+// populated enough to render.
+func newNarrowOS(t *testing.T, w, h int) *OS {
+	t.Helper()
+	m := NewOS(OSOptions{UserConfig: config.DefaultConfig()})
+	if m.KeybindRegistry == nil {
+		m.KeybindRegistry = config.NewKeybindRegistry(config.DefaultConfig())
+	}
+	m.Width, m.Height = w, h
+	m.EffectiveWidth, m.EffectiveHeight = w, h
+	return m
+}
+
+// TestOverlayPanelsFitNarrowScreens renders every overlay panel at each screen
+// size and asserts none of them draws outside the screen.
+func TestOverlayPanelsFitNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := newNarrowOS(t, sc.w, sc.h)
+
+			m.HelpCategory = -1
+			cats := GetHelpCategories(m.KeybindRegistry)
+			for i := range cats {
+				m.HelpCategory = i
+				m.HelpScrollOffset = 0
+				out, _ := m.RenderHelpMenu()
+				assertFitsScreen(t, fmt.Sprintf("help[%s]", cats[i].Name), out, sc.w, sc.h)
+			}
+			m.HelpSearchMode = true
+			m.HelpSearchQuery = "window"
+			out, _ := m.RenderHelpMenu()
+			assertFitsScreen(t, "help search", out, sc.w, sc.h)
+			m.HelpSearchMode = false
+
+			out, _, _ = m.renderCommandPalette()
+			assertFitsScreen(t, "palette", out, sc.w, sc.h)
+
+			m.CommandPaletteQuery = "zzzz-no-match"
+			out, _, _ = m.renderCommandPalette()
+			assertFitsScreen(t, "palette empty", out, sc.w, sc.h)
+			m.CommandPaletteQuery = ""
+
+			for i := range m.settingsCategories() {
+				m.SettingsCategory = i
+				m.SettingsSelected = 0
+				out, _, _ = m.renderSettings()
+				assertFitsScreen(t, fmt.Sprintf("settings[%d]", i), out, sc.w, sc.h)
+			}
+			// A long free-text value must not push the row past the panel.
+			ci, ii, _, ok := findSetting(m, "Behavior", "Preferred shell")
+			if ok {
+				m.SettingsCategory, m.SettingsSelected = ci, ii
+				m.SettingsEditing = true
+				m.SettingsEditBuffer = strings.Repeat("/very/long/path", 8)
+				out, _, _ = m.renderSettings()
+				assertFitsScreen(t, "settings editing", out, sc.w, sc.h)
+				m.SettingsEditing = false
+			}
+
+			m.OpenThemePicker()
+			out, _, _ = m.renderThemePicker()
+			assertFitsScreen(t, "themepicker", out, sc.w, sc.h)
+			m.CancelThemePicker()
+
+			// Session switcher outside daemon mode is the informational panel.
+			out, _, _ = m.renderSessionSwitcher()
+			assertFitsScreen(t, "session (no daemon)", out, sc.w, sc.h)
+			m.SessionSwitcherConfirmDelete = "a-very-long-session-name-that-will-not-fit-on-a-narrow-screen"
+			out, _, _ = m.renderSessionSwitcher()
+			assertFitsScreen(t, "session confirm", out, sc.w, sc.h)
+			m.SessionSwitcherConfirmDelete = ""
+
+			m.LayoutPickerItems = []LayoutTemplate{
+				{Name: "a-layout-name-that-is-far-too-long-for-a-narrow-screen", AutoTiling: true},
+				{Name: "dev"},
+			}
+			out, _, _ = m.renderLayoutPicker()
+			assertFitsScreen(t, "layout picker", out, sc.w, sc.h)
+			m.LayoutPickerMode = "save"
+			m.LayoutSaveBuffer = strings.Repeat("name", 30)
+			out, _, _ = m.renderLayoutPicker()
+			assertFitsScreen(t, "layout save", out, sc.w, sc.h)
+			m.LayoutPickerMode = ""
+
+			out, _, _ = m.renderAggregateView()
+			assertFitsScreen(t, "aggregate", out, sc.w, sc.h)
+
+			quit, _, _ := m.renderQuitConfirmDialog()
+			assertFitsScreen(t, "quit", quit, sc.w, sc.h)
+		})
+	}
+}
+
+// TestOverlayLayersFitNarrowScreens turns on every overlay at once and checks
+// each placed layer lands wholly inside the screen.
+func TestOverlayLayersFitNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := newNarrowOS(t, sc.w, sc.h)
+			m.ShowHelp = true
+			m.HelpCategory = -1
+			m.ShowCommandPalette = true
+			m.ShowSettings = true
+			m.ShowSessionSwitcher = true
+			m.ShowLayoutPicker = true
+			m.ShowQuitConfirm = true
+			m.ShowLogs = true
+			m.ShowCacheStats = true
+			m.ShowTapeManager = true
+			m.PrefixActive = true
+			m.LastPrefixTime = m.LastPrefixTime.Add(-time.Hour)
+			m.LogMessages = []LogMessage{
+				{Level: "ERROR", Message: strings.Repeat("a long log message ", 8)},
+				{Level: "INFO", Message: "short"},
+			}
+			m.ShowNotification(strings.Repeat("a long notification message ", 4), "error", time.Minute)
+			m.ShowKeys = true
+			m.RecentKeys = []KeyEvent{
+				{Key: "A", Modifiers: []string{"Ctrl", "Alt", "Shift"}, Timestamp: time.Now(), Count: 3},
+				{Key: "B", Timestamp: time.Now(), Count: 1},
+				{Key: "Enter", Timestamp: time.Now(), Count: 1},
+				{Key: "Backspace", Timestamp: time.Now(), Count: 9},
+			}
+
+			for _, layer := range m.renderOverlays() {
+				id := layer.GetID()
+				if r := layer.GetX() + layer.Width(); r > sc.w {
+					t.Errorf("layer %q spans x=%d..%d, screen is %d wide", id, layer.GetX(), r, sc.w)
+				}
+				if b := layer.GetY() + layer.Height(); b > sc.h {
+					t.Errorf("layer %q spans y=%d..%d, screen is %d tall", id, layer.GetY(), b, sc.h)
+				}
+				if layer.GetX() < 0 || layer.GetY() < 0 {
+					t.Errorf("layer %q is placed off the top-left at (%d,%d)", id, layer.GetX(), layer.GetY())
+				}
+			}
+		})
+	}
+}
+
+// TestOverlayDesktopSizesUnchanged pins the panel sizes at a normal terminal
+// size. Fitting the overlays to narrow screens must not shrink them on a screen
+// that has the room, which is the shared path native tuios renders on.
+func TestOverlayDesktopSizesUnchanged(t *testing.T) {
+	m := newNarrowOS(t, 120, 40)
+
+	if got := m.panelWidth(helpPanelInnerWidth); got != helpPanelInnerWidth {
+		t.Errorf("help width = %d, want %d", got, helpPanelInnerWidth)
+	}
+	if w, rows := m.paletteLayout(); w != paletteInnerWidth || rows != paletteMaxVisible {
+		t.Errorf("palette layout = %d x %d, want %d x %d", w, rows, paletteInnerWidth, paletteMaxVisible)
+	}
+	if w, rows := m.themePickerLayout(); w != themePickerInnerWidth || rows != themePickerVisibleRows {
+		t.Errorf("theme picker layout = %d x %d, want %d x %d", w, rows, themePickerInnerWidth, themePickerVisibleRows)
+	}
+	if got := m.dialogWidth(80); got != 80 {
+		t.Errorf("log viewer width = %d, want 80", got)
+	}
+	if got := m.tapeReviewRows(); got != tapeReviewViewportRows {
+		t.Errorf("tape review rows = %d, want %d", got, tapeReviewViewportRows)
+	}
+
+	cats := m.settingsCategories()
+	for i, cat := range cats {
+		m.SettingsCategory = i
+		w, rows := m.settingsLayout([]string{"Appearance", "Dock", "Behavior"}, len(cat.Items))
+		if w != settingsInnerWidth {
+			t.Errorf("settings[%s] width = %d, want %d", cat.Name, w, settingsInnerWidth)
+		}
+		// Every category shows all of its rows at a desktop height: nothing
+		// scrolls that did not scroll before.
+		if rows < len(cat.Items) || rows < settingsVisibleRows {
+			t.Errorf("settings[%s] rows = %d, want at least %d", cat.Name, rows, max(len(cat.Items), settingsVisibleRows))
+		}
+	}
+
+	// The help panel is 74 + 4 cells across and its tab strip stays on one row.
+	out, geo := m.RenderHelpMenu()
+	if geo.Width != helpPanelInnerWidth+4 {
+		t.Errorf("help panel width = %d, want %d", geo.Width, helpPanelInnerWidth+4)
+	}
+	if lipgloss.Height(out) != 25 {
+		t.Errorf("help panel height = %d, want 25 (one tab row)", lipgloss.Height(out))
+	}
+	for _, r := range geo.Tabs {
+		if r.Y0 != geo.Tabs[0].Y0 {
+			t.Errorf("help tabs wrapped onto %d rows at desktop width", r.Y0-geo.Tabs[0].Y0+1)
+			break
+		}
+	}
+}
+
+// TestWhichKeyFitsNarrowScreens renders the which-key overlay for every prefix
+// at every position and checks it lands wholly on screen.
+func TestWhichKeyFitsNarrowScreens(t *testing.T) {
+	prefixes := []struct {
+		name  string
+		apply func(*OS)
+	}{
+		{"leader", func(m *OS) {}},
+		{"workspace", func(m *OS) { m.WorkspacePrefixActive = true }},
+		{"minimize", func(m *OS) { m.MinimizePrefixActive = true }},
+		{"window", func(m *OS) { m.TilingPrefixActive = true }},
+		{"debug", func(m *OS) { m.DebugPrefixActive = true }},
+		{"tape", func(m *OS) { m.TapePrefixActive = true }},
+		{"layout", func(m *OS) { m.LayoutPrefixActive = true }},
+	}
+	positions := []string{"top-left", "top-right", "bottom-left", "bottom-right", "center"}
+
+	oldPos := config.WhichKeyPosition
+	defer func() { config.WhichKeyPosition = oldPos }()
+
+	for _, sc := range narrowScreens {
+		for _, p := range prefixes {
+			for _, pos := range positions {
+				t.Run(sc.name+"/"+p.name+"/"+pos, func(t *testing.T) {
+					config.WhichKeyPosition = pos
+					m := newNarrowOS(t, sc.w, sc.h)
+					m.PrefixActive = true
+					m.LastPrefixTime = time.Now().Add(-time.Hour)
+					p.apply(m)
+
+					found := false
+					for _, layer := range m.renderOverlays() {
+						if layer.GetID() != "whichkey" {
+							continue
+						}
+						found = true
+						assertFitsScreen(t, "whichkey", layer.GetContent(), sc.w, sc.h)
+						if layer.GetX() < 0 || layer.GetY() < 0 ||
+							layer.GetX()+layer.Width() > sc.w || layer.GetY()+layer.Height() > sc.h {
+							t.Errorf("whichkey placed at (%d,%d) size %dx%d, screen is %dx%d",
+								layer.GetX(), layer.GetY(), layer.Width(), layer.Height(), sc.w, sc.h)
+						}
+					}
+					if !found {
+						t.Fatal("no whichkey layer rendered")
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestTapeDialogsFitNarrowScreens renders the tape manager and the project-tape
+// review dialog, both of which size themselves from their own content.
+func TestTapeDialogsFitNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := newNarrowOS(t, sc.w, sc.h)
+
+			m.InitTapeManager()
+			m.TapeManager.Files = []TapeFile{
+				{Name: "a-tape-file-name-that-is-much-too-long-to-fit", Size: 4096, Modified: time.Now()},
+				{Name: "short", Size: 12, Modified: time.Now()},
+			}
+			assertFitsScreen(t, "tape manager", m.RenderTapeManager(), sc.w, sc.h)
+
+			m.TapeManager.Mode = TapeManagerNaming
+			m.TapeManager.NameBuffer = strings.Repeat("name", 30)
+			assertFitsScreen(t, "tape manager naming", m.RenderTapeManager(), sc.w, sc.h)
+
+			m.TapeManager.Mode = TapeManagerConfirmDelete
+			assertFitsScreen(t, "tape manager delete", m.RenderTapeManager(), sc.w, sc.h)
+
+			m.TapeReview = &TapeReviewState{
+				Path:    "/home/someone/very/deep/project/directory/tree/.tuios.tape",
+				Dir:     "/home/someone/very/deep/project/directory/tree",
+				Content: []byte(strings.Repeat("Type \"a command line that is quite long indeed\"\n", 40)),
+			}
+			assertFitsScreen(t, "tape review", m.RenderTapeReview(), sc.w, sc.h)
+		})
+	}
+}
+
+// TestDockFitsNarrowScreens checks the status bar, which spans the screen and
+// has a fixed-width estimate for its right-hand block.
+func TestDockFitsNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := newNarrowOS(t, sc.w, sc.h)
+			dock, _ := m.renderDockString()
+			assertFitsScreen(t, "dock", dock, sc.w, sc.h)
+		})
+	}
+}
+
+// TestWelcomeSplashFitsNarrowScreens renders the no-windows splash, which is
+// the first thing anyone sees.
+func TestWelcomeSplashFitsNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := newNarrowOS(t, sc.w, sc.h)
+			for _, layer := range m.renderOverlays() {
+				if layer.GetID() != "welcome" {
+					continue
+				}
+				assertFitsScreen(t, "welcome", layer.GetContent(), sc.w, sc.h)
+				return
+			}
+			t.Fatal("no welcome layer rendered")
+		})
+	}
+}

--- a/internal/app/overlay_narrow_test.go
+++ b/internal/app/overlay_narrow_test.go
@@ -25,9 +25,18 @@ var narrowScreens = []struct {
 	{"desktop", 120, 40},
 }
 
-// assertFitsScreen fails if any line of out is wider than w or the block is
-// taller than h. An overlay wider than the screen has its right-hand side drawn
-// off the edge, where it cannot be read or scrolled to.
+// assertFitsScreen fails if any line of out is wider than w, the block is
+// taller than h, or any line pads itself with a control character. An overlay
+// wider than the screen has its right-hand side drawn off the edge, where it
+// cannot be read or scrolled to.
+//
+// The control-character half guards a different way of getting the same answer
+// wrong. Every row here is padded to the panel width with literal spaces, and
+// the fitting arithmetic in overlay_fit.go measures those rows to decide what
+// else fits. A tab would break that: it is one byte that lipgloss measures as
+// one cell but a terminal advances to its next tab stop, so the panel's own
+// idea of where a row ends would stop matching the screen's. Carriage returns
+// and the rest are the same failure with a different glyph.
 func assertFitsScreen(t *testing.T, name, out string, w, h int) {
 	t.Helper()
 	if out == "" {
@@ -35,6 +44,11 @@ func assertFitsScreen(t *testing.T, name, out string, w, h int) {
 	}
 	lines := strings.Split(out, "\n")
 	for i, ln := range lines {
+		if j := strings.IndexAny(ln, "\t\r\v\f"); j >= 0 {
+			t.Errorf("%s: line %d pads with a control character (%q at byte %d): %q",
+				name, i, ln[j], j, ln)
+			return
+		}
 		if lw := lipgloss.Width(ln); lw > w {
 			t.Errorf("%s: line %d is %d cells wide, screen is %d: %q", name, i, lw, w, ln)
 			return

--- a/internal/app/pane_overflow_test.go
+++ b/internal/app/pane_overflow_test.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
+	"github.com/Gaurav-Gosain/tuios/internal/ui"
+)
+
+// A pane must draw inside its own rectangle and nowhere else.
+//
+// The way it stopped doing that: a snap animation, which every retile creates,
+// interpolates a window's X, Y, Width and Height on every tick and deliberately
+// leaves the emulator alone until the transition ends. So for the length of the
+// animation the pane's rectangle is the new one while its body is still the old
+// one, and renderTerminal hands back a body sized by the emulator - the
+// unfocused fast path returns the emulator's own Render() verbatim.
+//
+// lipgloss's Width and Height pad but never truncate, so that oversized body
+// grew the box: the bottom border landed one or more rows BELOW the pane's own
+// bottom edge, on top of the pane beneath it or in the status bar. In a three
+// pane layout, one tall pane on the left and two stacked on the right, the
+// bottom edges stopped lining up and the left pane's frame ran into the status
+// bar.
+func TestWindowBoxNeverExceedsItsRectangle(t *testing.T) {
+	// The bug is in the unfocused path, so this window must not be focused.
+	win := newTestWindow(t, "overflow-0001", 60, 34)
+	other := newTestWindow(t, "overflow-0002", 60, 34)
+	m := newTestOS(other)
+	m.Windows = append(m.Windows, win)
+
+	win.LockIO()
+	for y := 1; y <= 32; y++ {
+		_, _ = win.Terminal.Write([]byte("\x1b[" + itoa(y) + ";1Hline " + itoa(y) + " of a pane that is about to be made smaller"))
+	}
+	win.UnlockIO()
+	win.MarkContentDirty()
+
+	// Shrink the rectangle the way an in-flight snap animation does: geometry
+	// only, emulator untouched.
+	win.Width, win.Height = 40, 20
+	win.MarkPositionDirty()
+
+	box := m.renderWindowBox(win, 1, false, theme.BorderUnfocused())
+	w, h := lipgloss.Size(box)
+	if h > win.Height {
+		t.Errorf("box is %d rows for a %d row window: it overflows by %d", h, win.Height, h-win.Height)
+	}
+	if w > win.Width {
+		t.Errorf("box is %d columns for a %d column window: it overflows by %d", w, win.Width, w-win.Width)
+	}
+	// The bottom border has to be the last row of the box, not a row past it,
+	// and the body must not be what is left showing there. The border glyphs
+	// come from config because other tests in this package change them.
+	lines := strings.Split(box, "\n")
+	last := lines[len(lines)-1]
+	if !strings.Contains(last, config.GetWindowBorderBottomLeft()) || strings.Contains(last, "line ") {
+		t.Errorf("last row of the box is not the bottom border: %q", last)
+	}
+}
+
+// The tick that finishes the last animation is the tick that first puts every
+// pane at the size it settled at: Animation.Update only resizes the emulator
+// when it completes. Deciding whether to draw from HasActiveAnimations AFTER
+// UpdateAnimations has removed the finished animation answers "nothing is
+// happening", the frame is skipped, and the last frame the user sees is the
+// second-to-last animation step - with every pane still drawn at its
+// pre-animation size, forever, because nothing dirties the model afterwards.
+func TestAnimationCompletionTickStillRenders(t *testing.T) {
+	win := newTestWindow(t, "anim-tick-0001", 60, 34)
+	m := newTestOS(win)
+	m.Width, m.Height = 120, 40
+
+	anim := ui.NewSnapAnimation(win, 0, 0, 40, 20, time.Millisecond)
+	if anim == nil {
+		t.Fatal("expected a snap animation")
+	}
+	m.Animations = append(m.Animations, anim)
+	time.Sleep(3 * time.Millisecond)
+
+	// This is the shape of the TickerMsg branch: capture first, update, decide.
+	hadAnimations := m.HasActiveAnimations()
+	m.UpdateAnimations()
+	hasAnimations := m.HasActiveAnimations()
+
+	if hasAnimations {
+		t.Fatal("animation should have completed")
+	}
+	if !hadAnimations {
+		t.Fatal("animation should have been active before the update")
+	}
+	if !(hadAnimations || hasAnimations) {
+		t.Error("the tick that completed the animation would not render")
+	}
+	if win.Width != 40 || win.Height != 20 {
+		t.Errorf("window settled at %dx%d, want 40x20", win.Width, win.Height)
+	}
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -221,11 +221,44 @@ func (m *OS) GetCanvas(render bool) *lipgloss.Canvas {
 	return canvas
 }
 
+// fitToContentBox trims a rendered pane body to the window's content
+// rectangle.
+//
+// A pane's frame is its rectangle, and nothing it draws may land outside it.
+// renderTerminal does not guarantee that on its own: the unfocused fast path
+// returns the emulator's own Render(), sized by the emulator rather than by the
+// window, and a window's rectangle can change without the emulator following it
+// in the same frame. A snap animation is the ordinary way that happens - it
+// interpolates X, Y, Width and Height every tick and deliberately leaves the VT
+// alone until the transition ends, so mid-animation the body is still the size
+// the pane used to be.
+//
+// lipgloss's Width and Height pad but never truncate, so an oversized body used
+// to push the box past the pane: the bottom border landed a row or more below
+// the pane's own bottom edge, over the neighbouring pane or in the status bar.
+// Trimming here keeps the box a function of the window rectangle alone.
+//
+// The common case costs one lipgloss.Size, which is a single pass over a string
+// the caller has already built, and changes nothing.
+func fitToContentBox(content string, w, h int) string {
+	if w < 1 || h < 1 {
+		return content
+	}
+	cw, ch := lipgloss.Size(content)
+	if cw <= w && ch <= h {
+		return content
+	}
+	return lipgloss.NewStyle().MaxWidth(w).MaxHeight(h).Render(content)
+}
+
 // renderWindowBox renders a window's content, wrapped in its border unless the
 // window is borderless. Shared by the compositor path and the fullscreen fast
 // path so both produce identical output.
 func (m *OS) renderWindowBox(window *terminal.Window, index int, isFocused bool, borderColorObj color.Color) string {
-	content := m.renderTerminal(window, isFocused, m.Mode == TerminalMode)
+	content := fitToContentBox(
+		m.renderTerminal(window, isFocused, m.Mode == TerminalMode),
+		window.ContentWidth(), window.ContentHeight(),
+	)
 	if window.Tiled && (!window.Zoomed || config.SharedBorders) {
 		return content
 	}

--- a/internal/app/render_aggregate_view.go
+++ b/internal/app/render_aggregate_view.go
@@ -25,6 +25,14 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 	}
 	treeWidth := totalWidth*2/5 - 2
 	previewWidth := totalWidth - treeWidth - 5
+	// Two panes need room for two panes. On a narrow screen the tree column comes
+	// out around sixteen cells, which wraps every row it holds and shows a preview
+	// too narrow to read, so the preview is dropped and the tree takes the lot.
+	showPreview := previewWidth >= 24 && treeWidth >= 24
+	if !showPreview {
+		treeWidth = totalWidth - 4 // the box's own border and padding
+		previewWidth = 0
+	}
 	totalHeight := m.GetRenderHeight() * 3 / 4
 	if totalHeight < 15 {
 		totalHeight = min(m.GetRenderHeight()-4, 15)
@@ -96,12 +104,17 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 
 	var treeContent strings.Builder
 	if query := m.AggregateViewQuery; query != "" {
-		treeContent.WriteString(lipgloss.NewStyle().Foreground(pal.AccentBright).Bold(true).Render("Filter ") + normalStyle.Render(query) + "\n")
+		treeContent.WriteString(lipgloss.NewStyle().Foreground(pal.AccentBright).Bold(true).Render("Filter ") +
+			normalStyle.Render(truncateString(query, max(treeWidth-7, 1))) + "\n")
 	} else {
-		treeContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(fmt.Sprintf("Choose window (%d total)", len(items))) + "\n")
+		header := fmt.Sprintf("Choose window (%d total)", len(items))
+		if treeWidth < lipgloss.Width(header) {
+			header = fmt.Sprintf("%d windows", len(items))
+		}
+		treeContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(truncateString(header, treeWidth)) + "\n")
 	}
 	if len(filtered) == 0 {
-		treeContent.WriteString(dimStyle.Italic(true).Render("(no matching windows)") + "\n")
+		treeContent.WriteString(dimStyle.Italic(true).Render(truncateString("(no matching windows)", treeWidth)) + "\n")
 	}
 
 	startRow := 0
@@ -129,13 +142,17 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 	linesRendered := 0
 	for ri := startRow; ri < len(treeRows) && linesRendered < maxTreeLines; ri++ {
 		r := treeRows[ri]
+		// The tree is a fixed-width column: a row longer than it would be
+		// wrapped by lipgloss onto a second line, pushing the pane and the box
+		// around it past the height they were given.
+		text := truncateString(r.text, treeWidth)
 		switch {
 		case strings.HasPrefix(r.text, "Workspace"):
-			treeContent.WriteString(headerStyle.Render(r.text) + "\n")
+			treeContent.WriteString(headerStyle.Render(text) + "\n")
 		case r.selected:
-			treeContent.WriteString(selectedStyle.Render(r.text) + "\n")
+			treeContent.WriteString(selectedStyle.Render(text) + "\n")
 		default:
-			treeContent.WriteString(normalStyle.Render(r.text) + "\n")
+			treeContent.WriteString(normalStyle.Render(text) + "\n")
 		}
 		linesRendered++
 	}
@@ -147,7 +164,7 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 		raw := w.Terminal.String()
 		w.RUnlockIO()
 
-		previewContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(selectedItem.Title) +
+		previewContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(truncateString(selectedItem.Title, max(previewWidth-12, 4))) +
 			dimStyle.Render(fmt.Sprintf(" [%dx%d]", w.Width, w.Height)) + "\n")
 		previewContent.WriteString(dimStyle.Render(strings.Repeat("─", previewWidth)) + "\n")
 
@@ -158,14 +175,12 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 			start = len(lines) - previewLines
 		}
 		for i := start; i < len(lines) && i < start+previewLines; i++ {
-			line := lines[i]
-			if len(line) > previewWidth*3 {
-				line = line[:previewWidth*3]
-			}
-			previewContent.WriteString(line + "\n")
+			// Live window output, measured in cells rather than bytes: a row
+			// wider than the pane wraps and grows the box past its own height.
+			previewContent.WriteString(truncateToWidth(lines[i], previewWidth) + "\n")
 		}
 	} else if selectedItem != nil {
-		previewContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(selectedItem.Title) + "\n")
+		previewContent.WriteString(lipgloss.NewStyle().Bold(true).Foreground(pal.Fg).Render(truncateString(selectedItem.Title, previewWidth)) + "\n")
 		previewContent.WriteString(dimStyle.Render("(no content)") + "\n")
 	}
 
@@ -177,12 +192,14 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 	treeContent.WriteString(hint)
 
 	treePane := lipgloss.NewStyle().Width(treeWidth).Height(totalHeight).Render(treeContent.String())
-	previewPane := lipgloss.NewStyle().
-		Width(previewWidth).Height(totalHeight).
-		BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).BorderForeground(pal.FgMute).
-		PaddingLeft(1).Render(previewContent.String())
-
-	combined := lipgloss.JoinHorizontal(lipgloss.Top, treePane, previewPane)
+	combined := treePane
+	if showPreview {
+		previewPane := lipgloss.NewStyle().
+			Width(previewWidth).Height(totalHeight).
+			BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).BorderForeground(pal.FgMute).
+			PaddingLeft(1).Render(previewContent.String())
+		combined = lipgloss.JoinHorizontal(lipgloss.Top, treePane, previewPane)
+	}
 
 	// A solid lipgloss box (whose Background lipgloss keeps intact across the
 	// inner fg-only styles) rather than the manual-fill panel, so the tree/live

--- a/internal/app/render_aggregate_view.go
+++ b/internal/app/render_aggregate_view.go
@@ -169,7 +169,11 @@ func (m *OS) renderAggregateView() (string, overlay.Geometry, []overlayRowHit) {
 		previewContent.WriteString(dimStyle.Render("(no content)") + "\n")
 	}
 
-	hint := dimStyle.Render("↑↓ navigate   ⏎ jump   esc close")
+	hintText := "↑↓ navigate   ⏎ jump   esc close"
+	if treeWidth < lipgloss.Width(hintText) {
+		hintText = "↑↓ ⏎ esc"
+	}
+	hint := dimStyle.Render(truncateString(hintText, treeWidth))
 	treeContent.WriteString(hint)
 
 	treePane := lipgloss.NewStyle().Width(treeWidth).Height(totalHeight).Render(treeContent.String())

--- a/internal/app/render_command_palette.go
+++ b/internal/app/render_command_palette.go
@@ -9,11 +9,36 @@ import (
 	"github.com/Gaurav-Gosain/tuios/internal/theme"
 )
 
-// Command palette layout constants.
+// Command palette layout constants. These are the preferred sizes; a narrower
+// or shorter screen gets a palette fitted to it (see overlay_fit.go).
 const (
 	paletteInnerWidth = 64
 	paletteMaxVisible = 10
+
+	// paletteCategoryWidth is the narrowest inner width that still shows the
+	// [category] tag in front of a command name. Below it the tag is dropped so
+	// the name and its shortcut keep the room.
+	paletteCategoryWidth = 46
 )
+
+// paletteHints is the palette footer, shared by the renderer and the sizing
+// helper so both measure the same panel.
+var paletteHints = []overlay.Hint{
+	{Key: "↑↓", Label: "move"},
+	{Key: "⏎", Label: "run"},
+	{Key: "esc", Label: "close"},
+}
+
+// paletteLayout returns the palette's fitted inner width and visible row count.
+// The keyboard navigation uses the same numbers as the renderer so the
+// selection cannot scroll out of the rows actually drawn.
+func (m *OS) paletteLayout() (width, rows int) {
+	width = m.panelWidth(paletteInnerWidth)
+	// Body lines that are not command rows: the search input, its rule, and the
+	// match count.
+	rows = m.panelBodyRows(paletteMaxVisible, 3, width, nil, paletteHints)
+	return width, rows
+}
 
 // renderCommandPalette draws the command palette on the shared panel grammar: a
 // search input, a scrolling list of matching commands with category tags and
@@ -25,29 +50,32 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 	pal := theme.UI()
 	bg := pal.Surface
 
+	width, visible := m.paletteLayout()
+	m.CommandPaletteScroll = scrollWindow(m.CommandPaletteScroll, m.CommandPaletteSelected, len(filtered), visible)
+
 	var lines []string
 
 	// Search input.
 	cursor := overlay.Style(bg).Foreground(pal.Accent).Render("█")
 	search := overlay.Style(bg).Foreground(pal.AccentBright).Bold(true).Render("› ") +
 		overlay.Style(bg).Foreground(pal.Fg).Render(m.CommandPaletteQuery) + cursor
-	lines = append(lines, search, overlay.Rule(paletteInnerWidth, bg, pal))
+	lines = append(lines, search, overlay.Rule(width, bg, pal))
 
 	if len(filtered) == 0 {
 		lines = append(lines, overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  No matching commands"))
-		for len(lines) < paletteMaxVisible+3 {
+		for len(lines) < visible+3 {
 			lines = append(lines, overlay.Style(bg).Render(" "))
 		}
 	} else {
 		start := m.CommandPaletteScroll
-		end := min(start+paletteMaxVisible, len(filtered))
+		end := min(start+visible, len(filtered))
 		for i := start; i < end; i++ {
-			lines = append(lines, paletteRow(filtered[i], i == m.CommandPaletteSelected, pal))
+			lines = append(lines, paletteRow(filtered[i], i == m.CommandPaletteSelected, pal, width))
 		}
-		for len(lines) < paletteMaxVisible+2 {
+		for len(lines) < visible+2 {
 			lines = append(lines, overlay.Style(bg).Render(" "))
 		}
-		if len(filtered) > paletteMaxVisible {
+		if len(filtered) > visible {
 			info := fmt.Sprintf("%d of %d commands", len(filtered), len(items))
 			lines = append(lines, overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  "+info))
 		} else {
@@ -58,13 +86,9 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 	panel := overlay.Panel{
 		Glyph: "", // command
 		Title: "Command Palette",
-		Width: paletteInnerWidth,
+		Width: width,
 		Body:  strings.Join(lines, "\n"),
-		Hints: []overlay.Hint{
-			{Key: "↑↓", Label: "move"},
-			{Key: "⏎", Label: "run"},
-			{Key: "esc", Label: "close"},
-		},
+		Hints: paletteHints,
 	}
 	content, geo := panel.Render(pal)
 
@@ -72,7 +96,7 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 	var rows []overlayRowHit
 	if len(filtered) > 0 {
 		start := m.CommandPaletteScroll
-		end := min(start+paletteMaxVisible, len(filtered))
+		end := min(start+visible, len(filtered))
 		for i := start; i < end; i++ {
 			rowY := geo.BodyY + (i - start) + 2 // +2 for the search line and rule
 			rows = append(rows, overlayRowHit{
@@ -86,7 +110,7 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 
 // paletteRow renders one command row: a category tag, the name, and the
 // shortcut, with a full-width highlight bar when selected.
-func paletteRow(item CommandPaletteItem, selected bool, pal overlay.Palette) string {
+func paletteRow(item CommandPaletteItem, selected bool, pal overlay.Palette, width int) string {
 	bg := pal.Surface
 	nameColor := pal.FgDim
 	if selected {
@@ -94,20 +118,31 @@ func paletteRow(item CommandPaletteItem, selected bool, pal overlay.Palette) str
 		nameColor = pal.Fg
 	}
 
-	catTag := overlay.Style(bg).Foreground(pal.FgMute).Render("[" + item.Category + "]")
+	// On a narrow panel the category tag is the first thing to go: it is the
+	// least useful part of the row and it costs the most.
+	tag := ""
+	tagW := 0
+	if width >= paletteCategoryWidth {
+		tag = overlay.Style(bg).Foreground(pal.FgMute).Render("["+item.Category+"]") +
+			overlay.Style(bg).Render(" ")
+		tagW = lipgloss.Width(item.Category) + 3
+	}
+
 	shortcut := ""
+	shortcutW := 0
 	if item.Shortcut != "" {
 		shortcut = overlay.Style(bg).Foreground(pal.FgMute).Render(item.Shortcut)
+		shortcutW = lipgloss.Width(item.Shortcut)
 	}
 
 	marker := "  "
 	if selected {
 		marker = "› "
 	}
+	name := overlay.Truncate(item.Name, max(width-2-tagW-shortcutW-1, 1))
 	left := overlay.Style(bg).Foreground(pal.Accent).Bold(true).Render(marker) +
-		catTag + overlay.Style(bg).Render(" ") +
-		overlay.Style(bg).Foreground(nameColor).Bold(selected).Render(item.Name)
+		tag + overlay.Style(bg).Foreground(nameColor).Bold(selected).Render(name)
 
-	gap := max(paletteInnerWidth-lipgloss.Width(left)-lipgloss.Width(shortcut), 1)
+	gap := max(width-lipgloss.Width(left)-shortcutW, 1)
 	return left + overlay.Style(bg).Render(strings.Repeat(" ", gap)) + shortcut
 }

--- a/internal/app/render_command_palette.go
+++ b/internal/app/render_command_palette.go
@@ -32,12 +32,12 @@ var paletteHints = []overlay.Hint{
 // paletteLayout returns the palette's fitted inner width and visible row count.
 // The keyboard navigation uses the same numbers as the renderer so the
 // selection cannot scroll out of the rows actually drawn.
-func (m *OS) paletteLayout() (width, rows int) {
+func (m *OS) paletteLayout() (width, rows int, hints []overlay.Hint) {
 	width = m.panelWidth(paletteInnerWidth)
 	// Body lines that are not command rows: the search input, its rule, and the
 	// match count.
-	rows = m.panelBodyRows(paletteMaxVisible, 3, width, nil, paletteHints)
-	return width, rows
+	rows, hints = m.panelBody(paletteMaxVisible, 3, width, nil, paletteHints)
+	return width, rows, hints
 }
 
 // renderCommandPalette draws the command palette on the shared panel grammar: a
@@ -50,7 +50,7 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 	pal := theme.UI()
 	bg := pal.Surface
 
-	width, visible := m.paletteLayout()
+	width, visible, hints := m.paletteLayout()
 	m.CommandPaletteScroll = scrollWindow(m.CommandPaletteScroll, m.CommandPaletteSelected, len(filtered), visible)
 
 	var lines []string
@@ -88,7 +88,7 @@ func (m *OS) renderCommandPalette() (string, overlay.Geometry, []overlayRowHit) 
 		Title: "Command Palette",
 		Width: width,
 		Body:  strings.Join(lines, "\n"),
-		Hints: paletteHints,
+		Hints: hints,
 	}
 	content, geo := panel.Render(pal)
 

--- a/internal/app/render_dock.go
+++ b/internal/app/render_dock.go
@@ -162,28 +162,52 @@ func (m *OS) renderDockString() (string, int) {
 		styledWorkspaceText,
 	)
 
+	actualLeftWidth := lipgloss.Width(leftInfo)
+	centerWidth := lipgloss.Width(dockItemsStr.String())
+	// The right block never takes more room than the left block and the dock
+	// items leave, so the bar as a whole stays inside the screen.
+	rightWidth := max(min(layout.RightWidth, m.GetRenderWidth()-actualLeftWidth-centerWidth), 0)
+
 	var rightInfo string
 	focusedWindow := m.GetFocusedWindow()
 
 	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
 	if inCopyMode {
-		var helpText string
+		var helpTexts []string
 		switch focusedWindow.CopyMode.State {
 		case terminal.CopyModeNormal:
-			helpText = "hjkl:move w/b/e:word f/F/t/T:char /:search n/N:next/prev C-l:clear ;,:repeat v:visual y:yank i:term q:quit"
+			helpTexts = []string{
+				"hjkl:move w/b/e:word f/F/t/T:char /:search n/N:next/prev C-l:clear ;,:repeat v:visual y:yank i:term q:quit",
+				"hjkl:move w/b/e:word /:search v:visual y:yank q:quit",
+				"hjkl /:search v y q",
+			}
 		case terminal.CopyModeSearch:
-			helpText = "Type to search  n/N:next/prev  Enter:done  Esc:cancel"
+			helpTexts = []string{
+				"Type to search  n/N:next/prev  Enter:done  Esc:cancel",
+				"n/N:next  Enter:done  Esc:cancel",
+			}
 		case terminal.CopyModeVisualChar:
-			helpText = "hjkl:extend w/b/e:word f/F/t/T:char ;,:repeat {/}:para %:bracket y:yank Esc:cancel"
+			helpTexts = []string{
+				"hjkl:extend w/b/e:word f/F/t/T:char ;,:repeat {/}:para %:bracket y:yank Esc:cancel",
+				"hjkl:extend w/b/e:word y:yank Esc:cancel",
+				"hjkl y:yank Esc",
+			}
 		case terminal.CopyModeVisualLine:
-			helpText = "jk:extend  y:yank  Esc:cancel"
+			helpTexts = []string{"jk:extend  y:yank  Esc:cancel", "jk y Esc"}
 		}
 
 		helpStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#a0a0b0")).
 			Background(lipgloss.Color("#1a1a2e")).
 			Padding(0, 1)
-		rightInfo = helpStyle.Render(helpText)
+		// Take the longest help line that fits; the copy-mode keys are worth a
+		// dock's width but not worth spilling off the end of it.
+		for i, text := range helpTexts {
+			rightInfo = helpStyle.Render(text)
+			if lipgloss.Width(rightInfo) <= rightWidth || i == len(helpTexts)-1 {
+				break
+			}
+		}
 	} else {
 		var sysInfoParts []string
 		if config.ShowCPU {
@@ -192,14 +216,20 @@ func (m *OS) renderDockString() (string, int) {
 		if config.ShowRAM {
 			sysInfoParts = append(sysInfoParts, m.GetRAMUsage())
 		}
-		if len(sysInfoParts) > 0 {
+		// The CPU graph is the first thing dropped on a dock too narrow for
+		// both readouts, then the RAM figure; a clipped graph reads as noise.
+		for len(sysInfoParts) > 0 {
 			rightInfo = sysInfoStyle.Render(strings.Join(sysInfoParts, " "))
+			if lipgloss.Width(rightInfo) <= rightWidth {
+				break
+			}
+			sysInfoParts = sysInfoParts[1:]
+			rightInfo = ""
 		}
 	}
-
-	actualLeftWidth := lipgloss.Width(leftInfo)
-	centerWidth := lipgloss.Width(dockItemsStr.String())
-	rightWidth := layout.RightWidth
+	if w := lipgloss.Width(rightInfo); w > rightWidth {
+		rightInfo = truncateToWidth(rightInfo, rightWidth)
+	}
 
 	availableSpace := m.GetRenderWidth() - actualLeftWidth - rightWidth - centerWidth
 	leftSpacer := availableSpace / 2
@@ -225,6 +255,11 @@ func (m *OS) renderDockString() (string, int) {
 	)
 
 	renderWidth := m.GetRenderWidth()
+	// Backstop: whatever the parts add up to, the bar is one screen wide.
+	if lipgloss.Width(dockBar) > renderWidth {
+		dockBar = truncateToWidth(dockBar, renderWidth)
+	}
+
 	if m.cachedSeparatorWidth != renderWidth {
 		m.cachedSeparator = strings.Repeat(config.GetWindowSeparatorChar(), renderWidth)
 		m.cachedSeparatorWidth = renderWidth

--- a/internal/app/render_dock.go
+++ b/internal/app/render_dock.go
@@ -6,7 +6,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
-	"github.com/Gaurav-Gosain/tuios/internal/terminal"
 )
 
 func (m *OS) renderDock() *lipgloss.Layer {
@@ -173,28 +172,7 @@ func (m *OS) renderDockString() (string, int) {
 
 	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
 	if inCopyMode {
-		var helpTexts []string
-		switch focusedWindow.CopyMode.State {
-		case terminal.CopyModeNormal:
-			helpTexts = []string{
-				"hjkl:move w/b/e:word f/F/t/T:char /:search n/N:next/prev C-l:clear ;,:repeat v:visual y:yank i:term q:quit",
-				"hjkl:move w/b/e:word /:search v:visual y:yank q:quit",
-				"hjkl /:search v y q",
-			}
-		case terminal.CopyModeSearch:
-			helpTexts = []string{
-				"Type to search  n/N:next/prev  Enter:done  Esc:cancel",
-				"n/N:next  Enter:done  Esc:cancel",
-			}
-		case terminal.CopyModeVisualChar:
-			helpTexts = []string{
-				"hjkl:extend w/b/e:word f/F/t/T:char ;,:repeat {/}:para %:bracket y:yank Esc:cancel",
-				"hjkl:extend w/b/e:word y:yank Esc:cancel",
-				"hjkl y:yank Esc",
-			}
-		case terminal.CopyModeVisualLine:
-			helpTexts = []string{"jk:extend  y:yank  Esc:cancel", "jk y Esc"}
-		}
+		helpTexts := copyModeHelpTexts(focusedWindow.CopyMode.State)
 
 		helpStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#a0a0b0")).

--- a/internal/app/render_helpers_buttons_test.go
+++ b/internal/app/render_helpers_buttons_test.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The control pill's width and the column each glyph lands on are a contract
+// with the mouse hit-test, which addresses the buttons as negative offsets from
+// the window's right edge. Changing a button's character or its padding silently
+// slides every glyph sideways and the clicks stop landing, so pin the layout.
+
+// pillColumns renders the top border the way addToBorder does and returns the
+// visible cells, so a column can be addressed as an offset from the right edge.
+func pillColumns(t *testing.T, tiling bool, width int) []rune {
+	t.Helper()
+
+	buttonColor := lipgloss.Color("#7dd3fc")
+	buttonStyle := baseButtonStyle.Background(buttonColor)
+	cross := buttonStyle.Render(config.GetWindowButtonClose())
+	dash := buttonStyle.Render("  - ")
+
+	var buttons string
+	if tiling {
+		buttons = makeRounded(dash+cross, buttonColor)
+	} else {
+		square := buttonStyle.Render(" □ ")
+		buttons = makeRounded(dash+square+cross, buttonColor)
+	}
+
+	border := RightString(buttons, width, buttonColor)
+	if border == "" {
+		t.Fatalf("RightString returned nothing for width %d", width)
+	}
+	return []rune(ansi.Strip(border))
+}
+
+// at returns the cell at a negative offset from the right edge, matching the
+// convention the button-position constants use.
+func at(t *testing.T, cols []rune, offset int) rune {
+	t.Helper()
+	idx := len(cols) + offset
+	if idx < 0 || idx >= len(cols) {
+		t.Fatalf("offset %d is outside a %d-cell border", offset, len(cols))
+	}
+	return cols[idx]
+}
+
+func TestControlPillWidths(t *testing.T) {
+	// Left pill + "  - " + " X " + right pill, plus " [] " when floating.
+	const tilingPillWidth = 9
+	const floatingPillWidth = 12
+
+	buttonColor := lipgloss.Color("#7dd3fc")
+	buttonStyle := baseButtonStyle.Background(buttonColor)
+	cross := buttonStyle.Render(config.GetWindowButtonClose())
+	dash := buttonStyle.Render("  - ")
+	square := buttonStyle.Render(" □ ")
+
+	if got := lipgloss.Width(makeRounded(dash+cross, buttonColor)); got != tilingPillWidth {
+		t.Errorf("tiling pill is %d cells wide, want %d", got, tilingPillWidth)
+	}
+	if got := lipgloss.Width(makeRounded(dash+square+cross, buttonColor)); got != floatingPillWidth {
+		t.Errorf("floating pill is %d cells wide, want %d", got, floatingPillWidth)
+	}
+}
+
+func TestControlPillGlyphsLandOnTheirHitboxes(t *testing.T) {
+	closeGlyph := []rune(config.GetWindowButtonClose())[1]
+
+	// Wide and narrow panes: the pill is right-aligned, so its glyphs sit at
+	// the same offsets from the right edge regardless of how much border runs
+	// to their left.
+	for _, width := range []int{20, 40, 78, 200} {
+		t.Run("tiling", func(t *testing.T) {
+			cols := pillColumns(t, true, width)
+
+			// " X " spans CloseButtonLeft..CloseButtonRight with the glyph in
+			// the middle and a padding cell on either side.
+			if got := at(t, cols, config.CloseButtonLeft); got != ' ' {
+				t.Errorf("width %d: CloseButtonLeft (%d) holds %q, want a padding space",
+					width, config.CloseButtonLeft, got)
+			}
+			if got := at(t, cols, config.CloseButtonLeft+1); got != closeGlyph {
+				t.Errorf("width %d: close glyph is not centred in its hitbox: found %q",
+					width, got)
+			}
+			if got := at(t, cols, config.CloseButtonRight); got != ' ' {
+				t.Errorf("width %d: CloseButtonRight (%d) holds %q, want a padding space",
+					width, config.CloseButtonRight, got)
+			}
+
+			if got := at(t, cols, config.MinimizeButtonLeftTiling+1); got != '-' {
+				t.Errorf("width %d: minimize glyph not centred in its tiling hitbox: found %q",
+					width, got)
+			}
+		})
+
+		t.Run("floating", func(t *testing.T) {
+			cols := pillColumns(t, false, width)
+
+			if got := at(t, cols, config.CloseButtonLeft+1); got != closeGlyph {
+				t.Errorf("width %d: close glyph is not centred in its hitbox: found %q",
+					width, got)
+			}
+			if got := at(t, cols, config.MaximizeButtonLeft+1); got != '□' {
+				t.Errorf("width %d: maximize glyph not centred in its hitbox: found %q",
+					width, got)
+			}
+			if got := at(t, cols, config.MinimizeButtonLeftNonTiling+1); got != '-' {
+				t.Errorf("width %d: minimize glyph not centred in its non-tiling hitbox: found %q",
+					width, got)
+			}
+		})
+	}
+}
+
+// The close glyph must occupy exactly one cell. A wider one would push every
+// button in the pill left of where the hit-test looks for it, and a terminal
+// that measures it as one cell while drawing it wider would overlap whatever
+// sits to its right.
+func TestCloseButtonIsThreeCells(t *testing.T) {
+	for _, s := range []string{config.WindowButtonClose, config.WindowButtonCloseASCII} {
+		if got := lipgloss.Width(s); got != 3 {
+			t.Errorf("close button %q is %d cells, want 3", s, got)
+		}
+		runes := []rune(s)
+		if len(runes) != 3 {
+			t.Fatalf("close button %q is %d runes, want 3", s, len(runes))
+		}
+		if runes[0] != ' ' || runes[2] != ' ' {
+			t.Errorf("close button %q is missing its padding spaces", s)
+		}
+		if got := lipgloss.Width(string(runes[1])); got != 1 {
+			t.Errorf("close glyph U+%04X is %d cells, want 1", runes[1], got)
+		}
+	}
+}

--- a/internal/app/render_layout_picker.go
+++ b/internal/app/render_layout_picker.go
@@ -16,13 +16,14 @@ func (m *OS) renderLayoutPicker() (string, overlay.Geometry, []overlayRowHit) {
 	if m.LayoutPickerMode == "save" {
 		pal := theme.UI()
 		bg := pal.Surface
+		width := m.panelWidth(layoutPickerWidth)
 		input := overlay.Style(bg).Foreground(pal.AccentBright).Bold(true).Render("Name  ") +
-			overlay.Style(bg).Foreground(pal.Fg).Render(m.LayoutSaveBuffer) +
+			overlay.Style(bg).Foreground(pal.Fg).Render(overlay.Truncate(m.LayoutSaveBuffer, max(width-7, 1))) +
 			overlay.Style(bg).Foreground(pal.Accent).Render("█")
 		panel := overlay.Panel{
 			Glyph: "",
 			Title: "Save Layout",
-			Width: layoutPickerWidth,
+			Width: width,
 			Body:  input,
 			Hints: []overlay.Hint{{Key: "⏎", Label: "save"}, {Key: "esc", Label: "cancel"}},
 		}
@@ -44,25 +45,29 @@ func (m *OS) renderLayoutPicker() (string, overlay.Geometry, []overlayRowHit) {
 		Query:      m.LayoutPickerQuery,
 		Count:      len(filtered),
 		Selected:   m.LayoutPickerSelected,
-		Scroll:     m.LayoutPickerScroll,
+		Scroll:     &m.LayoutPickerScroll,
 		EmptyMsg:   "No saved layouts",
 		Hints: []overlay.Hint{
 			{Key: "⏎", Label: "apply"},
 			{Key: "d", Label: "delete"},
 			{Key: "esc", Label: "close"},
 		},
-		RenderRow: func(i int, selected bool, rowBg color.Color, pal overlay.Palette) string {
+		RenderRow: func(i int, selected bool, rowBg color.Color, pal overlay.Palette, width int) string {
 			item := filtered[i]
 			detail := fmt.Sprintf("%d windows", len(item.Windows))
 			if item.AutoTiling {
 				detail += " · tiling"
 			}
+			// On a narrow panel the detail is dropped before the name is.
+			if width-lipgloss.Width(detail)-6 < 12 {
+				detail = fmt.Sprintf("%d", len(item.Windows))
+			}
 			labelColor := pal.FgDim
 			if selected {
 				labelColor = pal.Fg
 			}
-			name := overlay.Truncate(item.Name, layoutPickerWidth-lipgloss.Width(detail)-6)
-			return listRowLine(layoutPickerWidth, listRowMarker(selected), name, detail, labelColor, pal.FgMute, selected, rowBg, pal)
+			name := overlay.Truncate(item.Name, max(width-lipgloss.Width(detail)-6, 1))
+			return listRowLine(width, listRowMarker(selected), name, detail, labelColor, pal.FgMute, selected, rowBg, pal)
 		},
 	})
 }

--- a/internal/app/render_list_overlay.go
+++ b/internal/app/render_list_overlay.go
@@ -38,7 +38,7 @@ type listOverlay struct {
 // listOverlayLayout returns the fitted inner width and visible row count for a
 // list overlay, so the keyboard and wheel navigation can scroll by the same
 // number of rows the renderer draws.
-func (m *OS) listOverlayLayout(cfg listOverlay) (width, rows int) {
+func (m *OS) listOverlayLayout(cfg listOverlay) (width, rows int, hints []overlay.Hint) {
 	width = m.panelWidth(cfg.Width)
 	// Body lines that are not list rows: the scroll indicator, plus the search
 	// input and its rule when the list has one.
@@ -46,8 +46,8 @@ func (m *OS) listOverlayLayout(cfg listOverlay) (width, rows int) {
 	if cfg.Search {
 		extra += 2
 	}
-	rows = m.panelBodyRows(cfg.MaxVisible, extra, width, nil, cfg.Hints)
-	return width, rows
+	rows, hints = m.panelBody(cfg.MaxVisible, extra, width, nil, cfg.Hints)
+	return width, rows, hints
 }
 
 // renderListOverlay renders cfg into a panel and returns the string, geometry
@@ -56,7 +56,7 @@ func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []ove
 	pal := theme.UI()
 	bg := pal.Surface
 
-	cfg.Width, cfg.MaxVisible = m.listOverlayLayout(cfg)
+	cfg.Width, cfg.MaxVisible, cfg.Hints = m.listOverlayLayout(cfg)
 	scroll := 0
 	if cfg.Scroll != nil {
 		*cfg.Scroll = scrollWindow(*cfg.Scroll, cfg.Selected, cfg.Count, cfg.MaxVisible)

--- a/internal/app/render_list_overlay.go
+++ b/internal/app/render_list_overlay.go
@@ -23,13 +23,31 @@ type listOverlay struct {
 	Query      string
 	Count      int
 	Selected   int
-	Scroll     int
-	EmptyMsg   string
-	Hints      []overlay.Hint
-	// RenderRow returns the content for row i on the given row background. It
-	// should be at most Width cells wide; the helper fills the remainder with
-	// rowBg so the selection highlight spans the row.
-	RenderRow func(i int, selected bool, rowBg color.Color, pal overlay.Palette) string
+	// Scroll points at the caller's scroll offset; the renderer clamps it to the
+	// rows it can actually show, which depends on the screen height.
+	Scroll   *int
+	EmptyMsg string
+	Hints    []overlay.Hint
+	// RenderRow returns the content for row i on the given row background, at
+	// most width cells wide (width is the fitted panel width, not the requested
+	// one); the helper fills the remainder with rowBg so the selection highlight
+	// spans the row.
+	RenderRow func(i int, selected bool, rowBg color.Color, pal overlay.Palette, width int) string
+}
+
+// listOverlayLayout returns the fitted inner width and visible row count for a
+// list overlay, so the keyboard and wheel navigation can scroll by the same
+// number of rows the renderer draws.
+func (m *OS) listOverlayLayout(cfg listOverlay) (width, rows int) {
+	width = m.panelWidth(cfg.Width)
+	// Body lines that are not list rows: the scroll indicator, plus the search
+	// input and its rule when the list has one.
+	extra := 1
+	if cfg.Search {
+		extra += 2
+	}
+	rows = m.panelBodyRows(cfg.MaxVisible, extra, width, nil, cfg.Hints)
+	return width, rows
 }
 
 // renderListOverlay renders cfg into a panel and returns the string, geometry
@@ -37,6 +55,13 @@ type listOverlay struct {
 func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []overlayRowHit) {
 	pal := theme.UI()
 	bg := pal.Surface
+
+	cfg.Width, cfg.MaxVisible = m.listOverlayLayout(cfg)
+	scroll := 0
+	if cfg.Scroll != nil {
+		*cfg.Scroll = scrollWindow(*cfg.Scroll, cfg.Selected, cfg.Count, cfg.MaxVisible)
+		scroll = *cfg.Scroll
+	}
 
 	var lines []string
 	rowYOffset := 0
@@ -48,7 +73,7 @@ func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []ove
 		rowYOffset = 2
 	}
 
-	start := cfg.Scroll
+	start := scroll
 	end := min(start+cfg.MaxVisible, cfg.Count)
 	shown := 0
 	for i := start; i < end; i++ {
@@ -56,7 +81,7 @@ func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []ove
 		if i == cfg.Selected {
 			rowBg = pal.RowSel
 		}
-		lines = append(lines, overlay.Fill(cfg.RenderRow(i, i == cfg.Selected, rowBg, pal), cfg.Width, rowBg))
+		lines = append(lines, overlay.Fill(cfg.RenderRow(i, i == cfg.Selected, rowBg, pal, cfg.Width), cfg.Width, rowBg))
 		shown++
 	}
 	if cfg.Count == 0 {
@@ -87,7 +112,7 @@ func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []ove
 	}
 	content, geo := panel.Render(pal)
 
-	rows := make([]overlayRowHit, 0, end-start)
+	rows := make([]overlayRowHit, 0, max(end-start, 0))
 	for i := start; i < end; i++ {
 		rowY := geo.BodyY + (i - start) + rowYOffset
 		rows = append(rows, overlayRowHit{
@@ -103,19 +128,74 @@ func (m *OS) renderListOverlay(cfg listOverlay) (string, overlay.Geometry, []ove
 func (m *OS) simpleOverlayPanel(glyph, title string, bodyLines []string, hints []overlay.Hint) (string, overlay.Geometry, []overlayRowHit) {
 	pal := theme.UI()
 	bg := pal.Surface
-	styled := make([]string, len(bodyLines))
-	for i, l := range bodyLines {
-		styled[i] = overlay.Style(bg).Foreground(pal.FgDim).Render("  " + l)
+	width := m.panelWidth(simplePanelWidth)
+	// A message narrower than the panel is one line; a longer one wraps rather
+	// than running off the edge.
+	var styled []string
+	for _, l := range bodyLines {
+		for _, wrapped := range wrapPlain(l, width-2) {
+			styled = append(styled, overlay.Style(bg).Foreground(pal.FgDim).Render("  "+wrapped))
+		}
 	}
 	panel := overlay.Panel{
 		Glyph: glyph,
 		Title: title,
-		Width: 52,
+		Width: width,
 		Body:  strings.Join(styled, "\n"),
 		Hints: hints,
 	}
 	content, geo := panel.Render(pal)
 	return content, geo, nil
+}
+
+// simplePanelWidth is the preferred inner width of an informational panel.
+const simplePanelWidth = 52
+
+// wrapPlain breaks an unstyled string onto lines of at most width cells,
+// preferring word boundaries. An empty input yields one empty line so blank
+// spacer lines survive.
+func wrapPlain(s string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	if s == "" || lipgloss.Width(s) <= width {
+		return []string{s}
+	}
+	var out []string
+	line := ""
+	flush := func() {
+		if line != "" {
+			out = append(out, line)
+			line = ""
+		}
+	}
+	for _, word := range strings.Fields(s) {
+		// A word longer than the line (a path, say) is broken across lines
+		// rather than dropped.
+		for lipgloss.Width(word) > width {
+			flush()
+			runes := []rune(word)
+			cut := len(runes)
+			for cut > 1 && lipgloss.Width(string(runes[:cut])) > width {
+				cut--
+			}
+			out = append(out, string(runes[:cut]))
+			word = string(runes[cut:])
+		}
+		switch {
+		case line == "":
+			line = word
+		case lipgloss.Width(line)+1+lipgloss.Width(word) <= width:
+			line += " " + word
+		default:
+			flush()
+			line = word
+		}
+	}
+	if line != "" {
+		out = append(out, line)
+	}
+	return out
 }
 
 // moveListSelection advances a (selected, scroll) pair by delta within a list

--- a/internal/app/render_overlays.go
+++ b/internal/app/render_overlays.go
@@ -74,32 +74,60 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
    ██║   ╚██████╔╝██║╚██████╔╝███████║
    ╚═╝    ╚═════╝ ╚═╝ ╚═════╝ ╚══════╝`
 
+		// The splash is the first thing anyone sees, at whatever width. Its
+		// three parts have fixed widths - 38 columns of block letters, a 28
+		// column subtitle and a 68 column hint line - and the box adds a border
+		// and two columns of padding on each side. Asking for all of it needs 74
+		// columns, so on anything narrower it used to run off the right edge
+		// with the border cut away. Drop to what fits instead.
+		const (
+			artCols      = 38
+			subtitleCols = 28
+			hintCols     = 68
+		)
+		avail := m.GetRenderWidth() - 6 // both borders, both paddings
+
 		ui := theme.UI()
+		titleText := asciiArt
+		if avail < artCols {
+			titleText = "TUIOS"
+		}
 		title := lipgloss.NewStyle().
 			Foreground(ui.Accent).
 			Bold(true).
-			Render(asciiArt)
+			Render(titleText)
 
-		subtitle := lipgloss.NewStyle().
-			Foreground(ui.AccentBright).
-			Render("Terminal UI Operating System")
+		parts := []string{title}
 
-		instruction := lipgloss.NewStyle().
+		if avail >= subtitleCols {
+			parts = append(parts, "", lipgloss.NewStyle().
+				Foreground(ui.AccentBright).
+				Render("Terminal UI Operating System"))
+		}
+
+		// The hints read as one line when there is room for one, and stack when
+		// there is not, so no width loses a hint entirely.
+		hints := []string{
+			"Press 'n' for a new window",
+			"'?' for help",
+			"',' for settings",
+		}
+		sep := "\n"
+		if avail >= hintCols {
+			sep = "   •   "
+		}
+		parts = append(parts, "", lipgloss.NewStyle().
 			Foreground(ui.FgDim).
-			Render("Press 'n' for a new window   •   '?' for help   •   ',' for settings")
+			Align(lipgloss.Center).
+			Render(strings.Join(hints, sep)))
 
-		content := lipgloss.JoinVertical(lipgloss.Center,
-			title,
-			"",
-			subtitle,
-			"",
-			instruction,
-		)
+		content := lipgloss.JoinVertical(lipgloss.Center, parts...)
 
 		boxStyle := lipgloss.NewStyle().
 			Border(getNormalBorder()).
 			BorderForeground(ui.Accent).
-			Padding(1, 2)
+			Padding(1, 2).
+			MaxWidth(m.GetRenderWidth())
 
 		centeredContent := lipgloss.Place(
 			m.GetRenderWidth(), m.GetRenderHeight(),
@@ -232,7 +260,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Foreground(lipgloss.Color("8")).
 			Render("Press 'q'/'esc' to exit, 'r' to reset stats"))
 
-		statsContent := strings.Join(statsLines, "\n")
+		statsContent := clipStyledLines(strings.Join(statsLines, "\n"), m.dialogWidth(60)-dialogChrome)
 
 		statsBox := lipgloss.NewStyle().
 			Border(getBorder()).
@@ -249,6 +277,11 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Foreground(lipgloss.Color("14")).
 			Bold(true).
 			Render("System Logs")
+
+		// The viewer prefers 80 columns; a narrower screen gets a narrower
+		// viewer rather than a viewer with its right-hand side off the edge.
+		logBoxWidth := m.dialogWidth(80)
+		logTextWidth := logBoxWidth - dialogChrome
 
 		maxDisplayHeight := max(m.GetRenderHeight()-8, 8)
 		totalLogs := len(m.LogMessages)
@@ -290,7 +323,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 				Render(fmt.Sprintf("[%s]", msg.Level))
 
 			logLine := fmt.Sprintf("%s %s %s", timeStr, levelStr, msg.Message)
-			logLines = append(logLines, logLine)
+			logLines = append(logLines, clipStyled(logLine, logTextWidth))
 			displayCount++
 		}
 
@@ -304,9 +337,13 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 		}
 
 		logLines = append(logLines, "")
+		hints := "q:close  j/k:scroll  E:copy errors  A:copy all"
+		if logTextWidth < lipgloss.Width(hints) {
+			hints = "q:close  j/k:scroll"
+		}
 		logLines = append(logLines, lipgloss.NewStyle().
 			Foreground(lipgloss.Color("8")).
-			Render("q:close  j/k:scroll  E:copy errors  A:copy all"))
+			Render(clipStyled(hints, logTextWidth)))
 
 		logContent := strings.Join(logLines, "\n")
 
@@ -314,7 +351,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Border(getBorder()).
 			BorderForeground(theme.HelpBorder()).
 			Padding(1, 2).
-			Width(80).
+			Width(logBoxWidth).
 			Background(lipgloss.Color("#1a1a2a")).
 			Render(logContent)
 
@@ -436,6 +473,19 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			bindings = config.GetPrefixKeybindings("", m.IsDaemonSession)
 		}
 
+		// The overlay spends four rows on a blank pad above and below, the title
+		// and its rule. A prefix with more bindings than the rest of the screen
+		// can hold says how many it left out rather than running off the bottom
+		// where they cannot be read.
+		moreCount := 0
+		if rh := m.GetRenderHeight(); rh > 0 {
+			maxRows := max(rh-5, 1)
+			if len(bindings) > maxRows {
+				moreCount = len(bindings) - (maxRows - 1)
+				bindings = bindings[:maxRows-1]
+			}
+		}
+
 		maxKeyLen := 0
 		maxDescLen := 0
 		for _, binding := range bindings {
@@ -447,6 +497,14 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			}
 		}
 		contentWidth := max(maxKeyLen+2+maxDescLen, len(title))
+		// The overlay carries two cells of padding on each side and sits two
+		// cells in from the screen edge, so it can ask for at most that much
+		// less than the screen. Descriptions are cut to whatever is left; the
+		// key column is what the overlay is for and keeps its width.
+		if maxWidth := m.GetRenderWidth() - 8; maxWidth > 0 && contentWidth > maxWidth {
+			contentWidth = max(maxWidth, maxKeyLen+2)
+		}
+		descWidth := max(contentWidth-maxKeyLen-2, 1)
 
 		bg := lipgloss.Color("#1f2937")
 
@@ -464,7 +522,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Foreground(lipgloss.Color("#ffffff")).
 			Bold(true).
 			Background(bg).
-			Render(title)
+			Render(truncateString(title, contentWidth))
 		styledLines = append(styledLines, padLine(titleStyled, contentWidth))
 
 		sepStyled := lipgloss.NewStyle().
@@ -485,9 +543,17 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			descStyled := lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#d1d5db")).
 				Background(bg).
-				Render(binding.Description)
+				Render(truncateString(binding.Description, descWidth))
 			line := keyStyled + paddingStyled + descStyled
 			styledLines = append(styledLines, padLine(line, contentWidth))
+		}
+
+		if moreCount > 0 {
+			more := lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#9ca3af")).
+				Background(bg).
+				Render(truncateString(fmt.Sprintf("+%d more", moreCount), contentWidth))
+			styledLines = append(styledLines, padLine(more, contentWidth))
 		}
 
 		paddingH := lipgloss.NewStyle().Background(bg).Render("  ")
@@ -525,6 +591,10 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			overlayX = renderWidth - overlayWidth - 2
 			overlayY = renderHeight - overlayHeight - 2
 		}
+		// A binding list taller than the screen would otherwise be positioned
+		// off the top, hiding the first entries with no way to reach them.
+		overlayX = max(min(overlayX, renderWidth-overlayWidth), 0)
+		overlayY = max(min(overlayY, renderHeight-overlayHeight), 0)
 
 		whichKeyLayer := lipgloss.NewLayer(renderedOverlay).
 			X(overlayX).
@@ -651,18 +721,21 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 	if m.ShowKeys && len(m.RecentKeys) > 0 {
 		m.CleanupExpiredKeys(3 * time.Second)
 		if len(m.RecentKeys) > 0 {
-			showkeysContent := m.renderShowkeys()
+			rightMargin := 2
+			// The strip grows to the left from the right edge, so on a narrow
+			// screen it would start off the left edge; drop the oldest keys
+			// until what is left fits instead.
+			showkeysContent := m.renderShowkeysFitted(max(m.GetRenderWidth()-rightMargin, 1))
 			contentWidth := lipgloss.Width(showkeysContent)
 			contentHeight := lipgloss.Height(showkeysContent)
 
-			rightMargin := 2
 			dockOffset := 0
 			if config.DockbarPosition == "bottom" {
 				dockOffset = config.DockHeight
 			}
 
-			x := m.GetRenderWidth() - contentWidth - rightMargin
-			y := m.GetRenderHeight() - contentHeight - dockOffset
+			x := max(m.GetRenderWidth()-contentWidth-rightMargin, 0)
+			y := max(m.GetRenderHeight()-contentHeight-dockOffset, 0)
 
 			zIndex := config.ZIndexNotifications + 1
 			if m.ShowHelp {

--- a/internal/app/render_overlays.go
+++ b/internal/app/render_overlays.go
@@ -86,10 +86,14 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			hintCols     = 68
 		)
 		avail := m.GetRenderWidth() - 6 // both borders, both paddings
+		// The same argument applies to the height: the block letters are six
+		// rows of a box that also carries a border, padding, a subtitle and up
+		// to three stacked hints, which is more than a short terminal has.
+		availRows := m.dialogContentRows()
 
 		ui := theme.UI()
 		titleText := asciiArt
-		if avail < artCols {
+		if avail < artCols || availRows < 12 {
 			titleText = "TUIOS"
 		}
 		title := lipgloss.NewStyle().
@@ -99,7 +103,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 
 		parts := []string{title}
 
-		if avail >= subtitleCols {
+		if avail >= subtitleCols && availRows >= 8 {
 			parts = append(parts, "", lipgloss.NewStyle().
 				Foreground(ui.AccentBright).
 				Render("Terminal UI Operating System"))
@@ -121,7 +125,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Align(lipgloss.Center).
 			Render(strings.Join(hints, sep)))
 
-		content := lipgloss.JoinVertical(lipgloss.Center, parts...)
+		content := lipgloss.JoinVertical(lipgloss.Center, squeezeLines(parts, availRows)...)
 
 		boxStyle := lipgloss.NewStyle().
 			Border(getNormalBorder()).
@@ -260,6 +264,7 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 			Foreground(lipgloss.Color("8")).
 			Render("Press 'q'/'esc' to exit, 'r' to reset stats"))
 
+		statsLines = squeezeLines(statsLines, m.dialogContentRows())
 		statsContent := clipStyledLines(strings.Join(statsLines, "\n"), m.dialogWidth(60)-dialogChrome)
 
 		statsBox := lipgloss.NewStyle().

--- a/internal/app/render_quit_dialog.go
+++ b/internal/app/render_quit_dialog.go
@@ -45,8 +45,15 @@ func pillButton(label string, selected bool, accent color.Color, pal overlay.Pal
 func (m *OS) renderQuitConfirmDialog() (string, int, int) {
 	pal := theme.UI()
 	bg := pal.Surface
+	width := m.panelWidth(quitDialogInnerWidth)
 
-	question := overlay.Style(bg).Foreground(pal.Fg).Render("Close all windows and quit?")
+	// The full question needs 27 columns; a narrower dialog asks it shorter
+	// rather than spilling the text past its own edge.
+	text := "Close all windows and quit?"
+	if width < lipgloss.Width(text) {
+		text = "Quit?"
+	}
+	question := overlay.Style(bg).Foreground(pal.Fg).Render(text)
 
 	yesSelected := m.QuitConfirmSelection == 0
 	// "Yes" is the destructive action, so it takes the warn color when selected.
@@ -55,15 +62,15 @@ func (m *OS) renderQuitConfirmDialog() (string, int, int) {
 	buttons := yes + overlay.Style(bg).Render("   ") + no
 
 	body := strings.Join([]string{
-		centerOnSurface(question, quitDialogInnerWidth, bg),
+		centerOnSurface(question, width, bg),
 		overlay.Style(bg).Render(" "),
-		centerOnSurface(buttons, quitDialogInnerWidth, bg),
+		centerOnSurface(buttons, width, bg),
 	}, "\n")
 
 	panel := overlay.Panel{
 		Glyph: "", // warning
 		Title: "Quit TUIOS",
-		Width: quitDialogInnerWidth,
+		Width: width,
 		Body:  body,
 		Hints: []overlay.Hint{
 			{Key: "←→", Label: "select"},

--- a/internal/app/render_session_switcher.go
+++ b/internal/app/render_session_switcher.go
@@ -3,6 +3,7 @@ package app
 import (
 	"image/color"
 
+	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/overlay"
 )
 
@@ -44,14 +45,14 @@ func (m *OS) renderSessionSwitcher() (string, overlay.Geometry, []overlayRowHit)
 		Query:      m.SessionSwitcherQuery,
 		Count:      len(filtered),
 		Selected:   m.SessionSwitcherSelected,
-		Scroll:     m.SessionSwitcherScroll,
+		Scroll:     &m.SessionSwitcherScroll,
 		EmptyMsg:   empty,
 		Hints: []overlay.Hint{
 			{Key: "⏎", Label: "switch"},
 			{Key: "ctrl+d", Label: "delete"},
 			{Key: "esc", Label: "close"},
 		},
-		RenderRow: func(i int, selected bool, rowBg color.Color, pal overlay.Palette) string {
+		RenderRow: func(i int, selected bool, rowBg color.Color, pal overlay.Palette, width int) string {
 			item := filtered[i]
 			trailing, trailColor := "", pal.FgMute
 			if item.IsCurrent {
@@ -61,7 +62,8 @@ func (m *OS) renderSessionSwitcher() (string, overlay.Geometry, []overlayRowHit)
 			if selected {
 				labelColor = pal.Fg
 			}
-			return listRowLine(sessionSwitcherWidth, listRowMarker(selected), item.Name, trailing, labelColor, trailColor, selected, rowBg, pal)
+			name := overlay.Truncate(item.Name, max(width-lipgloss.Width(trailing)-4, 1))
+			return listRowLine(width, listRowMarker(selected), name, trailing, labelColor, trailColor, selected, rowBg, pal)
 		},
 	})
 }

--- a/internal/app/render_settings.go
+++ b/internal/app/render_settings.go
@@ -9,11 +9,30 @@ import (
 	"github.com/Gaurav-Gosain/tuios/internal/theme"
 )
 
-// Settings overlay layout constants.
+// Settings overlay layout constants. These are the preferred sizes; a narrower
+// or shorter screen gets a panel fitted to it (see overlay_fit.go).
 const (
 	settingsInnerWidth  = 62
 	settingsVisibleRows = 7
 )
+
+// settingsHints is the settings footer, shared by the renderer and the sizing
+// helper so both measure the same panel.
+var settingsHints = []overlay.Hint{
+	{Key: "↑↓", Label: "move"},
+	{Key: "←→", Label: "change"},
+	{Key: "tab", Label: "section"},
+	{Key: "esc", Label: "close"},
+}
+
+// settingsLayout returns the fitted inner width and the number of setting rows
+// that fit, given the category tabs (which may wrap onto several rows).
+func (m *OS) settingsLayout(tabs []string, itemCount int) (width, rows int) {
+	width = m.panelWidth(settingsInnerWidth)
+	// Body lines that are not setting rows: a blank and the description.
+	rows = m.panelBodyRows(max(itemCount, settingsVisibleRows), 2, width, tabs, settingsHints)
+	return width, rows
+}
 
 // renderSettings draws the settings overlay and returns the rendered panel, its
 // geometry, and the per-row hit rectangles for mouse routing.
@@ -33,20 +52,33 @@ func (m *OS) renderSettings() (string, overlay.Geometry, []overlayRowHit) {
 	pal := theme.UI()
 	bg := pal.Surface
 
+	tabs := make([]string, len(cats))
+	for i, c := range cats {
+		tabs[i] = c.Name
+	}
+
+	width, visible := m.settingsLayout(tabs, len(cat.Items))
+	// A category with more settings than fit scrolls; the selection stays in
+	// view so the arrow keys can always reach every setting.
+	m.SettingsScroll = scrollWindow(m.SettingsScroll, m.SettingsSelected, len(cat.Items), visible)
+	start := m.SettingsScroll
+	end := min(start+visible, len(cat.Items))
+
 	// Build each row and remember its control width so the hit rects can be
 	// derived from the panel geometry afterward.
 	type rowInfo struct {
 		control string
 		isBool  bool
+		idx     int
 	}
 	var lines []string
-	infos := make([]rowInfo, len(cat.Items))
-	for i, item := range cat.Items {
-		line, control, isBool := m.settingsRow(item, i == m.SettingsSelected, pal)
+	infos := make([]rowInfo, 0, end-start)
+	for i := start; i < end; i++ {
+		line, control, isBool := m.settingsRow(cat.Items[i], i == m.SettingsSelected, pal, width)
 		lines = append(lines, line)
-		infos[i] = rowInfo{control: control, isBool: isBool}
+		infos = append(infos, rowInfo{control: control, isBool: isBool, idx: i})
 	}
-	for len(lines) < settingsVisibleRows {
+	for len(lines) < visible {
 		lines = append(lines, overlay.Style(bg).Render(" "))
 	}
 
@@ -54,45 +86,40 @@ func (m *OS) renderSettings() (string, overlay.Geometry, []overlayRowHit) {
 	if len(cat.Items) > 0 {
 		desc = cat.Items[m.SettingsSelected].Desc
 	}
+	if len(cat.Items) > visible {
+		// Say where in the category the selection is, so a scrolled-off setting
+		// is discoverable rather than simply missing.
+		desc = lipgloss.Sprintf("(%d/%d) ", m.SettingsSelected+1, len(cat.Items)) + desc
+	}
 	// "  " prefix counts against the inner width budget, same as the row
 	// marker does for setting rows, so the truncation target leaves room
 	// for it.
-	desc = overlay.Truncate(desc, settingsInnerWidth-2)
+	desc = overlay.Truncate(desc, width-2)
 	lines = append(lines,
 		overlay.Style(bg).Render(" "),
 		overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  "+desc),
 	)
 
-	tabs := make([]string, len(cats))
-	for i, c := range cats {
-		tabs[i] = c.Name
-	}
-
 	panel := overlay.Panel{
 		Glyph:     "", // gear
 		Title:     "Settings",
-		Width:     settingsInnerWidth,
+		Width:     width,
 		Tabs:      tabs,
 		ActiveTab: m.SettingsCategory,
 		Body:      strings.Join(lines, "\n"),
-		Hints: []overlay.Hint{
-			{Key: "↑↓", Label: "move"},
-			{Key: "←→", Label: "change"},
-			{Key: "tab", Label: "section"},
-			{Key: "esc", Label: "close"},
-		},
+		Hints:     settingsHints,
 	}
 	content, geo := panel.Render(pal)
 
 	// Derive hit rects: each row spans the full panel width at BodyY+i; the
 	// control sits right-aligned in the inner area.
-	rows := make([]overlayRowHit, 0, len(cat.Items))
+	rows := make([]overlayRowHit, 0, len(infos))
 	for i, info := range infos {
 		rowY := geo.BodyY + i
 		full := overlay.Rect{X0: 0, Y0: rowY, X1: geo.Width, Y1: rowY + 1}
 		ctrlW := lipgloss.Width(info.control)
 		ctrlX := geo.BodyX + geo.InnerWidth - ctrlW
-		hit := overlayRowHit{Rect: full, Idx: i}
+		hit := overlayRowHit{Rect: full, Idx: info.idx}
 		if info.isBool {
 			hit.Inc = overlay.Rect{X0: ctrlX, Y0: rowY, X1: ctrlX + ctrlW, Y1: rowY + 1}
 		} else {
@@ -107,7 +134,7 @@ func (m *OS) renderSettings() (string, overlay.Geometry, []overlayRowHit) {
 
 // settingsRow renders a single setting and returns the row string, its control
 // string (for hit-rect sizing), and whether the control is a boolean toggle.
-func (m *OS) settingsRow(item settingItem, selected bool, pal overlay.Palette) (string, string, bool) {
+func (m *OS) settingsRow(item settingItem, selected bool, pal overlay.Palette, width int) (string, string, bool) {
 	bg := pal.Surface
 	marker := "  "
 	if selected {
@@ -121,26 +148,28 @@ func (m *OS) settingsRow(item settingItem, selected bool, pal overlay.Palette) (
 	case controlBool:
 		control = overlay.Toggle(item.boolVal(m), selected, bg, pal)
 	case controlString:
-		control = m.settingsStringControl(item, selected, bg, pal)
+		control = m.settingsStringControl(item, selected, bg, pal, width)
 	default:
-		control = overlay.Cycler(item.value(m), selected, bg, pal)
+		control = overlay.Cycler(overlay.Truncate(item.value(m), max(width/2, 6)), selected, bg, pal)
 	}
 
 	labelColor := pal.Fg
 	if !selected {
 		labelColor = pal.FgDim
 	}
+	// The label yields to the control: the control is the part the row is for.
+	label := overlay.Truncate(item.Label, max(width-lipgloss.Width(control)-3, 1))
 	left := overlay.Style(bg).Foreground(pal.Accent).Bold(true).Render(marker) +
-		overlay.Style(bg).Foreground(labelColor).Bold(selected).Render(item.Label)
+		overlay.Style(bg).Foreground(labelColor).Bold(selected).Render(label)
 
-	gap := max(settingsInnerWidth-lipgloss.Width(left)-lipgloss.Width(control), 1)
+	gap := max(width-lipgloss.Width(left)-lipgloss.Width(control), 1)
 	return left + overlay.Style(bg).Render(strings.Repeat(" ", gap)) + control, control, isBool
 }
 
 // settingsStringControl renders a free-text setting as a bracketed field. An
 // empty value shows the placeholder greyed out; while the row is being edited it
 // shows the live buffer with a trailing cursor.
-func (m *OS) settingsStringControl(item settingItem, selected bool, bg color.Color, pal overlay.Palette) string {
+func (m *OS) settingsStringControl(item settingItem, selected bool, bg color.Color, pal overlay.Palette, width int) string {
 	editing := m.SettingsEditing && selected
 	val := item.value(m)
 	if editing {
@@ -156,7 +185,9 @@ func (m *OS) settingsStringControl(item settingItem, selected bool, bg color.Col
 		text = item.Placeholder
 		fg = pal.FgMute
 	}
-	text = overlay.Truncate(text, 30)
+	// The field never takes more than half the row, so the label it sits beside
+	// keeps something to show even on a narrow panel.
+	text = overlay.Truncate(text, min(30, max(width/2, 6)))
 	if editing {
 		cursor := "▏"
 		if overlay.ASCII {

--- a/internal/app/render_settings.go
+++ b/internal/app/render_settings.go
@@ -27,11 +27,11 @@ var settingsHints = []overlay.Hint{
 
 // settingsLayout returns the fitted inner width and the number of setting rows
 // that fit, given the category tabs (which may wrap onto several rows).
-func (m *OS) settingsLayout(tabs []string, itemCount int) (width, rows int) {
+func (m *OS) settingsLayout(tabs []string, itemCount int) (width, rows int, hints []overlay.Hint) {
 	width = m.panelWidth(settingsInnerWidth)
 	// Body lines that are not setting rows: a blank and the description.
-	rows = m.panelBodyRows(max(itemCount, settingsVisibleRows), 2, width, tabs, settingsHints)
-	return width, rows
+	rows, hints = m.panelBody(max(itemCount, settingsVisibleRows), 2, width, tabs, settingsHints)
+	return width, rows, hints
 }
 
 // renderSettings draws the settings overlay and returns the rendered panel, its
@@ -57,7 +57,7 @@ func (m *OS) renderSettings() (string, overlay.Geometry, []overlayRowHit) {
 		tabs[i] = c.Name
 	}
 
-	width, visible := m.settingsLayout(tabs, len(cat.Items))
+	width, visible, hints := m.settingsLayout(tabs, len(cat.Items))
 	// A category with more settings than fit scrolls; the selection stays in
 	// view so the arrow keys can always reach every setting.
 	m.SettingsScroll = scrollWindow(m.SettingsScroll, m.SettingsSelected, len(cat.Items), visible)
@@ -107,7 +107,7 @@ func (m *OS) renderSettings() (string, overlay.Geometry, []overlayRowHit) {
 		Tabs:      tabs,
 		ActiveTab: m.SettingsCategory,
 		Body:      strings.Join(lines, "\n"),
-		Hints:     settingsHints,
+		Hints:     hints,
 	}
 	content, geo := panel.Render(pal)
 

--- a/internal/app/render_theme_picker.go
+++ b/internal/app/render_theme_picker.go
@@ -9,11 +9,30 @@ import (
 	"github.com/Gaurav-Gosain/tuios/internal/theme"
 )
 
-// Theme picker layout constants.
+// Theme picker layout constants. These are the preferred sizes; a narrower or
+// shorter screen gets a panel fitted to it (see overlay_fit.go).
 const (
 	themePickerInnerWidth  = 52
 	themePickerVisibleRows = 10
 )
+
+// themePickerHints is the theme picker footer, shared by the renderer and the
+// sizing helper so both measure the same panel.
+var themePickerHints = []overlay.Hint{
+	{Key: "type", Label: "filter"},
+	{Key: "↑↓", Label: "preview"},
+	{Key: "⏎", Label: "apply"},
+	{Key: "esc", Label: "cancel"},
+}
+
+// themePickerLayout returns the fitted inner width and visible row count.
+func (m *OS) themePickerLayout() (width, rows int) {
+	width = m.panelWidth(themePickerInnerWidth)
+	// Body lines that are not theme rows: the search input, its rule, and the
+	// count line.
+	rows = m.panelBodyRows(themePickerVisibleRows, 3, width, nil, themePickerHints)
+	return width, rows
+}
 
 // renderThemePicker draws the searchable theme picker with a live color-swatch
 // preview per theme, returning the panel, geometry, and per-row hit rects.
@@ -28,8 +47,8 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 	} else {
 		m.ThemePickerSelected = 0
 	}
-	maxScroll := max(len(items)-themePickerVisibleRows, 0)
-	m.ThemePickerScroll = clampInt(m.ThemePickerScroll, 0, maxScroll)
+	width, visible := m.themePickerLayout()
+	m.ThemePickerScroll = scrollWindow(m.ThemePickerScroll, m.ThemePickerSelected, len(items), visible)
 
 	var lines []string
 
@@ -37,25 +56,25 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 	cursor := overlay.Style(bg).Foreground(pal.Accent).Render("█")
 	search := overlay.Style(bg).Foreground(pal.AccentBright).Bold(true).Render("› ") +
 		overlay.Style(bg).Foreground(pal.Fg).Render(m.ThemePickerQuery) + cursor
-	lines = append(lines, search, overlay.Rule(themePickerInnerWidth, bg, pal))
+	lines = append(lines, search, overlay.Rule(width, bg, pal))
 
 	start := m.ThemePickerScroll
-	end := min(start+themePickerVisibleRows, len(items))
+	end := min(start+visible, len(items))
 	shown := 0
 	for i := start; i < end; i++ {
-		lines = append(lines, m.themeRow(items[i], i == m.ThemePickerSelected, pal))
+		lines = append(lines, m.themeRow(items[i], i == m.ThemePickerSelected, pal, width))
 		shown++
 	}
 	if len(items) == 0 {
 		lines = append(lines, overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  No matching themes"))
 		shown++
 	}
-	for shown < themePickerVisibleRows {
+	for shown < visible {
 		lines = append(lines, overlay.Style(bg).Render(" "))
 		shown++
 	}
 
-	if len(items) > themePickerVisibleRows {
+	if len(items) > visible {
 		info := lipgloss.Sprintf("%d of %d themes", m.ThemePickerSelected+1, len(items))
 		lines = append(lines, overlay.Style(bg).Foreground(pal.FgMute).Italic(true).Render("  "+info))
 	} else {
@@ -65,14 +84,9 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 	panel := overlay.Panel{
 		Glyph: "", // palette
 		Title: "Theme",
-		Width: themePickerInnerWidth,
+		Width: width,
 		Body:  strings.Join(lines, "\n"),
-		Hints: []overlay.Hint{
-			{Key: "type", Label: "filter"},
-			{Key: "↑↓", Label: "preview"},
-			{Key: "⏎", Label: "apply"},
-			{Key: "esc", Label: "cancel"},
-		},
+		Hints: themePickerHints,
 	}
 	content, geo := panel.Render(pal)
 
@@ -89,7 +103,7 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 
 // themeRow renders one theme entry: a name on the left and a color-swatch
 // preview on the right, with a highlight bar when selected.
-func (m *OS) themeRow(id string, selected bool, pal overlay.Palette) string {
+func (m *OS) themeRow(id string, selected bool, pal overlay.Palette, width int) string {
 	bg := pal.Surface
 	nameColor := pal.FgDim
 	marker := "  "
@@ -101,16 +115,17 @@ func (m *OS) themeRow(id string, selected bool, pal overlay.Palette) string {
 
 	swatch := themeSwatchStrip(id, bg)
 	swatchW := lipgloss.Width(swatch)
-
-	name := id
-	nameMax := themePickerInnerWidth - 2 - swatchW - 2
-	if nameMax > 1 {
-		name = overlay.Truncate(name, nameMax)
+	// On a panel too narrow for a name and a swatch strip, the name wins: the
+	// swatch is a preview of something the row already names.
+	if swatchW+8 > width {
+		swatch, swatchW = "", 0
 	}
+
+	name := overlay.Truncate(id, max(width-2-swatchW-2, 1))
 	left := overlay.Style(bg).Foreground(pal.Accent).Bold(true).Render(marker) +
 		overlay.Style(bg).Foreground(nameColor).Bold(selected).Render(name)
 
-	gap := max(themePickerInnerWidth-lipgloss.Width(left)-swatchW, 1)
+	gap := max(width-lipgloss.Width(left)-swatchW, 1)
 	return left + overlay.Style(bg).Render(strings.Repeat(" ", gap)) + swatch
 }
 

--- a/internal/app/render_theme_picker.go
+++ b/internal/app/render_theme_picker.go
@@ -26,12 +26,12 @@ var themePickerHints = []overlay.Hint{
 }
 
 // themePickerLayout returns the fitted inner width and visible row count.
-func (m *OS) themePickerLayout() (width, rows int) {
+func (m *OS) themePickerLayout() (width, rows int, hints []overlay.Hint) {
 	width = m.panelWidth(themePickerInnerWidth)
 	// Body lines that are not theme rows: the search input, its rule, and the
 	// count line.
-	rows = m.panelBodyRows(themePickerVisibleRows, 3, width, nil, themePickerHints)
-	return width, rows
+	rows, hints = m.panelBody(themePickerVisibleRows, 3, width, nil, themePickerHints)
+	return width, rows, hints
 }
 
 // renderThemePicker draws the searchable theme picker with a live color-swatch
@@ -47,7 +47,7 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 	} else {
 		m.ThemePickerSelected = 0
 	}
-	width, visible := m.themePickerLayout()
+	width, visible, hints := m.themePickerLayout()
 	m.ThemePickerScroll = scrollWindow(m.ThemePickerScroll, m.ThemePickerSelected, len(items), visible)
 
 	var lines []string
@@ -86,7 +86,7 @@ func (m *OS) renderThemePicker() (string, overlay.Geometry, []overlayRowHit) {
 		Title: "Theme",
 		Width: width,
 		Body:  strings.Join(lines, "\n"),
-		Hints: themePickerHints,
+		Hints: hints,
 	}
 	content, geo := panel.Render(pal)
 

--- a/internal/app/resize_deferral.go
+++ b/internal/app/resize_deferral.go
@@ -1,0 +1,154 @@
+package app
+
+import "time"
+
+// The deferred half of a resize, and the rule that it can never outlive the
+// gesture that asked for it.
+//
+// A retile that happens while a resize is still in progress places panes
+// directly and resizes them visually only, recording the real size in
+// PendingResizes for later. That is right while the size is still moving: the
+// expensive half (reallocating every emulator's backing store, TIOCSWINSZ,
+// SIGWINCH, the daemon round trip, every guest's full repaint) costs more than
+// a frame and the user is not finished choosing a size yet.
+//
+// It is wrong the moment the gesture ends, and the original design ended it
+// only when a message arrived: ViewportResizeSettledMsg for a terminal resize,
+// mouse release for a drag. Neither is guaranteed. Update recovers panics and
+// returns a nil command when it does, which drops the settle that the very same
+// handler had just armed; the mouse release itself goes missing whenever the
+// pointer leaves the surface the events come from mid-drag, which a browser
+// client does every time. Either way the flag stayed set for the rest
+// of the session, so every retile after it - including the one a new window
+// triggers - took the visual-only branch, no pane ever got its real size, and
+// the layout was left showing whatever rectangles happened to be current.
+//
+// So the deferral is keyed on freshness instead. It holds only while a resize
+// event has arrived recently; past that it expires by itself and drains the
+// work it was holding. Nothing has to arrive for the layout to become correct
+// again. The cost of expiring early during a genuine pause mid-gesture is one
+// retile taking the full path, which is what it would have done anyway had the
+// gesture ended there.
+
+// resizeDeferralTimeout is how long after the last resize event the deferral
+// still counts as live.
+//
+// Comfortably longer than viewportResizeSettleDelay, so the settle message
+// remains the normal way a terminal resize ends and this only acts when that
+// message never comes. Short enough that a lost mouse release is not something
+// the user has to notice: the next retile after half a second is a real one.
+const resizeDeferralTimeout = 500 * time.Millisecond
+
+// resizeDeferralActive reports whether a retile happening now should place
+// panes directly and defer the expensive half.
+//
+// It has a side effect on purpose: finding the deferral stale is the only
+// reliable moment to end it, so it ends it, and drains what was deferred. Call
+// it once per retile rather than per pane.
+func (m *OS) resizeDeferralActive() bool {
+	if !m.Resizing && !m.viewportResizing {
+		return false
+	}
+
+	now := time.Now()
+	fresh := false
+	if m.Resizing && !m.lastPointerAt.IsZero() && now.Sub(m.lastPointerAt) <= resizeDeferralTimeout {
+		fresh = true
+	}
+	if m.viewportResizing && !m.viewportResizeAt.IsZero() && now.Sub(m.viewportResizeAt) <= resizeDeferralTimeout {
+		fresh = true
+	}
+	if fresh {
+		return true
+	}
+
+	m.endResizeDeferral()
+	return false
+}
+
+// endResizeDeferral finishes a deferred resize now: the recorded sizes are
+// pushed through to the emulators, the PTYs and the daemon, and the next retile
+// lays panes out for real.
+//
+// m.Resizing is left alone. It belongs to the mouse handlers and describes
+// whether a button is down, which is not this function's business; with the
+// timestamp stale the deferral stays off until a fresh resize step refreshes
+// it, and a gesture that resumes simply re-enters the deferral.
+func (m *OS) endResizeDeferral() {
+	m.viewportResizing = false
+	m.renderSkipped = false
+	m.ApplyPendingResizes()
+}
+
+// noteResizeStep records that a resize event just arrived, which is what keeps
+// the deferral alive.
+func (m *OS) noteResizeStep(at time.Time) {
+	m.viewportResizeAt = at
+}
+
+// notePointerEvent records that a mouse event just arrived. A resize drag is
+// only live while the pointer is still reporting.
+func (m *OS) notePointerEvent(at time.Time) {
+	m.lastPointerAt = at
+}
+
+// requireRealLayout ends any deferred resize before a structural change to the
+// layout - a window opening, closing or splitting, tiling being toggled, a
+// layout being loaded. Those are not resize steps, and their result is what the
+// user is left looking at, so they must never be laid out visually-only and
+// left for a message that may not come.
+func (m *OS) requireRealLayout() {
+	if m.viewportResizing || len(m.PendingResizes) > 0 {
+		m.endResizeDeferral()
+	}
+}
+
+// endLostGesture retires a drag or resize whose release never arrived.
+//
+// It does what mouse release does minus the parts that need the release's own
+// coordinates: the gesture is over, the panes keep the geometry the last motion
+// gave them, and the deferred resizes are pushed through. The alternative is a
+// gesture that never ends, and that is not merely a stuck flag - while it is
+// set, MarkTerminalsWithNewContent refuses to look at any pane, so no window
+// shows another byte of output for the rest of the session.
+func (m *OS) endLostGesture() {
+	wasResizing := m.Resizing
+	m.Dragging = false
+	m.Resizing = false
+	m.InteractionMode = false
+	m.DraggedWindowIndex = -1
+
+	m.endResizeDeferral()
+	m.clearStaleManipulation()
+
+	// A resize drag is what the BSP tree derives its ratios from; without this
+	// the next retile discards everything the drag did.
+	if wasResizing && m.AutoTiling && !m.UseScrollingLayout {
+		m.SyncBSPTreeFromGeometry()
+	}
+	m.renderSkipped = false
+}
+
+// clearStaleManipulation drops IsBeingManipulated from any window still
+// carrying it while no drag or resize is in progress.
+//
+// The flag freezes a pane's content at its last cached frame, which is right
+// for a pane the pointer is moving and is silent, total corruption once the
+// gesture is over: the pane keeps drawing a screenshot of itself and never
+// shows another byte of output. Mouse release clears it, and mouse release is
+// exactly the event that is lost when the pointer leaves the surface the events
+// come from. Outside a gesture no window should carry it, so this is a safe
+// sweep rather than a guess.
+func (m *OS) clearStaleManipulation() {
+	if m.Dragging || m.Resizing || m.InteractionMode {
+		return
+	}
+	for _, w := range m.Windows {
+		if w == nil || !w.IsBeingManipulated {
+			continue
+		}
+		w.IsBeingManipulated = false
+		w.MarkContentDirty()
+		w.InvalidateCache()
+	}
+}

--- a/internal/app/resize_deferral_test.go
+++ b/internal/app/resize_deferral_test.go
@@ -1,0 +1,261 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// The deferred half of a resize used to be ended only by a message arriving.
+// These tests pin the property that replaced that: the deferral expires on its
+// own, so no dropped, superseded or never-armed message can leave the layout
+// permanently half-applied.
+
+func newDeferralOS(t *testing.T, width, height, windows int) *OS {
+	t.Helper()
+
+	prevAnim := config.AnimationsEnabled
+	config.AnimationsEnabled = false
+	t.Cleanup(func() { config.AnimationsEnabled = prevAnim })
+
+	m := &OS{
+		NumWorkspaces:    9,
+		CurrentWorkspace: 1,
+		WorkspaceFocus:   make(map[int]int),
+		PendingResizes:   make(map[string][2]int),
+		Width:            width,
+		Height:           height,
+		AutoTiling:       true,
+		UseBSPLayout:     true,
+		FocusedWindow:    0,
+	}
+	for i := range windows {
+		m.Windows = append(m.Windows, newDeferralWindow(t, fmt.Sprintf("win-%036d", i+1)))
+	}
+	m.TileAllWindows()
+	return m
+}
+
+// newDeferralWindow builds a window with a live emulator. A bare
+// terminal.Window is not enough here: Window.Resize returns early when Terminal
+// is nil, so the real (non-deferred) layout path would leave such a window at
+// its construction size and the test could not tell the two branches apart.
+func newDeferralWindow(t *testing.T, id string) *terminal.Window {
+	t.Helper()
+	ptyDataChan := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ptyDataChan:
+			case <-done:
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() { close(done) })
+
+	win := terminal.NewDaemonWindow(id, "test", 0, 0, 10, 5, 0, "pty-"+id, ptyDataChan)
+	if win == nil {
+		t.Fatal("NewDaemonWindow returned nil")
+	}
+	win.Workspace = 1
+	t.Cleanup(func() { win.Close() })
+	return win
+}
+
+// tiledRects returns the geometry of the panes that should be partitioning the
+// screen right now.
+func tiledRects(m *OS) []*terminal.Window {
+	var out []*terminal.Window
+	for _, w := range m.Windows {
+		if w.Workspace == m.CurrentWorkspace && !w.Minimized && !w.IsFloating {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func assertNoOverlap(t *testing.T, m *OS, when string) {
+	t.Helper()
+	wins := tiledRects(m)
+	for i := range wins {
+		for j := i + 1; j < len(wins); j++ {
+			a, b := wins[i], wins[j]
+			ox := min(a.X+a.Width, b.X+b.Width) - max(a.X, b.X)
+			oy := min(a.Y+a.Height, b.Y+b.Height) - max(a.Y, b.Y)
+			if ox > 0 && oy > 0 {
+				t.Errorf("%s: %s (%d,%d %dx%d) overlaps %s (%d,%d %dx%d) by %dx%d",
+					when, a.ID, a.X, a.Y, a.Width, a.Height,
+					b.ID, b.X, b.Y, b.Width, b.Height, ox, oy)
+			}
+		}
+	}
+}
+
+// TestDroppedSettleDoesNotWedgeTheLayout is the regression test for the
+// reported defect: tiled mode showing panes at stale, overlapping positions.
+//
+// A terminal resize sets viewportResizing and arms a settle to clear it. If
+// that settle never arrives - Update recovers a panic and returns a nil
+// command, taking the settle with it, or the message is otherwise lost - the
+// flag used to stay set for the rest of the session. Every later retile then
+// took the "place directly, resize visually only" branch and recorded its work
+// in PendingResizes for a drain that would never happen, so no pane ever got a
+// real size again.
+func TestDroppedSettleDoesNotWedgeTheLayout(t *testing.T) {
+	m := newDeferralOS(t, 120, 40, 2)
+
+	// A terminal resize arrives and its settle is dropped on the floor.
+	m.Width, m.Height = 100, 30
+	m.viewportResizing = true
+	m.viewportResizeGen++
+	m.noteResizeStep(time.Now())
+	m.TileAllWindows()
+
+	if !m.viewportResizing {
+		t.Fatal("deferral should be live immediately after a resize")
+	}
+
+	// Nothing clears it. Time passes, as it does when the settle never comes.
+	m.noteResizeStep(time.Now().Add(-2 * resizeDeferralTimeout))
+	m.lastPointerAt = time.Now().Add(-2 * resizeDeferralTimeout)
+
+	// The next thing the user does is open a window.
+	w := newDeferralWindow(t, "win-00000000000000000000000000000new")
+	m.Windows = append(m.Windows, w)
+	m.AddWindowToBSPTree(w)
+
+	if m.viewportResizing {
+		t.Error("viewportResizing still set after a structural layout change")
+	}
+	if len(m.PendingResizes) != 0 {
+		t.Errorf("PendingResizes still holds %d entries; the deferred work was never drained", len(m.PendingResizes))
+	}
+	assertNoOverlap(t, m, "after opening a window on a wedged deferral")
+
+	// And the panes really cover the screen, rather than sitting wherever the
+	// pre-resize layout had left them.
+	for _, win := range tiledRects(m) {
+		if win.Width <= 0 || win.Height <= 0 {
+			t.Errorf("%s has degenerate size %dx%d", win.ID, win.Width, win.Height)
+		}
+		if win.X+win.Width > m.GetRenderWidth()+1 {
+			t.Errorf("%s (x=%d w=%d) overruns the %d-column viewport", win.ID, win.X, win.Width, m.GetRenderWidth())
+		}
+	}
+}
+
+// TestResizeDeferralExpires pins the timeout itself: a deferral whose last
+// resize event is older than resizeDeferralTimeout is not live, and asking
+// drains what it was holding.
+func TestResizeDeferralExpires(t *testing.T) {
+	m := newDeferralOS(t, 120, 40, 2)
+
+	m.viewportResizing = true
+	m.noteResizeStep(time.Now())
+	if !m.resizeDeferralActive() {
+		t.Fatal("a deferral with a fresh resize step should be active")
+	}
+
+	m.PendingResizes["win-"+"000000000000000000000000000000001"] = [2]int{40, 20}
+	m.noteResizeStep(time.Now().Add(-resizeDeferralTimeout - time.Millisecond))
+	if m.resizeDeferralActive() {
+		t.Error("a deferral whose last resize step is older than the timeout should be dead")
+	}
+	if m.viewportResizing {
+		t.Error("expiring the deferral should have cleared viewportResizing")
+	}
+	if len(m.PendingResizes) != 0 {
+		t.Error("expiring the deferral should have drained PendingResizes")
+	}
+}
+
+// TestLostMouseReleaseDoesNotFreezePaneContent covers the other half of the
+// same class: a drag whose release is lost (a browser pointer that left the
+// tab) leaves IsBeingManipulated set, and that flag makes a pane render its
+// cached frame forever.
+func TestLostMouseReleaseDoesNotFreezePaneContent(t *testing.T) {
+	m := newDeferralOS(t, 120, 40, 2)
+
+	m.Dragging = true
+	m.InteractionMode = true
+	m.Windows[0].IsBeingManipulated = true
+
+	// While the gesture is live the flag is left alone.
+	m.clearStaleManipulation()
+	if !m.Windows[0].IsBeingManipulated {
+		t.Fatal("manipulation flag cleared while a drag was still in progress")
+	}
+
+	// The release never arrives, but the input layer eventually notices the
+	// pointer is gone and the drag ends. Nothing clears the per-window flag.
+	m.Dragging = false
+	m.InteractionMode = false
+
+	m.clearStaleManipulation()
+	if m.Windows[0].IsBeingManipulated {
+		t.Error("IsBeingManipulated still set with no drag or resize in progress")
+	}
+	if !m.Windows[0].ContentDirty {
+		t.Error("the pane was not marked dirty, so it would keep serving its cached frame")
+	}
+}
+
+// TestSettleClearsDeferralRegardlessOfFlagState guards the handler itself: the
+// settle for the newest resize generation ends the deferral whatever state the
+// bookkeeping flag happens to be in, and a settle from a superseded generation
+// leaves the live one alone.
+func TestSettleClearsDeferralRegardlessOfFlagState(t *testing.T) {
+	m := newDeferralOS(t, 120, 40, 2)
+	m.viewportResizeGen = 7
+	m.viewportResizing = true
+	m.noteResizeStep(time.Now())
+	m.PendingResizes["win-"+"000000000000000000000000000000001"] = [2]int{40, 20}
+
+	// A stale settle must not end a storm that is still in progress.
+	_, _ = m.Update(ViewportResizeSettledMsg{Gen: 6})
+	if !m.viewportResizing {
+		t.Error("a superseded settle ended the live deferral")
+	}
+	if len(m.PendingResizes) == 0 {
+		t.Error("a superseded settle drained the deferred work early")
+	}
+
+	// The current one always does.
+	_, _ = m.Update(ViewportResizeSettledMsg{Gen: 7})
+	if m.viewportResizing {
+		t.Error("the current settle did not clear viewportResizing")
+	}
+	if len(m.PendingResizes) != 0 {
+		t.Error("the current settle did not drain PendingResizes")
+	}
+}
+
+// TestWindowSizeMsgAlwaysArmsAndTimestampsTheDeferral makes sure the resize
+// handler records the timestamp the expiry depends on. Without it the deferral
+// would be judged stale on the very next retile and the coalescing this whole
+// mechanism exists for would be gone.
+func TestWindowSizeMsgAlwaysArmsAndTimestampsTheDeferral(t *testing.T) {
+	m := newDeferralOS(t, 120, 40, 2)
+
+	before := time.Now()
+	_, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	if cmd == nil {
+		t.Fatal("a resize must arm a settle")
+	}
+	if !m.viewportResizing {
+		t.Fatal("a resize must start the deferral")
+	}
+	if m.viewportResizeAt.Before(before) {
+		t.Fatal("a resize must record when it arrived")
+	}
+	if !m.resizeDeferralActive() {
+		t.Fatal("the deferral should be live right after a resize")
+	}
+}

--- a/internal/app/showkeys.go
+++ b/internal/app/showkeys.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // CaptureKeyEvent captures a keyboard event for the showkeys overlay.
@@ -185,10 +186,35 @@ func (m *OS) CleanupExpiredKeys(timeout time.Duration) {
 	}
 }
 
+// renderShowkeysFitted renders the showkeys strip, dropping the oldest keys
+// until it fits in maxWidth cells. The strip is anchored to the right edge, so
+// an over-wide strip would otherwise start off the left edge of the screen with
+// its first pills unreadable.
+func (m *OS) renderShowkeysFitted(maxWidth int) string {
+	out := m.renderShowkeys()
+	if maxWidth <= 0 || lipgloss.Width(out) <= maxWidth {
+		return out
+	}
+	keys := m.RecentKeys
+	for len(keys) > 1 && lipgloss.Width(out) > maxWidth {
+		keys = keys[1:]
+		out = renderShowkeysFrom(keys)
+	}
+	if lipgloss.Width(out) > maxWidth {
+		out = ansi.Truncate(out, maxWidth, "")
+	}
+	return out
+}
+
 // renderShowkeys renders the showkeys overlay with styled key display.
 // Returns the rendered content as a styled lipgloss string.
 func (m *OS) renderShowkeys() string {
-	if len(m.RecentKeys) == 0 {
+	return renderShowkeysFrom(m.RecentKeys)
+}
+
+// renderShowkeysFrom renders a specific run of key events as the pill strip.
+func renderShowkeysFrom(recentKeys []KeyEvent) string {
+	if len(recentKeys) == 0 {
 		return ""
 	}
 
@@ -223,7 +249,7 @@ func (m *OS) renderShowkeys() string {
 
 	var renderedKeys []string
 
-	for _, keyEvent := range m.RecentKeys {
+	for _, keyEvent := range recentKeys {
 		var keyStr string
 		var modifierStr string
 

--- a/internal/app/tape_review.go
+++ b/internal/app/tape_review.go
@@ -243,16 +243,24 @@ func (r *TapeReviewState) tapeContentLines() []string {
 	return strings.Split(strings.ReplaceAll(string(r.Content), "\t", "    "), "\n")
 }
 
+// tapeReviewRows is how many lines of the tape the dialog shows on the screen
+// it is actually drawn on: the preferred viewport, or fewer when the screen is
+// short. The header, the content box's own frame and the footer come off first.
+func (m *OS) tapeReviewRows() int {
+	return m.dialogRows(tapeReviewViewportRows, 14)
+}
+
 // tapeReviewMaxScroll is the furthest the content can scroll.
 func (m *OS) tapeReviewMaxScroll() int {
 	if m.TapeReview == nil {
 		return 0
 	}
 	n := len(m.TapeReview.tapeContentLines())
-	if n <= tapeReviewViewportRows {
+	rows := m.tapeReviewRows()
+	if n <= rows {
 		return 0
 	}
-	return n - tapeReviewViewportRows
+	return n - rows
 }
 
 // RenderTapeReview renders the review/trust dialog box. The caller centers it.
@@ -270,16 +278,22 @@ func (m *OS) RenderTapeReview() string {
 	codeStyle := lipgloss.NewStyle().Foreground(theme.WelcomeText())
 	warnStyle := lipgloss.NewStyle().Foreground(theme.NotificationWarning())
 
+	// The dialog is content-sized, so its longest line decides its width; every
+	// line is built against what the screen can hold.
+	textW := m.dialogTextWidth()
+	rows := m.tapeReviewRows()
+
 	var lines []string
 	lines = append(lines, titleStyle.Render("Project Tape"))
 	lines = append(lines, "")
 
-	// Header: path + trust status.
-	lines = append(lines, labelStyle.Render("Path:  ")+pathStyle.Render(shortTapePath(r.Path)))
+	// Header: path + trust status. A long path keeps its tail, which is the
+	// part that says which project this is.
+	lines = append(lines, labelStyle.Render("Path:  ")+pathStyle.Render(tailFit(shortTapePath(r.Path), max(textW-7, 1))))
 	lines = append(lines, labelStyle.Render("Trust: ")+tapeStatusLabel(r.Status, r.Changed))
 
 	// What running it will do, from a cheap header parse (no execution).
-	lines = append(lines, labelStyle.Render("Runs:  ")+pathStyle.Render(tapeRunSummary(r.Header, r.Dir)))
+	lines = append(lines, labelStyle.Render("Runs:  ")+pathStyle.Render(truncateString(tapeRunSummary(r.Header, r.Dir), max(textW-7, 1))))
 	if r.Status == trust.StatusIneligible && r.Reason != "" {
 		lines = append(lines, warnStyle.Render("Ignored: "+r.Reason))
 	}
@@ -289,28 +303,30 @@ func (m *OS) RenderTapeReview() string {
 	if r.Status != trust.StatusIneligible {
 		content := r.tapeContentLines()
 		start := min(r.Scroll, m.tapeReviewMaxScroll())
-		end := min(start+tapeReviewViewportRows, len(content))
+		end := min(start+rows, len(content))
 		box := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(theme.HelpBorder()).
 			Padding(0, 1)
 		var body []string
+		// The content box adds a border and a column of padding on each side.
+		lineW := min(72, max(textW-4, 8))
 		for i := start; i < end; i++ {
-			body = append(body, codeStyle.Render(truncateString(content[i], 72)))
+			body = append(body, codeStyle.Render(truncateString(content[i], lineW)))
 		}
 		if len(body) == 0 {
 			body = append(body, dimStyle.Render("(empty)"))
 		}
 		lines = append(lines, box.Render(strings.Join(body, "\n")))
-		if len(content) > tapeReviewViewportRows {
+		if len(content) > rows {
 			lines = append(lines, dimStyle.Render(fmt.Sprintf("lines %d-%d of %d  (↑/↓ scroll)", start+1, end, len(content))))
 		}
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, dimStyle.Render(tapeReviewFooter(r, keyStyle, dimStyle)))
+	lines = append(lines, dimStyle.Render(tapeReviewFooter(r, keyStyle, dimStyle, textW)))
 
-	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	content := clipStyledLines(lipgloss.JoinVertical(lipgloss.Left, lines...), textW)
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(theme.HelpBorder()).
@@ -320,20 +336,51 @@ func (m *OS) RenderTapeReview() string {
 }
 
 // tapeReviewFooter builds the action hint line for the dialog's current status.
-func tapeReviewFooter(r *TapeReviewState, keyStyle, dimStyle lipgloss.Style) string {
+func tapeReviewFooter(r *TapeReviewState, keyStyle, dimStyle lipgloss.Style, width int) string {
+	var full, short string
 	switch r.Status {
 	case trust.StatusIneligible:
-		return keyStyle.Render("Esc") + " Dismiss"
+		full = keyStyle.Render("Esc") + " Dismiss"
+		short = full
 	case trust.StatusTrusted:
-		return keyStyle.Render("r") + " Run   " +
+		full = keyStyle.Render("r") + " Run   " +
 			keyStyle.Render("n") + " Revoke trust   " +
 			keyStyle.Render("Esc") + " Close"
+		short = keyStyle.Render("r") + " Run   " +
+			keyStyle.Render("n") + " Revoke   " +
+			keyStyle.Render("Esc") + " Close"
 	default:
-		return keyStyle.Render("r") + " Run once   " +
+		full = keyStyle.Render("r") + " Run once   " +
 			keyStyle.Render("t") + " Trust and run   " +
 			keyStyle.Render("n") + " Never   " +
 			keyStyle.Render("Esc") + " Not now"
+		short = keyStyle.Render("r") + " Run   " +
+			keyStyle.Render("t") + " Trust   " +
+			keyStyle.Render("n") + " Never   " +
+			keyStyle.Render("Esc") + " Close"
 	}
+	// The actions are the point of the dialog, so a narrow screen gets shorter
+	// labels rather than fewer keys.
+	if lipgloss.Width(full) > width {
+		return short
+	}
+	return full
+}
+
+// tailFit shortens s from the left, keeping its last width cells behind an
+// ellipsis. Paths read from the right.
+func tailFit(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width <= 3 {
+		return string(runes[len(runes)-width:])
+	}
+	return "..." + string(runes[len(runes)-(width-3):])
 }
 
 // tapeStatusLabel renders a colored trust-status word for the dialog header.

--- a/internal/app/tapemanager.go
+++ b/internal/app/tapemanager.go
@@ -432,6 +432,10 @@ func (m *OS) RenderTapeManager() string {
 		Foreground(theme.HelpKeyBadge()).
 		Bold(true)
 
+	// The dialog is content-sized, so every line has to be built against what
+	// the screen can hold rather than against a comfortable desktop width.
+	textW := m.dialogTextWidth()
+
 	// Build content based on mode
 	var lines []string
 
@@ -453,8 +457,8 @@ func (m *OS) RenderTapeManager() string {
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(theme.HelpBorder()).
 			Padding(0, 1).
-			Width(40)
-		lines = append(lines, inputStyle.Render(m.TapeManager.NameBuffer+"█"))
+			Width(min(40, textW))
+		lines = append(lines, inputStyle.Render(truncateString(m.TapeManager.NameBuffer, max(textW-4, 1))+"█"))
 		lines = append(lines, "")
 		lines = append(lines, dimStyle.Render(keyStyle.Render("Enter")+" Confirm  "+keyStyle.Render("Esc")+" Cancel"))
 
@@ -486,7 +490,7 @@ func (m *OS) RenderTapeManager() string {
 			lines = append(lines, "")
 
 			// Calculate visible range
-			maxVisible := tapeManagerVisibleRows
+			maxVisible := m.dialogRows(tapeManagerVisibleRows, 10)
 			startIdx := m.TapeManager.ScrollOffset
 			endIdx := min(startIdx+maxVisible, len(m.TapeManager.Files))
 
@@ -496,7 +500,14 @@ func (m *OS) RenderTapeManager() string {
 				// Format file info
 				sizeStr := formatFileSize(file.Size)
 				timeStr := file.Modified.Format("Jan 02 15:04")
-				info := fmt.Sprintf("%-20s %8s  %s", truncateString(file.Name, 20), sizeStr, timeStr)
+				// The name column gives way first, then the timestamp: a row
+				// that keeps its full name at the cost of the screen edge is
+				// not a row anyone can read.
+				nameW := clampInt(textW-26, 6, 20)
+				info := fmt.Sprintf("%-*s %8s  %s", nameW, truncateString(file.Name, nameW), sizeStr, timeStr)
+				if textW < nameW+24 {
+					info = fmt.Sprintf("%-*s %8s", nameW, truncateString(file.Name, nameW), sizeStr)
+				}
 
 				if i == m.TapeManager.SelectedIndex {
 					lines = append(lines, selectedStyle.Render(config.TapeSelectedIcon+" "+info))
@@ -515,15 +526,23 @@ func (m *OS) RenderTapeManager() string {
 
 		// Controls
 		lines = append(lines, "")
-		lines = append(lines, dimStyle.Render(
-			keyStyle.Render("↑/↓")+" Select  "+
-				keyStyle.Render("Enter")+" Play  "+
-				keyStyle.Render("r")+" Record  "+
-				keyStyle.Render("d")+" Delete  "+
-				keyStyle.Render("Esc")+" Close"))
+		controls := keyStyle.Render("↑/↓") + " Select  " +
+			keyStyle.Render("Enter") + " Play  " +
+			keyStyle.Render("r") + " Record  " +
+			keyStyle.Render("d") + " Delete  " +
+			keyStyle.Render("Esc") + " Close"
+		if lipgloss.Width(controls) > textW {
+			// A narrow dialog gets the same actions under shorter labels.
+			controls = keyStyle.Render("↑↓") + " Sel  " +
+				keyStyle.Render("⏎") + " Play  " +
+				keyStyle.Render("r") + " Rec  " +
+				keyStyle.Render("d") + " Del  " +
+				keyStyle.Render("Esc") + " Close"
+		}
+		lines = append(lines, dimStyle.Render(controls))
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	content := clipStyledLines(lipgloss.JoinVertical(lipgloss.Left, lines...), textW)
 
 	// Create bordered box
 	boxStyle := lipgloss.NewStyle().

--- a/internal/app/tapemanager.go
+++ b/internal/app/tapemanager.go
@@ -542,6 +542,7 @@ func (m *OS) RenderTapeManager() string {
 		lines = append(lines, dimStyle.Render(controls))
 	}
 
+	lines = squeezeLines(lines, m.dialogContentRows())
 	content := clipStyledLines(lipgloss.JoinVertical(lipgloss.Left, lines...), textW)
 
 	// Create bordered box

--- a/internal/app/theme_picker.go
+++ b/internal/app/theme_picker.go
@@ -84,7 +84,7 @@ func (m *OS) ThemePickerMove(delta int) {
 		return
 	}
 	m.ThemePickerSelected = clampInt(m.ThemePickerSelected+delta, 0, len(items)-1)
-	_, visible := m.themePickerLayout()
+	_, visible, _ := m.themePickerLayout()
 	if m.ThemePickerSelected < m.ThemePickerScroll {
 		m.ThemePickerScroll = m.ThemePickerSelected
 	}

--- a/internal/app/theme_picker.go
+++ b/internal/app/theme_picker.go
@@ -84,11 +84,12 @@ func (m *OS) ThemePickerMove(delta int) {
 		return
 	}
 	m.ThemePickerSelected = clampInt(m.ThemePickerSelected+delta, 0, len(items)-1)
+	_, visible := m.themePickerLayout()
 	if m.ThemePickerSelected < m.ThemePickerScroll {
 		m.ThemePickerScroll = m.ThemePickerSelected
 	}
-	if m.ThemePickerSelected >= m.ThemePickerScroll+themePickerVisibleRows {
-		m.ThemePickerScroll = m.ThemePickerSelected - themePickerVisibleRows + 1
+	if m.ThemePickerSelected >= m.ThemePickerScroll+visible {
+		m.ThemePickerScroll = m.ThemePickerSelected - visible + 1
 	}
 	// Live preview.
 	m.applyTheme(items[m.ThemePickerSelected])

--- a/internal/app/tiling.go
+++ b/internal/app/tiling.go
@@ -60,6 +60,10 @@ func (m *OS) TileAllWindows() {
 
 	m.LogInfo("TileAllWindows called with %d visible windows, BSP=%v, Scrolling=%v", len(visibleWindows), m.UseBSPLayout, m.UseScrollingLayout)
 
+	// Ends a deferral whose gesture is over, so the master-stack branch below
+	// and ApplyBSPLayout further down agree about which path they are on.
+	deferring := m.resizeDeferralActive()
+
 	// Scrolling layout mode (niri-like)
 	if m.UseScrollingLayout {
 		sl := m.GetOrCreateScrollingLayout()
@@ -79,7 +83,14 @@ func (m *OS) TileAllWindows() {
 				// Set Tiled before Resize so the border deduction (and therefore
 				// the emulator size) matches the shared-borders state.
 				visibleWindows[i].Tiled = config.SharedBorders
-				visibleWindows[i].Resize(l.Width, l.Height)
+				// Mid-resize the PTY round trip is deferred, exactly as the BSP
+				// path does it; ViewportResizeSettledMsg drains PendingResizes.
+				if deferring {
+					visibleWindows[i].ResizeVisual(l.Width, l.Height)
+					m.PendingResizes[visibleWindows[i].ID] = [2]int{l.Width, l.Height}
+				} else {
+					visibleWindows[i].Resize(l.Width, l.Height)
+				}
 				visibleWindows[i].InvalidateCache()
 			}
 		}
@@ -176,6 +187,10 @@ func (m *OS) TileAllWindows() {
 
 // ToggleAutoTiling toggles automatic tiling mode
 func (m *OS) ToggleAutoTiling() {
+	// Switching mode is structural: the layout it lands on is final, not a step
+	// on the way to a size the user is still choosing.
+	m.requireRealLayout()
+
 	m.AutoTiling = !m.AutoTiling
 	// Deferred because the enabling branch returns early for scrolling mode.
 	defer m.FireLayoutChanged()

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -120,6 +120,10 @@ func (m *OS) ApplyBSPLayout() {
 	bounds := m.GetBSPBounds()
 	layouts := tree.ApplyLayout(bounds)
 
+	// Asked once for the whole layout, not per pane: it is what decides between
+	// the two branches below, and it ends a stale deferral as a side effect.
+	deferring := m.resizeDeferralActive()
+
 	for windowIntID, rect := range layouts {
 		win := m.getWindowByIntID(windowIntID)
 		if win == nil || win.Workspace != m.CurrentWorkspace || win.Minimized || win.IsFloating {
@@ -149,7 +153,19 @@ func (m *OS) ApplyBSPLayout() {
 		// per frame for a size the user is still in the middle of choosing.
 		// Resize visually instead and record it in PendingResizes, which mouse
 		// release already drains into one real resize per window.
-		if m.Resizing {
+		// A terminal resize is the same kind of event, one step removed: the
+		// browser or the terminal emulator delivers a size per frame for as long
+		// as the user drags the window edge, and easing toward each one built a
+		// fresh 300ms snap per pane per step. The panes were still easing when
+		// the next size arrived, so they never arrived anywhere, and after the
+		// pointer stopped the layout kept moving for the rest of the last
+		// animation - which is exactly the catch-up a drag feels like. The size
+		// is not a destination to travel to; it is where the panes already are.
+		//
+		// Only while the resize is actually live, though. See
+		// resize_deferral.go: a deferral that outlives its gesture leaves every
+		// later retile placing panes visually and never giving them a real size.
+		if deferring {
 			win.X, win.Y = rect.X, rect.Y
 			if win.Tiled != config.SharedBorders {
 				win.Tiled = config.SharedBorders
@@ -157,7 +173,13 @@ func (m *OS) ApplyBSPLayout() {
 			}
 			if win.Width != rect.W || win.Height != rect.H {
 				win.ResizeVisual(rect.W, rect.H)
-				win.IsBeingManipulated = true
+				// IsBeingManipulated freezes a pane's content at its cached
+				// frame, which is right for a pane the pointer is dragging and
+				// wrong for a terminal resize: nothing is being manipulated, and
+				// the panes should keep drawing their live contents.
+				if m.Resizing {
+					win.IsBeingManipulated = true
+				}
 				m.PendingResizes[win.ID] = [2]int{rect.W, rect.H}
 			}
 			win.MarkPositionDirty()
@@ -215,6 +237,11 @@ func (m *OS) CancelSnapAnimation(win *terminal.Window) {
 // AddWindowToBSPTree adds a window to the BSP tree and applies the layout.
 // This should be called when a new window is created in tiling mode.
 func (m *OS) AddWindowToBSPTree(window *terminal.Window) {
+	// A new pane is a structural change, not a resize step. Whatever resize was
+	// in flight, the layout this produces is what the user is left looking at,
+	// so it has to be a real one.
+	m.requireRealLayout()
+
 	tree := m.GetOrCreateBSPTree()
 	windowIntID := m.getWindowIntID(window.ID)
 
@@ -264,6 +291,10 @@ func (m *OS) AddWindowToBSPTree(window *terminal.Window) {
 // RemoveWindowFromBSPTree removes a window from the BSP tree and reapplies the layout.
 // This should be called when a window is closed in tiling mode.
 func (m *OS) RemoveWindowFromBSPTree(window *terminal.Window) {
+	// Closing a pane is structural too; the panes that inherit its space must
+	// end up at real sizes. See AddWindowToBSPTree.
+	m.requireRealLayout()
+
 	tree := m.WorkspaceTrees[m.CurrentWorkspace]
 	if tree == nil {
 		return

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -361,6 +361,29 @@ func EnableCallbacksAfterDelay() tea.Cmd {
 	})
 }
 
+// viewportResizeSettleDelay is how long the model waits for a terminal-resize
+// storm to stop before it does the expensive half of a resize.
+//
+// Long enough that a drag of the terminal's own edge, which delivers one size
+// per frame for as long as the pointer is down, never pays it mid-gesture;
+// short enough that letting go feels immediate.
+const viewportResizeSettleDelay = 120 * time.Millisecond
+
+// ViewportResizeSettledMsg says no new terminal size has arrived for
+// [viewportResizeSettleDelay], so the sizes recorded during the storm can be
+// pushed through to the emulators, the PTYs and the daemon.
+type ViewportResizeSettledMsg struct {
+	// Gen is the resize generation this settle was armed for. A later resize
+	// bumps the generation, which retires every settle already in flight.
+	Gen uint64
+}
+
+func viewportResizeSettleCmd(gen uint64) tea.Cmd {
+	return tea.Tick(viewportResizeSettleDelay, func(time.Time) tea.Msg {
+		return ViewportResizeSettledMsg{Gen: gen}
+	})
+}
+
 // TriggerAltScreenRedrawMsg triggers alt screen apps to redraw.
 type TriggerAltScreenRedrawMsg struct{}
 
@@ -482,6 +505,13 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// dirties the model after that, so the wrong frame is final.
 		hadAnimations := m.HasActiveAnimations()
 		m.UpdateAnimations()
+
+		// Retire interaction state no gesture is holding any more. A mouse
+		// release is the only thing that clears IsBeingManipulated, and it is
+		// lost whenever the pointer leaves the surface the events come from
+		// mid-drag; the pane it was set on then renders its cached frame
+		// forever.
+		m.clearStaleManipulation()
 
 		// Update system info (only when explicitly enabled)
 		if config.ShowCPU {
@@ -695,6 +725,27 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		tea.PasteMsg, tea.PasteStartMsg, tea.PasteEndMsg:
 		// Reset idle counter on any user input to restore full tick rate
 		m.idleFrames = 0
+		// A resize drag is live only while the pointer is still reporting. This
+		// is what lets the deferral in resize_deferral.go expire when a mouse
+		// release is lost, without a timeout that would cut short a slow drag:
+		// any further motion refreshes it.
+		switch mm := msg.(type) {
+		case tea.MouseClickMsg, tea.MouseReleaseMsg, tea.MouseWheelMsg:
+			m.notePointerEvent(time.Now())
+		case tea.MouseMotionMsg:
+			m.notePointerEvent(time.Now())
+			// Motion with no button held while a drag is supposedly in
+			// progress means the release happened somewhere we never heard
+			// about, which is what a pointer leaving the surface the events
+			// come from does: the button comes up out of reach and what comes
+			// back is motion reporting no buttons. Left alone the pane stays
+			// glued to the pointer and is dragged around a tiled layout with
+			// nothing pressed, which is exactly how tiled panes end up at
+			// overlapping positions.
+			if (m.Dragging || m.Resizing) && mm.Button == tea.MouseNone {
+				m.endLostGesture()
+			}
+		}
 		// Any user input must produce a fresh frame. Without this a tick that
 		// marked the frame skippable would make View return the cached content,
 		// so state changed by this event (overlay selection, drag offset, etc.)
@@ -734,6 +785,22 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		m.Width = msg.Width
 		m.Height = msg.Height
 		m.MarkAllDirty()
+		// A resize is drawn immediately and finished later. Everything below
+		// lays the panes out at the new size; the expensive half - resizing each
+		// emulator's backing store for real, telling the PTY and the daemon,
+		// and asking every guest to redraw - waits until the sizes stop
+		// arriving. Without this a drag of the terminal's own edge pays that
+		// whole bill once per delivered size.
+		m.viewportResizing = true
+		m.renderSkipped = false
+		m.viewportResizeGen++
+		// The timestamp, not the flag, is what keeps the deferral alive. The
+		// settle below is the normal way it ends; noteResizeStep is what makes
+		// sure it ends at all if the settle never arrives - which it does not
+		// when a panic in this handler is recovered, since the recovery returns
+		// a nil command and takes the settle with it.
+		m.noteResizeStep(time.Now())
+		settle := viewportResizeSettleCmd(m.viewportResizeGen)
 
 		// Apply the one-shot [startup] preferences now that the real terminal
 		// size is known: NewOS runs before the first WindowSizeMsg, so opening a
@@ -804,7 +871,7 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 				m.KittyPassthrough.HideAllPlacements()
 			}
 
-			return m, nil
+			return m, settle
 		}
 
 		// Retile windows if in tiling mode
@@ -815,16 +882,26 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			m.ClampWindowsToView()
 		}
 
-		// Flush PTY buffers after resize to ensure TUI apps (btop, vim, etc.)
-		// redraw properly. The PTY resize sends SIGWINCH, but we also need to
-		// mark all content dirty and invalidate caches for the new output.
-		m.FlushPTYBuffersAfterResize()
-
 		// NOTE: Don't HideAllPlacements on kitty here  - the delete+re-place cycle
 		// can lose image data on some terminals. RefreshAllPlacements runs every
 		// render and will reposition in place via `a=p` (the image data persists
 		// across `d=i` deletes per the kitty protocol).
 
+		// The PTY resize, the SIGWINCH it carries and the whole-screen redraw
+		// every guest answers with land in ViewportResizeSettledMsg instead.
+		return m, settle
+
+	case ViewportResizeSettledMsg:
+		if msg.Gen != m.viewportResizeGen {
+			// A newer resize has already superseded this one; its own settle
+			// will end the deferral, and ending it here would pay the expensive
+			// half in the middle of the storm this exists to coalesce.
+			return m, nil
+		}
+		// Deliberately not conditional on viewportResizing: this is the settle
+		// for the newest resize, so whatever state the flag is in, the deferred
+		// work is due now. Draining an empty PendingResizes costs nothing.
+		m.endResizeDeferral()
 		return m, nil
 
 	case tea.MouseMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -470,7 +470,17 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			}
 		}
 
-		// Update animations
+		// Update animations. Whether any were running is captured BEFORE the
+		// update, because the tick that finishes the last one is the tick that
+		// matters most: Animation.Update leaves the VT alone while a transition
+		// is in flight and only resizes it on the final tick, so that tick is
+		// where the panes first render at the size they actually settled at. Ask
+		// HasActiveAnimations afterwards and it answers "none", the frame-skip
+		// below decides nothing needs drawing, and View serves the previous
+		// frame: the last thing the user sees is the second-to-last animation
+		// step, with every pane still drawn to its pre-animation size. Nothing
+		// dirties the model after that, so the wrong frame is final.
+		hadAnimations := m.HasActiveAnimations()
 		m.UpdateAnimations()
 
 		// Update system info (only when explicitly enabled)
@@ -580,7 +590,7 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		hasBackgroundChanges := m.MarkTerminalsWithNewContent()
 
 		// Render on tick if something periodic needs visual updates OR background windows changed
-		needsRender := hasAnimations || m.InteractionMode || m.PrefixActive || needsDockTick || hasBackgroundChanges
+		needsRender := hadAnimations || hasAnimations || m.InteractionMode || m.PrefixActive || needsDockTick || hasBackgroundChanges
 		if !needsRender {
 			m.renderSkipped = true
 			if len(cmds) > 1 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -678,3 +678,83 @@ func TestApplyAppearanceConfig_ScrollLines(t *testing.T) {
 		t.Errorf("ScrollLines = %d after an unset value, want it unchanged at 5", config.ScrollLines)
 	}
 }
+
+// TestApplyAppearanceConfig_CoversTheWholeFile guards the gap that made the
+// settings page look like it did not save anything.
+//
+// Every option below is written to config.toml by the settings page and read
+// back from a package global. They used to be applied only by ApplyOverrides,
+// which cmd/tuios calls and nothing else does, so a session that loaded its
+// config through ApplyAppearanceConfig alone (`tuios tape`, the pkg/tuios
+// embed, and every live reload through ConfigReloadedMsg) came back with the
+// defaults and the change looked lost.
+func TestApplyAppearanceConfig_CoversTheWholeFile(t *testing.T) {
+	orig := struct {
+		border, dock            string
+		buttons, scrollbar      bool
+		clock, cpu, ram, revScr bool
+		scrollback, fps         int
+		leader                  string
+	}{
+		config.BorderStyle, config.DockbarPosition,
+		config.HideWindowButtons, config.HideScrollbar,
+		config.ShowClock, config.ShowCPU, config.ShowRAM, config.NiriReverseScroll,
+		config.ScrollbackLines, config.NormalFPS,
+		config.LeaderKey,
+	}
+	defer func() {
+		config.BorderStyle, config.DockbarPosition = orig.border, orig.dock
+		config.HideWindowButtons, config.HideScrollbar = orig.buttons, orig.scrollbar
+		config.ShowClock, config.ShowCPU, config.ShowRAM = orig.clock, orig.cpu, orig.ram
+		config.NiriReverseScroll = orig.revScr
+		config.ScrollbackLines, config.NormalFPS = orig.scrollback, orig.fps
+		config.LeaderKey = orig.leader
+	}()
+
+	cfg := config.DefaultConfig()
+	cfg.Appearance.BorderStyle = "double"
+	cfg.Appearance.DockbarPosition = "top"
+	cfg.Appearance.HideWindowButtons = true
+	cfg.Appearance.HideScrollbar = true
+	cfg.Appearance.ShowClock = true
+	cfg.Appearance.ShowCPU = true
+	cfg.Appearance.ShowRAM = true
+	cfg.Appearance.NiriReverseScroll = true
+	cfg.Appearance.ScrollbackLines = 12345
+	cfg.Appearance.MaxFPS = 30
+	cfg.Keybindings.LeaderKey = "ctrl+a"
+
+	config.ApplyAppearanceConfig(cfg)
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"BorderStyle", config.BorderStyle, "double"},
+		{"DockbarPosition", config.DockbarPosition, "top"},
+		{"HideWindowButtons", config.HideWindowButtons, true},
+		{"HideScrollbar", config.HideScrollbar, true},
+		{"ShowClock", config.ShowClock, true},
+		{"ShowCPU", config.ShowCPU, true},
+		{"ShowRAM", config.ShowRAM, true},
+		{"NiriReverseScroll", config.NiriReverseScroll, true},
+		{"ScrollbackLines", config.ScrollbackLines, 12345},
+		{"NormalFPS", config.NormalFPS, 30},
+		{"LeaderKey", config.LeaderKey, "ctrl+a"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+
+	// Turning a toggle back off has to survive too: these are plain bools with
+	// no unset state, so a conditional assignment would make "off" unsaveable.
+	cfg.Appearance.HideWindowButtons = false
+	cfg.Appearance.ShowClock = false
+	config.ApplyAppearanceConfig(cfg)
+	if config.HideWindowButtons || config.ShowClock {
+		t.Error("clearing hide_window_buttons/show_clock did not reach the globals")
+	}
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -515,7 +515,19 @@ const (
 	WindowBorderVertical = "│" // U+2502
 
 	// WindowButtonClose is the close/kill window button character.
-	WindowButtonClose = " ⤫ " // Close/kill window
+	//
+	// U+2715 MULTIPLICATION X, not the U+292B RISING DIAGONAL CROSSING FALLING
+	// DIAGONAL it used to be. U+292B lives in Miscellaneous Mathematical
+	// Symbols-B, which JetBrainsMono Nerd Font does not cover at all, so a
+	// terminal running it falls back to whatever proportional system font
+	// happens to have the codepoint. That substitute's advance is wider than
+	// one cell, so the glyph draws past the column the layout budgeted for it
+	// and the falling diagonal is clipped by whatever is painted next.
+	// U+2715 is in the font, has an advance of exactly one cell, and keeps its
+	// ink well inside it. It carries the same East Asian Width class "N" as
+	// U+292B, so it still measures 1 cell and the button pill keeps its old
+	// width. See the hit-test offsets below, which depend on that width.
+	WindowButtonClose = " ✕ " // Close/kill window
 	// WindowSeparatorChar is the separator character for window elements.
 	WindowSeparatorChar = "─" // U+2500
 )

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -60,6 +60,14 @@ type Overrides struct {
 
 // ApplyOverrides applies CLI flag overrides to global config, falling back to user config defaults.
 // If userConfig is nil, only CLI flag values (when set) are applied.
+//
+// The userConfig fallbacks below duplicate what ApplyAppearanceConfig already
+// does, and they compute the same values from the same fields. They stay here
+// because this function must also work on its own, for the entrypoints that
+// only call it (cmd/tuios-web). Callers that do both (cmd/tuios) get the config
+// applied twice with the flags winning, which is the intended precedence; any
+// new setting belongs in ApplyAppearanceConfig, and only needs a line here if a
+// CLI flag can override it.
 func ApplyOverrides(overrides Overrides, userConfig *UserConfig) {
 	// ASCII Only - simple flag override
 	if overrides.ASCIIOnly {

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"runtime"
 	"slices"
@@ -557,12 +558,61 @@ func fillMissingAppearance(cfg, defaultCfg *UserConfig) {
 	}
 }
 
-// ApplyAppearanceConfig applies parsed appearance settings to the package
-// globals read by the render loop. It must be called on the Bubble Tea
+// ApplyAppearanceConfig applies a parsed config file to the package globals the
+// render loop and the input handler read. It must be called on the Bubble Tea
 // goroutine (from Update or at startup before the program runs), never from the
 // file-watcher goroutine, because the globals are read concurrently on the
 // render path.
+//
+// This is the whole of the config-file-to-globals mapping, deliberately: an
+// entrypoint that loads a config and calls this gets every setting the settings
+// page can write, with nothing left needing a second call. It used to cover
+// only part of the [appearance] section and the rest lived in ApplyOverrides,
+// so border style, dock position, the dock meters, the scrollbar, the window
+// buttons, scrollback, scroll direction, the frame cap and the theme were
+// applied by cmd/tuios (which calls both) and silently dropped everywhere else:
+// `tuios tape`, the pkg/tuios embed, and every live config reload through
+// ConfigReloadedMsg. ApplyOverrides still layers CLI flags on top, so flags
+// keep winning where they are set.
 func ApplyAppearanceConfig(cfg *UserConfig) {
+	// BorderStyle defaults to rounded. Empty means "not configured", so the
+	// current value (a flag, or the default) stands.
+	if cfg.Appearance.BorderStyle != "" {
+		BorderStyle = cfg.Appearance.BorderStyle
+	}
+
+	// DockbarPosition defaults to bottom.
+	if cfg.Appearance.DockbarPosition != "" {
+		DockbarPosition = cfg.Appearance.DockbarPosition
+	}
+
+	// The hide/show toggles are plain bools with no "unset" state, so they are
+	// assigned unconditionally: turning one off in the settings page has to
+	// survive a reload just as turning it on does.
+	HideWindowButtons = cfg.Appearance.HideWindowButtons
+	HideScrollbar = cfg.Appearance.HideScrollbar
+	ShowClock = cfg.Appearance.ShowClock
+	ShowCPU = cfg.Appearance.ShowCPU
+	ShowRAM = cfg.Appearance.ShowRAM
+	NiriReverseScroll = cfg.Appearance.NiriReverseScroll
+
+	if cfg.Appearance.ScrollbackLines > 0 {
+		ScrollbackLines = cfg.Appearance.ScrollbackLines
+	}
+
+	// Clamped exactly as ApplyOverrides clamps it, because this is now the
+	// other place a saved max_fps reaches the tick loop from and the two must
+	// not disagree about what the file is allowed to ask for.
+	if cfg.Appearance.MaxFPS > 0 {
+		NormalFPS = max(min(cfg.Appearance.MaxFPS, MaxFPSCap), 10)
+	}
+
+	// LeaderKey lives in [keybindings] rather than [appearance], but it is a
+	// package global fed by the same file and it had the same gap.
+	if cfg.Keybindings.LeaderKey != "" {
+		LeaderKey = cfg.Keybindings.LeaderKey
+	}
+
 	// AnimationsEnabled defaults to true (nil means use default)
 	// Only set global if explicitly configured
 	if cfg.Appearance.AnimationsEnabled != nil {
@@ -616,8 +666,19 @@ func ApplyAppearanceConfig(cfg *UserConfig) {
 		ZoomMaxWidth = cfg.Appearance.ZoomMaxWidth
 	}
 
+	// Theme. An empty name means "no theme, use the terminal's own colors",
+	// which is also the startup state, so there is nothing to undo and the
+	// initialize is skipped. This matches ApplyOverrides, which then re-applies
+	// with the --theme flag's name when one was given.
+	if cfg.Appearance.Theme != "" {
+		if err := theme.Initialize(cfg.Appearance.Theme); err != nil {
+			log.Printf("Warning: Failed to load theme '%s': %v", cfg.Appearance.Theme, err)
+		}
+	}
+
 	// Custom border colors override the theme-derived colors. Empty strings
-	// clear any override and restore theme colors.
+	// clear any override and restore theme colors. This runs after the theme
+	// switch above, which resets the derived colors.
 	theme.SetBorderOverrides(cfg.Appearance.BorderFocusedColor, cfg.Appearance.BorderUnfocusedColor)
 }
 

--- a/internal/config/window_button_glyphs_test.go
+++ b/internal/config/window_button_glyphs_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The window control pill is drawn into a fixed grid of cells, and every
+// single-width grapheme in it gets exactly one cell. A glyph the font does not
+// cover falls back to some proportional system font whose advance overruns that
+// cell, and the overrun is then clipped or overpainted by whatever comes next,
+// which is how the close button lost the right half of its X. These tests pin
+// both halves of that contract: the chrome runes must measure one cell, and the
+// font tuios ships must actually have them.
+
+// windowChromeRunes lists every rune tuios paints into window decorations
+// through the Nerd Font path. Each must be covered by the bundled font.
+func windowChromeRunes(t *testing.T) map[rune]string {
+	t.Helper()
+	out := map[rune]string{}
+	add := func(name, s string) {
+		for _, r := range s {
+			if r == ' ' {
+				continue
+			}
+			out[r] = name
+		}
+	}
+	add("WindowButtonClose", WindowButtonClose)
+	add("WindowButtonMinimize", "-")
+	add("WindowButtonMaximize", "□")
+	add("WindowPillLeft", WindowPillLeft)
+	add("WindowPillRight", WindowPillRight)
+	add("WindowBorderTopLeft", WindowBorderTopLeft)
+	add("WindowBorderTopRight", WindowBorderTopRight)
+	add("WindowBorderBottomLeft", WindowBorderBottomLeft)
+	add("WindowBorderBottomRight", WindowBorderBottomRight)
+	add("WindowBorderHorizontal", WindowBorderHorizontal)
+	add("WindowBorderVertical", WindowBorderVertical)
+	return out
+}
+
+func TestWindowChromeRunesAreSingleWidth(t *testing.T) {
+	for r, name := range windowChromeRunes(t) {
+		if w := ansi.StringWidth(string(r)); w != 1 {
+			t.Errorf("%s: U+%04X measures %d cells, want 1", name, r, w)
+		}
+	}
+
+	// The pill contents are what the mouse hit-test offsets are measured
+	// against, so their total width is load-bearing, not cosmetic.
+	if w := ansi.StringWidth(WindowButtonClose); w != 3 {
+		t.Errorf("WindowButtonClose measures %d cells, want 3", w)
+	}
+	if w := ansi.StringWidth(WindowButtonCloseASCII); w != 3 {
+		t.Errorf("WindowButtonCloseASCII measures %d cells, want 3", w)
+	}
+}
+
+// TestWindowChromeRunesAreInBundledFont is the direct guard against the defect:
+// U+292B was used for the close button but is absent from JetBrainsMono Nerd
+// Font, so it was drawn from a fallback font whose glyph was wider than a cell
+// and got clipped. The check needs font files to read, so it skips where none
+// are present rather than passing vacuously.
+func TestWindowChromeRunesAreInBundledFont(t *testing.T) {
+	fonts := bundledFontPaths(t)
+	if len(fonts) == 0 {
+		t.Skip("bundled web fonts not found; nothing to check")
+	}
+
+	runes := windowChromeRunes(t)
+	for _, path := range fonts {
+		cmap, err := readTrueTypeCmap(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", filepath.Base(path), err)
+		}
+		if len(cmap) == 0 {
+			t.Fatalf("%s: parsed an empty cmap", filepath.Base(path))
+		}
+		for r, name := range runes {
+			if !cmap[r] {
+				t.Errorf("%s: %s U+%04X is not in %s; the renderer will fall "+
+					"back to a proportional font and clip the glyph to one cell",
+					filepath.Base(path), name, r, filepath.Base(path))
+			}
+		}
+	}
+}
+
+// bundledFontPaths locates web/fonts relative to the repository root.
+func bundledFontPaths(t *testing.T) []string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	for range 6 {
+		candidate := filepath.Join(dir, "web", "fonts")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			matches, err := filepath.Glob(filepath.Join(candidate, "*.ttf"))
+			if err != nil {
+				return nil
+			}
+			return matches
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return nil
+}
+
+// readTrueTypeCmap returns the set of Unicode code points a TrueType file maps
+// to a glyph. Only the two subtable formats the bundled fonts use (4 and 12)
+// are decoded; a file that offered neither would come back empty and fail the
+// caller's sanity check rather than pass vacuously.
+func readTrueTypeCmap(path string) (map[rune]bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // test-only, path is repo-local
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 12 {
+		return nil, errShortFont
+	}
+
+	numTables := int(binary.BigEndian.Uint16(data[4:6]))
+	cmapOff := 0
+	for i := range numTables {
+		rec := 12 + i*16
+		if rec+16 > len(data) {
+			return nil, errShortFont
+		}
+		if string(data[rec:rec+4]) == "cmap" {
+			cmapOff = int(binary.BigEndian.Uint32(data[rec+8 : rec+12]))
+			break
+		}
+	}
+	if cmapOff == 0 || cmapOff+4 > len(data) {
+		return nil, errShortFont
+	}
+
+	out := map[rune]bool{}
+	numSub := int(binary.BigEndian.Uint16(data[cmapOff+2 : cmapOff+4]))
+	for i := range numSub {
+		rec := cmapOff + 4 + i*8
+		if rec+8 > len(data) {
+			return nil, errShortFont
+		}
+		platform := binary.BigEndian.Uint16(data[rec : rec+2])
+		encoding := binary.BigEndian.Uint16(data[rec+2 : rec+4])
+		// Unicode platform, or Windows BMP/full-repertoire.
+		if platform != 0 && !(platform == 3 && (encoding == 1 || encoding == 10)) {
+			continue
+		}
+		sub := cmapOff + int(binary.BigEndian.Uint32(data[rec+4:rec+8]))
+		if sub+4 > len(data) {
+			continue
+		}
+		switch binary.BigEndian.Uint16(data[sub : sub+2]) {
+		case 4:
+			parseCmapFormat4(data, sub, out)
+		case 12:
+			parseCmapFormat12(data, sub, out)
+		}
+	}
+	return out, nil
+}
+
+func parseCmapFormat4(data []byte, sub int, out map[rune]bool) {
+	if sub+14 > len(data) {
+		return
+	}
+	segX2 := int(binary.BigEndian.Uint16(data[sub+6 : sub+8]))
+	segs := segX2 / 2
+	endOff := sub + 14
+	startOff := endOff + segX2 + 2
+	if startOff+segX2 > len(data) {
+		return
+	}
+	for s := range segs {
+		end := binary.BigEndian.Uint16(data[endOff+s*2 : endOff+s*2+2])
+		start := binary.BigEndian.Uint16(data[startOff+s*2 : startOff+s*2+2])
+		if start > end || end == 0xFFFF {
+			continue
+		}
+		// The glyph id lookup is irrelevant here: presence in a segment is
+		// enough to say the font claims the code point.
+		for c := rune(start); c <= rune(end); c++ {
+			out[c] = true
+		}
+	}
+}
+
+func parseCmapFormat12(data []byte, sub int, out map[rune]bool) {
+	if sub+16 > len(data) {
+		return
+	}
+	nGroups := int(binary.BigEndian.Uint32(data[sub+12 : sub+16]))
+	for g := range nGroups {
+		rec := sub + 16 + g*12
+		if rec+12 > len(data) {
+			return
+		}
+		start := rune(binary.BigEndian.Uint32(data[rec : rec+4]))
+		end := rune(binary.BigEndian.Uint32(data[rec+4 : rec+8]))
+		if start > end || end-start > 0x10000 {
+			// Guard against a pathological range blowing up the map; the
+			// chrome runes all sit in small, ordinary ranges.
+			end = start
+		}
+		for c := start; c <= end; c++ {
+			out[c] = true
+		}
+	}
+}
+
+type fontErr string
+
+func (e fontErr) Error() string { return string(e) }
+
+const errShortFont = fontErr("truncated or malformed font file")

--- a/internal/layout/bsp.go
+++ b/internal/layout/bsp.go
@@ -812,12 +812,20 @@ func (t *BSPTree) findAnyWindowInSubtree(node *TileNode) int {
 	return t.findAnyWindowInSubtree(node.Right)
 }
 
+// cellAspect is how many times taller a character cell is than it is wide.
+// Every rect here is measured in cells, but the reader is looking at pixels, so
+// comparing W against H directly calls a shape wide when it is visibly tall. A
+// tall narrow terminal of 51x37 cells is landscape by the numbers and upright
+// to the eye, and splitting it side by side gives two 25 column panes. Scale
+// the height before comparing so the split follows the shape on screen.
+const cellAspect = 2
+
 // determineAutoSplit determines the split direction based on the auto scheme
 func (t *BSPTree) determineAutoSplit(targetNode *TileNode, bounds Rect) SplitType {
 	switch t.AutoScheme {
 	case SchemeLongestSide:
-		// Split along the longest dimension
-		if bounds.W >= bounds.H {
+		// Split along the longest dimension as it appears on screen.
+		if bounds.W >= bounds.H*cellAspect {
 			return SplitVertical
 		}
 		return SplitHorizontal
@@ -839,7 +847,17 @@ func (t *BSPTree) determineAutoSplit(targetNode *TileNode, bounds Rect) SplitTyp
 		// window rotates V, H, V, H. Unlike SchemeAlternate this keys off the
 		// target node rather than the global split count, so splitting a
 		// shallower window follows that window's own depth parity.
-		if targetNode.Depth()%2 == 0 {
+		//
+		// Which axis it starts on follows the screen rather than being fixed.
+		// A spiral that always opened side by side split a tall 51x37 terminal
+		// into two 25 column panes on the very first window; see cellAspect for
+		// why the height is scaled before the comparison. Seeding the parity
+		// this way keeps the rotation intact and only chooses where it begins.
+		vertical := targetNode.Depth()%2 == 0
+		if bounds.W < bounds.H*cellAspect {
+			vertical = !vertical
+		}
+		if vertical {
 			return SplitVertical
 		}
 		return SplitHorizontal
@@ -853,7 +871,9 @@ func (t *BSPTree) determineAutoSplit(targetNode *TileNode, bounds Rect) SplitTyp
 		if !ok {
 			r = bounds
 		}
-		w, h := r.W, r.H
+		// Both comparisons are against the height as it is drawn, not as it is
+		// counted; see cellAspect.
+		w, h := r.W, r.H*cellAspect
 		if w > h*2 {
 			// Very wide window: split vertically (side by side)
 			return SplitVertical

--- a/internal/layout/tiling.go
+++ b/internal/layout/tiling.go
@@ -38,21 +38,45 @@ func CalculateTilingLayout(n int, screenWidth int, usableHeight int, topMargin i
 		})
 
 	case 2:
-		// Two windows - side by side with configurable ratio
-		masterWidth := int(float64(screenWidth) * masterRatio)
-		slaveWidth := screenWidth - masterWidth
+		// Two windows, split along whichever axis the screen is longer on as it
+		// is drawn. A cell is about twice as tall as it is wide, so a tall
+		// 51x37 terminal reads as landscape by the numbers while being
+		// obviously upright to the eye; splitting it side by side hands out two
+		// 25 column panes. Compare against the scaled height so the split
+		// follows the shape on screen, and stack when it is taller.
+		if screenWidth >= usableHeight*cellAspect {
+			masterWidth := int(float64(screenWidth) * masterRatio)
+			slaveWidth := screenWidth - masterWidth
+			layouts = append(layouts,
+				TileLayout{
+					X:      0,
+					Y:      topMargin,
+					Width:  masterWidth,
+					Height: usableHeight,
+				},
+				TileLayout{
+					X:      masterWidth,
+					Y:      topMargin,
+					Width:  slaveWidth,
+					Height: usableHeight,
+				},
+			)
+			break
+		}
+		masterHeight := int(float64(usableHeight) * masterRatio)
+		slaveHeight := usableHeight - masterHeight
 		layouts = append(layouts,
 			TileLayout{
 				X:      0,
 				Y:      topMargin,
-				Width:  masterWidth,
-				Height: usableHeight,
+				Width:  screenWidth,
+				Height: masterHeight,
 			},
 			TileLayout{
-				X:      masterWidth,
-				Y:      topMargin,
-				Width:  slaveWidth,
-				Height: usableHeight,
+				X:      0,
+				Y:      topMargin + masterHeight,
+				Width:  screenWidth,
+				Height: slaveHeight,
 			},
 		)
 

--- a/internal/overlay/panel.go
+++ b/internal/overlay/panel.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Hint is one key/label pair shown in a panel footer.
@@ -30,6 +31,88 @@ type Panel struct {
 // sidePad is the number of surface cells padding each side of the content.
 const sidePad = 2
 
+// MinPanelWidth is the narrowest inner content width a panel is asked to lay
+// itself out at. Below this the rows have nowhere to put a marker and a label,
+// so a screen this narrow gets a panel as wide as the screen and nothing more.
+const MinPanelWidth = 12
+
+// FitWidth returns the inner content width for a panel that would prefer
+// preferred columns on a screen screenW columns wide. A panel is Width+2*sidePad
+// cells across, so anything wider than the screen minus that padding draws
+// outside the screen with its right-hand side simply missing. Callers pass the
+// width they want and get the width they can have.
+func FitWidth(preferred, screenW int) int {
+	if screenW <= 0 {
+		return preferred // size not known yet; the caller's preference stands
+	}
+	avail := screenW - 2*sidePad
+	if avail < preferred {
+		preferred = avail
+	}
+	return max(preferred, 1)
+}
+
+// TabRowCount reports how many rows the tab strip of a panel of the given inner
+// width needs. Hosts use it to budget the body's row count against the screen
+// height before they build the body.
+func TabRowCount(tabs []string, width int) int {
+	if len(tabs) == 0 {
+		return 0
+	}
+	rows := 1
+	curW := 0
+	wrapW := tabWrapWidth(width)
+	for _, name := range tabs {
+		w := lipgloss.Width(name) + 2 // Padding(0, 1)
+		if w > wrapW {
+			w = wrapW
+		}
+		if curW > 0 && curW+w > wrapW {
+			rows++
+			curW = 0
+		}
+		curW += w
+	}
+	return rows
+}
+
+// HintRowCount reports how many rows the footer hint strip of a panel of the
+// given inner width needs. Hosts use it to budget the body's row count against
+// the screen height before they build the body.
+func HintRowCount(hints []Hint, width int) int {
+	if len(hints) == 0 {
+		return 0
+	}
+	rows, curW := 1, 0
+	for _, h := range hints {
+		w := hintWidth(h)
+		if curW > 0 && curW+3+w > width {
+			rows++
+			curW = 0
+		}
+		if curW > 0 {
+			curW += 3
+		}
+		curW += w
+	}
+	return rows
+}
+
+// hintWidth is the rendered width of one hint: the key, a space, and the label.
+func hintWidth(h Hint) int {
+	return lipgloss.Width(h.Key) + 1 + lipgloss.Width(h.Label)
+}
+
+// tabWrapWidth is the width the tab strip lays out against, which is the inner
+// width every other row uses. Letting the strip spill into the right-hand pad
+// buys one more tab per row and costs the panel its symmetry: the first tab sits
+// on the left pad while the last runs past the rule underneath it, which reads
+// as the strip being shoved rightwards. A tab that no longer fits belongs on the
+// next row, which the strip already wraps onto.
+func tabWrapWidth(width int) int {
+	return width
+}
+
 // glyphPrefix returns the glyph plus a trailing space, honoring ASCII mode.
 func glyphPrefix(glyph string) string {
 	if ASCII || glyph == "" {
@@ -38,40 +121,107 @@ func glyphPrefix(glyph string) string {
 	return glyph + " "
 }
 
-// Tabs renders the section tab row: the active tab is an accent pill, the rest
-// muted. It also returns the panel-relative rect of each tab, given the tab
-// row's top-left origin (originX, originY).
-func tabsRow(tabs []string, active int, bg color.Color, pal Palette, originX, originY int) (string, []Rect) {
-	rendered := make([]string, 0, len(tabs))
-	rects := make([]Rect, 0, len(tabs))
-	x := originX
-	for i, name := range tabs {
-		var pill string
-		if i == active {
-			pill = lipgloss.NewStyle().
+// tabsRows renders the section tab strip, wrapping onto further rows when the
+// pills do not fit across one. The active tab is an accent pill, the rest muted.
+// It also returns the panel-relative rect of each tab, given the strip's
+// top-left origin (originX, originY).
+func tabsRows(tabs []string, active int, bg color.Color, pal Palette, originX, originY, width int) ([]string, []Rect) {
+	// Only the active pill is padded. It carries a background, so the padding is
+	// the gap between its colour and its label; on the others it is invisible
+	// spacing, and paying two columns per tab for it is what pushed the strip
+	// wider than the rule beneath it. The inactive tabs are separated by a single
+	// space instead, which costs one column per gap rather than two.
+	pill := func(name string, isActive bool) string {
+		if isActive {
+			return lipgloss.NewStyle().
 				Background(pal.Accent).Foreground(pal.PillFg).
 				Bold(true).Padding(0, 1).Render(name)
-		} else {
-			pill = Style(bg).Foreground(pal.FgDim).Padding(0, 1).Render(name)
 		}
-		w := lipgloss.Width(pill)
-		rects = append(rects, Rect{X0: x, Y0: originY, X1: x + w, Y1: originY + 1})
-		x += w
-		rendered = append(rendered, pill)
+		return Style(bg).Foreground(pal.FgDim).Render(name)
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, rendered...), rects
+	gap := Style(bg).Render(" ")
+
+	wrapW := tabWrapWidth(width)
+	var rows []string
+	rects := make([]Rect, len(tabs))
+	var cur []string
+	curW, y := 0, originY
+
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, cur...))
+		cur = cur[:0]
+		curW = 0
+		y++
+	}
+
+	for i, name := range tabs {
+		p := pill(name, i == active)
+		w := lipgloss.Width(p)
+		if w > wrapW {
+			// A single pill wider than the strip: shorten the label rather than
+			// let it hang off the edge.
+			p = pill(Truncate(name, max(wrapW-2, 1)), i == active)
+			w = lipgloss.Width(p)
+		}
+		// The separator belongs to the tab that follows it, so a row never ends
+		// on a trailing space and the width test counts what will actually be
+		// drawn.
+		lead := 0
+		if curW > 0 {
+			lead = 1
+		}
+		if curW > 0 && curW+lead+w > wrapW {
+			flush()
+			lead = 0
+		}
+		// The hit area starts at the separator rather than at the label, so the
+		// strip has no dead column between tabs: a click that lands in the gap
+		// picks the tab it precedes.
+		hitX := curW
+		if lead > 0 {
+			cur = append(cur, gap)
+			curW += lead
+		}
+		rects[i] = Rect{X0: originX + hitX, Y0: y, X1: originX + curW + w, Y1: y + 1}
+		cur = append(cur, p)
+		curW += w
+	}
+	flush()
+	return rows, rects
 }
 
-// footerRow renders the muted key-hint row.
-func footerRow(hints []Hint, bg color.Color, pal Palette) string {
+// footerRows renders the muted key-hint strip, wrapping onto further rows when
+// the hints do not fit across one.
+func footerRows(hints []Hint, bg color.Color, pal Palette, width int) []string {
 	keyStyle := Style(bg).Foreground(pal.AccentBright).Bold(true)
 	labelStyle := Style(bg).Foreground(pal.FgMute)
 	sep := Style(bg).Render("   ")
-	parts := make([]string, 0, len(hints))
+	const sepW = 3
+
+	var rows []string
+	var cur []string
+	curW := 0
 	for _, h := range hints {
-		parts = append(parts, keyStyle.Render(h.Key)+labelStyle.Render(" "+h.Label))
+		part := keyStyle.Render(h.Key) + labelStyle.Render(" "+h.Label)
+		w := lipgloss.Width(part)
+		if curW > 0 && curW+sepW+w > width {
+			rows = append(rows, strings.Join(cur, sep))
+			cur = cur[:0]
+			curW = 0
+		}
+		if curW > 0 {
+			curW += sepW
+		}
+		cur = append(cur, part)
+		curW += w
 	}
-	return strings.Join(parts, sep)
+	if len(cur) > 0 {
+		rows = append(rows, strings.Join(cur, sep))
+	}
+	return rows
 }
 
 // Render assembles the panel and returns the rendered string plus the geometry
@@ -82,8 +232,15 @@ func (p Panel) Render(pal Palette) (string, Geometry) {
 	pad := Style(bg).Render(strings.Repeat(" ", sidePad))
 	blank := Style(bg).Render(strings.Repeat(" ", totalW))
 
+	// Every row is padded out to the panel width and, as a backstop, cut down to
+	// it. A row that measures wider than the panel is a row drawn outside the
+	// panel's own box, which on a narrow screen means outside the screen.
 	line := func(content string) string {
-		return Fill(pad+content, totalW, bg)
+		s := pad + content
+		if lipgloss.Width(s) > totalW {
+			s = ansi.Truncate(s, totalW, "")
+		}
+		return Fill(s, totalW, bg)
 	}
 
 	var lines []string
@@ -92,14 +249,16 @@ func (p Panel) Render(pal Palette) (string, Geometry) {
 	lines = append(lines, blank) // 0: top pad
 
 	// 1: title chip. The whole row is a drag handle.
-	chip := Chip(glyphPrefix(p.Glyph)+p.Title, pal.Accent, pal.PillFg)
+	chip := Chip(Truncate(glyphPrefix(p.Glyph)+p.Title, max(p.Width-2, 1)), pal.Accent, pal.PillFg)
 	lines = append(lines, line(chip))
 	geo.TitleBar = Rect{X0: 0, Y0: len(lines) - 1, X1: totalW, Y1: len(lines)}
 	lines = append(lines, blank) // 2: blank
 
 	if len(p.Tabs) > 0 {
-		tabsStr, rects := tabsRow(p.Tabs, p.ActiveTab, bg, pal, sidePad, len(lines))
-		lines = append(lines, line(tabsStr))
+		tabRows, rects := tabsRows(p.Tabs, p.ActiveTab, bg, pal, sidePad, len(lines), p.Width)
+		for _, r := range tabRows {
+			lines = append(lines, line(r))
+		}
 		geo.Tabs = rects
 		lines = append(lines, line(Rule(p.Width, bg, pal)))
 		lines = append(lines, blank)
@@ -113,7 +272,9 @@ func (p Panel) Render(pal Palette) (string, Geometry) {
 	if len(p.Hints) > 0 {
 		lines = append(lines, blank)
 		lines = append(lines, line(Rule(p.Width, bg, pal)))
-		lines = append(lines, line(footerRow(p.Hints, bg, pal)))
+		for _, r := range footerRows(p.Hints, bg, pal, p.Width) {
+			lines = append(lines, line(r))
+		}
 	}
 	lines = append(lines, blank) // bottom pad
 

--- a/internal/terminal/window.go
+++ b/internal/terminal/window.go
@@ -189,9 +189,17 @@ type Window struct {
 	CachedContent      string
 	CachedLayer        *lipgloss.Layer
 	LastTerminalSeq    int
-	IsBeingManipulated bool               // True when being dragged or resized
-	UpdateCounter      int                // Counter for throttling background updates
-	cancelFunc         context.CancelFunc // For graceful goroutine cleanup
+	IsBeingManipulated bool // True when being dragged or resized
+	// announcedW/H are the emulator dimensions last handed downstream: to the
+	// PTY, to the daemon, and to the guest as a redraw. Resize used to decide
+	// "did the size change" by comparing against Width and Height, which is
+	// wrong the moment a resize is split in two. ResizeVisual sets Width and
+	// Height for the live preview, so by the time the deferred half runs they
+	// already match, Resize concludes nothing changed, and nothing downstream is
+	// told - the guest keeps drawing to the size it had before the drag.
+	announcedW, announcedH int
+	UpdateCounter          int                // Counter for throttling background updates
+	cancelFunc             context.CancelFunc // For graceful goroutine cleanup
 	// ioMu guards the emulator cell buffer and the Pty/Terminal handles. See
 	// the block comment above LockIO for the full contract; the short version:
 	//

--- a/internal/terminal/window_geometry.go
+++ b/internal/terminal/window_geometry.go
@@ -47,8 +47,12 @@ func (w *Window) Resize(width, height int) {
 	termWidth := max(width-borderDeduct, 1)
 	termHeight := max(height-borderDeduct, 1)
 
-	// Check if size actually changed
-	sizeChanged := w.Width != width || w.Height != height
+	// Did anything downstream actually change? Measured against what was last
+	// announced, not against Width and Height: a deferred resize has already
+	// applied those visually, and comparing with them makes the announcement
+	// look redundant exactly when it is not.
+	sizeChanged := termWidth != w.announcedW || termHeight != w.announcedH
+	w.announcedW, w.announcedH = termWidth, termHeight
 
 	// ioMu serializes the emulator buffer reallocation against the render
 	// reader (RLockIO) and the PTY writers; Terminal has no lock of its own.

--- a/pkg/tuios/tuios.go
+++ b/pkg/tuios/tuios.go
@@ -250,6 +250,29 @@ func newModel(options Options) *Model {
 	// Set up input handler
 	app.SetInputHandler(input.HandleInput)
 
+	// Load or create user config
+	var userConfig *config.UserConfig
+	if options.UserConfig != nil {
+		userConfig = options.UserConfig
+	} else {
+		var err error
+		userConfig, err = config.LoadUserConfig()
+		if err != nil {
+			userConfig = config.DefaultConfig()
+		}
+	}
+
+	// LoadUserConfig no longer applies the appearance globals itself, so apply
+	// them here exactly once, and pass the config into NewOS so it does not
+	// re-load and re-apply.
+	//
+	// This runs BEFORE the embed options below, not after: ApplyAppearanceConfig
+	// now covers border style, dock position, the hide toggles, scrollback and
+	// the theme, so applying the options first would let the user's config file
+	// silently overrule what the embedder asked for. Options are the outer
+	// layer here, exactly as CLI flags are in cmd/tuios.
+	config.ApplyAppearanceConfig(userConfig)
+
 	// Apply global config options
 	if options.ASCIIOnly {
 		config.UseASCIIOnly = true
@@ -274,23 +297,6 @@ func newModel(options Options) *Model {
 	if options.Theme != "" {
 		_ = theme.Initialize(options.Theme)
 	}
-
-	// Load or create user config
-	var userConfig *config.UserConfig
-	if options.UserConfig != nil {
-		userConfig = options.UserConfig
-	} else {
-		var err error
-		userConfig, err = config.LoadUserConfig()
-		if err != nil {
-			userConfig = config.DefaultConfig()
-		}
-	}
-
-	// LoadUserConfig no longer applies the appearance globals itself, so apply
-	// them here (after the embed options above) exactly once, and pass the
-	// config into NewOS so it does not re-load and re-apply.
-	config.ApplyAppearanceConfig(userConfig)
 
 	// Create keybind registry
 	keybindRegistry := config.NewKeybindRegistry(userConfig)


### PR DESCRIPTION
Eleven commits of fixes to shared code, found while building the WebAssembly demo but none of them specific to it. Every one reproduces in a normal terminal. The demo work itself stays on its own branch; nothing here touches `web/`, `wasm/` or any `_js.go` file.

## The one that matters most

A drag or resize whose mouse release never arrived left the window stuck in `Dragging`/`IsBeingManipulated` forever. The pane kept following the pointer, overlapping its neighbours and hanging off the screen while the status bar still claimed the layout was tiled. Worse, it also froze content updates for every pane, so the session looked alive and was not. Losing a release is ordinary: the pointer leaves the window, or the terminal drops the event.

Reproduced by injecting SGR mouse events: press on a title bar, three motions with the button held, then a motion with `b=35` instead of a release. On `main` the pane tracked to (88,26) and `echo LIVE_OUTPUT_MARKER` in that pane produced no output at all.

## Small terminals

Terminal cells are about twice as tall as they are wide, so splitting on raw width against height picked the wrong axis and gave you two thin columns where two short rows were obviously right. BSP and master-stack now compare against the aspect.

The overlays had no idea how wide the screen was. Panels drew past the right edge and the missing part was simply gone. Settings was the worst case: at 40 columns every value was off-screen, so the page showed a column of labels and nothing else.

```
before                          after
  > Theme                         > Theme                     < none >
    Border style                    Border style           < rounded >
    Window title                    Window title            < bottom >
    Shared borders                  Shared borders             [ off ]
```

The help overlay hid 6 of its 10 tabs and cut descriptions mid-word; the tab strip now wraps. The splash dropped its block letters below 38 columns instead of slicing them vertically.

## Also here

- Panes drew outside their own rectangle, because lipgloss pads but never truncates.
- The last frame of an animation was never drawn: `HasActiveAnimations` was asked after `UpdateAnimations` had already removed the finished animation, so the final step was skipped and the second-to-last state was what stayed on screen.
- A resize storm restarted a 300ms snap per pane per delivered size. Resizes are now deferred and settled, and the PTY is told the real size afterwards.
- `cmd/tuios` read the config file, then read half of it again, so options set in one place lost to stale values from the other.
- The close button was U+292B, which JetBrainsMono Nerd Font does not cover, so it came from a fallback font whose glyph overran its cell and got clipped. Now U+2715, same width class.

## Verification

`go build`, `go vet`, `gofmt`, and the full suite green across 19 packages. New tests cover resize deferral, pane overflow, the window control pill's hit-test, and an assertion that no overlay row at any of five screen sizes contains a control character. Every visual claim above was checked by driving the real binary under tmux at fixed sizes and reading the rendered output, not by unit test alone.