### PR TITLE
Stop a cell shift destroying the wide runes it moves

### DIFF
--- a/internal/vt/screen.go
+++ b/internal/vt/screen.go
@@ -243,7 +243,26 @@ func (s *Screen) InsertCell(n int) {
 	}
 
 	x, y := s.cur.X, s.cur.Y
-	s.buf.InsertCellArea(x, y, n, s.blankCell(), s.scroll)
+	line, n, ok := s.shiftBounds(x, y, n)
+	if !ok {
+		return
+	}
+	right := s.scroll.Max.X
+
+	// Copied by assignment rather than through the buffer's Set, which blanks
+	// the other half of any wide rune it lands on. That is right for an
+	// overwrite but ruinous inside a shift, where the cells being moved are
+	// still live: blanking the neighbour of a cell that has just been copied
+	// erases the copy, and a single shift over a line of CJK empties the line.
+	for i := right - 1; i >= x+n; i-- {
+		line[i] = line[i-n]
+	}
+	blank := s.blankCell()
+	for i := x; i < x+n; i++ {
+		putBlank(line, i, blank)
+	}
+	repairWide(line)
+	s.buf.TouchLine(x, y, right-x)
 }
 
 // DeleteCell deletes n cells at the cursor position moving cells to the left.
@@ -254,7 +273,83 @@ func (s *Screen) DeleteCell(n int) {
 	}
 
 	x, y := s.cur.X, s.cur.Y
-	s.buf.DeleteCellArea(x, y, n, s.blankCell(), s.scroll)
+	line, n, ok := s.shiftBounds(x, y, n)
+	if !ok {
+		return
+	}
+	right := s.scroll.Max.X
+
+	for i := x; i < right-n; i++ {
+		line[i] = line[i+n]
+	}
+	blank := s.blankCell()
+	for i := right - n; i < right; i++ {
+		putBlank(line, i, blank)
+	}
+	repairWide(line)
+	s.buf.TouchLine(x, y, right-x)
+}
+
+// shiftBounds validates a cell shift at (x, y) and returns the row it operates
+// on together with the count clamped to the space between x and the right
+// margin. It reports false when the position is outside the margins or the
+// screen, which is the case every caller treats as a no-op.
+func (s *Screen) shiftBounds(x, y, n int) (uv.Line, int, bool) {
+	area := s.scroll
+	if n <= 0 || y < area.Min.Y || y >= area.Max.Y || y >= s.buf.Height() ||
+		x < area.Min.X || x >= area.Max.X || x >= s.buf.Width() {
+		return nil, 0, false
+	}
+	if x+n > area.Max.X {
+		n = area.Max.X - x
+	}
+	return s.buf.Lines[y], n, true
+}
+
+// putBlank overwrites one column with the erase cell. Like the shift itself it
+// assigns rather than calling Set, because the columns it fills have already
+// been vacated and any wide rune the fill cuts is dealt with by repairWide.
+func putBlank(line uv.Line, x int, blank *uv.Cell) {
+	if blank == nil {
+		line[x] = uv.EmptyCell
+		return
+	}
+	line[x] = *blank
+}
+
+// repairWide blanks every half of a wide rune whose partner a shift left
+// behind. A rune that moved by an odd number of columns, or whose second half
+// fell off the right margin, leaves a cell claiming a column it no longer
+// shares with anything; a terminal has no way to draw that, so both ends of the
+// broken pair become spaces.
+//
+// One pass afterwards is deliberate. Proving which end of which shift can orphan
+// which half is fiddly and easy to get subtly wrong, whereas the invariant here
+// (a lead of width w is followed by exactly w-1 continuation cells, and no
+// continuation stands alone) is stated once and checked over the whole row.
+func repairWide(line uv.Line) {
+	for i := 0; i < len(line); i++ {
+		w := line[i].Width
+		switch {
+		case w > 1:
+			whole := true
+			for j := 1; j < w; j++ {
+				if i+j >= len(line) || line[i+j].Width != 0 {
+					whole = false
+					break
+				}
+			}
+			if !whole {
+				line[i].Empty()
+				continue
+			}
+			i += w - 1
+		case w == 0:
+			// Reached without being skipped over above, so there is no lead in
+			// front of it.
+			line[i].Empty()
+		}
+	}
 }
 
 // ScrollUp scrolls the content up n lines within the given region. Lines

--- a/internal/vt/wide_cell_shift_test.go
+++ b/internal/vt/wide_cell_shift_test.go
@@ -1,0 +1,95 @@
+package vt
+
+import (
+	"strings"
+	"testing"
+)
+
+// rowRunes renders a row the way a user would read it: the lead of a wide rune
+// contributes its text and its continuation cells contribute nothing, so the
+// string's length is the row's column count only when every rune is narrow.
+func rowRunes(e *Emulator, y int) string {
+	var b strings.Builder
+	for x := range e.Width() {
+		c := e.CellAt(x, y)
+		if c == nil {
+			b.WriteString("?")
+			continue
+		}
+		b.WriteString(c.Content)
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+// TestCellShiftKeepsWideRunes pins the behaviour that InsertCell and DeleteCell
+// shift cells without destroying the double-width runes they move.
+//
+// The expected values are not invented. They were taken from ghostty by way of
+// the tuitest harness, which fixed the identical defect in its own vendored
+// emulator and validated it against ghostty directly. tmux agrees on every
+// insert and on even deletes, and differs on an odd delete: where a deletion
+// cuts a wide rune in half, tmux drops the whole rune and shifts by two columns,
+// while ghostty removes the one column it was asked to and blanks the half left
+// standing. Following ghostty keeps a delete of n columns a delete of exactly n
+// columns, which is what the sequence means.
+func TestCellShiftKeepsWideRunes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		start string
+		seq   string
+		want  string
+	}{
+		// A row of nothing but wide runes: the case that used to empty the line.
+		{"delete 1 of wide", "中日本", "\x1b[1P", " 日本"},
+		{"delete 2 of wide", "中日本", "\x1b[2P", "日本"},
+		{"delete 3 of wide", "中日本", "\x1b[3P", " 本"},
+		{"insert 1 of wide", "中日本", "\x1b[1@", " 中日本"},
+		{"insert 2 of wide", "中日本", "\x1b[2@", "  中日本"},
+		{"insert 3 of wide", "中日本", "\x1b[3@", "   中日本"},
+
+		// Narrow runes on both sides, so the shift crosses a boundary in each
+		// direction rather than only ever starting on a lead.
+		{"delete 1 of mixed", "ab中日本cd", "\x1b[1P", "b中日本cd"},
+		{"delete 3 of mixed", "ab中日本cd", "\x1b[3P", " 日本cd"},
+		{"insert 1 of mixed", "ab中日本cd", "\x1b[1@", " ab中日本cd"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEmulator(20, 3)
+			e.WriteString(tc.start)
+			e.WriteString("\x1b[H")
+			e.WriteString(tc.seq)
+			if got := rowRunes(e, 0); got != tc.want {
+				t.Errorf("after %q on %q:\n got %q\nwant %q", tc.seq, tc.start, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCellShiftLeavesNoOrphanedHalf states the invariant the repair pass exists
+// to hold, over every shift width against a row that is entirely wide runes.
+// Checking the invariant rather than a rendering catches the case where a row
+// reads correctly but carries a continuation cell with no lead in front of it,
+// which draws as a blank that nothing can ever overwrite.
+func TestCellShiftLeavesNoOrphanedHalf(t *testing.T) {
+	for _, seq := range []string{"P", "@"} {
+		for n := 1; n <= 6; n++ {
+			e := NewEmulator(20, 3)
+			e.WriteString("中日本語")
+			e.WriteString("\x1b[H")
+			e.WriteString("\x1b[" + string(rune('0'+n)) + seq)
+
+			for x := 0; x < e.Width(); x++ {
+				c := e.CellAt(x, 0)
+				if c == nil || c.Width != 0 {
+					continue
+				}
+				// A continuation must be preceded by a lead wide enough to
+				// reach it.
+				lead := e.CellAt(x-1, 0)
+				if x == 0 || lead == nil || lead.Width < 2 {
+					t.Errorf("CSI %d%s: column %d is a continuation with no lead", n, seq, x)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Deleting one column from a line of CJK text emptied the entire line. Reproduced against `internal/vt` on main:

```
e.Write([]byte("中日本"))          // "中日本"
e.Write([]byte("\x1b[H\x1b[1P"))   // DCH 1
// -> ""                              the whole row is gone
e.Write([]byte("\x1b[H\x1b[1@"))   // ICH 1
// -> "  日本"                        中 vanished
```

`InsertCell` and `DeleteCell` handed the work to ultraviolet's `InsertCellArea`/`DeleteCellArea`, which move cells with `Buffer.Set`. `Set` blanks the other half of any wide rune it lands on. That is correct for an overwrite and ruinous inside a shift, because the cells being moved are still live: blanking the neighbour of a cell that was just copied erases the copy, and it cascades along the row.

Anyone running a program that edits a line of wide text in place, in any pane, lost the text.

## The fix

Shift by assignment, then one pass over the row to repair the ends. A rune moved by an odd number of columns, or whose second half fell off the right margin, leaves a cell claiming a column it no longer shares with anything, which a terminal cannot draw; both ends of such a pair become blanks.

The repair is a separate pass on purpose. Reasoning about which end of which shift orphans which half is easy to get subtly wrong, whereas the invariant it restores (a lead of width w is followed by exactly w-1 continuations, and no continuation stands alone) is stated once and checked over the whole row.

## Where the expected values come from

Not invented. Taken from ghostty via the tuitest harness, which hit the identical defect in its own vendored emulator and validated the fix against ghostty directly.

| sequence | this branch | ghostty | tmux |
| --- | --- | --- | --- |
| `CSI 1P` | `" 日本"` | `" 日本"` | `日本` |
| `CSI 2P` | `"日本"` | `"日本"` | `日本` |
| `CSI 3P` | `" 本"` | `" 本"` | `本` |
| `CSI 1@` | `" 中日本"` | `" 中日本"` | `" 中日本"` |
| `CSI 2@` | `"  中日本"` | `"  中日本"` | `"  中日本"` |
| `CSI 3@` | `"   中日本"` | `"   中日本"` | `"   中日本"` |

tmux agrees on every insert and on even deletes. It differs on an odd delete, where it drops the whole cut rune and shifts by two columns. ghostty removes the one column it was asked for and blanks the half left standing, which keeps a delete of n columns a delete of n columns. This follows ghostty, and the reasoning is in the test's comment so the next person does not have to rediscover it.

## Scope

The line-moving helpers next door are unaffected and were checked rather than assumed: `InsertLineArea` and `DeleteLineArea` move whole rows, which cannot split a rune, and `FillArea`/`ClearArea` are overwrites, where blanking a cut rune's partner is the right behaviour.

## Verification

Two tests: a table over inserts and deletes of 1 to 3 columns against all-wide and mixed rows, and an invariant test over shift widths 1 to 6 asserting no continuation cell is left without a lead. The second catches the case where a row reads correctly but carries an orphaned half that draws as a blank nothing can overwrite.

Both were confirmed to fail against the unfixed code. `go build`, `go vet`, `gofmt`, and the full suite green across 19 packages, plus the nested `e2e/tui` module, which the root `go test ./...` does not descend into.

ultraviolet's helpers remain wrong upstream; this fixes tuios's use of them.