### PR TITLE
Move CI off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
       #
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/e2e-tui.yml
+++ b/.github/workflows/e2e-tui.yml
@@ -27,7 +27,14 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          # The nested e2e module asks for a newer Go than the root module, and
+          # this job needs both: it builds cmd/tuios from the root and then runs
+          # the suite from e2e/tui. Installing the higher of the two satisfies
+          # each, since a module's go directive is a minimum. Reading the root
+          # go.mod here used to work only because Go quietly fetched the newer
+          # toolchain when the tests ran, which setup-go now prevents by pinning
+          # GOTOOLCHAIN to what it installed.
+          go-version-file: e2e/tui/go.mod
           cache-dependency-path: |
             go.sum
             e2e/tui/go.sum

--- a/.github/workflows/e2e-tui.yml
+++ b/.github/workflows/e2e-tui.yml
@@ -23,9 +23,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache-dependency-path: |

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Parse issue form
         uses: stefanbuck/github-issue-parser@v3
@@ -28,7 +28,7 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/bug.yml
 
       - name: Set labels based on the provided fields
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: "1.24"
+          # Track go.mod rather than a literal. Pinning "1.24" here while go.mod
+          # asked for a newer language version meant the release build resolved
+          # its own toolchain at build time instead of using the one set up
+          # above, which is slower and makes the pin a lie.
+          go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
 


### PR DESCRIPTION
Every run was printing:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/checkout@v4, actions/setup-go@v5
```

GitHub is retiring Node 20 on its runners and had already started forcing these onto Node 24, so they were running on a runtime they were never tested against. That is a failure waiting for an inconvenient moment rather than a cosmetic warning.

The warning understated it. Two more actions are on old runtimes and only stayed quiet because their workflows fire on issues and releases rather than on every push:

| action | was | now |
| --- | --- | --- |
| `actions/checkout` | v4, Node 20 (5 uses) | v7.0.1, Node 24 |
| `actions/setup-go` | v5, Node 20 (2 uses) | v7.0.0, Node 24 |
| `goreleaser/goreleaser-action` | v6, Node 20 | v7.2.3, Node 24 |
| `advanced-issue-labeler` | v2, **Node 16** | v3.2.4, Node 20 |

The repo was also inconsistent, with one workflow already on `checkout@v5` and the rest on v4.

## The two majors that could have bitten

`checkout@v7` refuses to check out a fork pull request under `pull_request_target` or `workflow_run`. No workflow here uses either trigger, so that restriction costs this repo nothing.

The issue labeler's v3 breaking changes are internal, swapping probot for octokit and adding zod input validation. The `issue-form` and `token` inputs it is called with are unchanged.

## A separate bug found on the way

`release.yml` pinned `go-version: "1.24"` while `go.mod` asks for `1.25.9`. Go's toolchain mechanism papered over the mismatch by fetching what the module actually needed at build time, which means the version the workflow set up was never the version that built the releases, and the pin was decorative. It now reads `go.mod`, which is what `e2e-tui.yml` already did.

That mismatch is also exactly where `setup-go` v6's toolchain-handling change would have landed, so it is fixed here rather than left to surface as a confusing release failure later.

All five workflow files parse as valid YAML.