### PR TITLE
Forward GORACE so a race report survives the pty

### DIFF
--- a/e2e/tui/harness_test.go
+++ b/e2e/tui/harness_test.go
@@ -173,6 +173,15 @@ func startIn(t *testing.T, base string, o startOpts) *tuitest.Terminal {
 	}
 	// A predictable POSIX shell, and no user rc files changing the prompt.
 	env = append(env, "SHELL=/bin/sh", "ENV=", "PS1=$ ")
+	// GORACE is forwarded so a tuios built with -race can be driven through this
+	// suite and have its findings survive. tuitest replaces the child's whole
+	// environment, so without this the child runs with GORACE unset and the race
+	// detector writes to stderr, which is the PTY the assertions read: the report
+	// is painted into the terminal, shredded across the emulator's line wrapping,
+	// and lost. With log_path set, each process writes its own file instead.
+	if gorace := os.Getenv("GORACE"); gorace != "" {
+		env = append(env, "GORACE="+gorace)
+	}
 	env = append(env, o.env...)
 
 	cols, rows := o.cols, o.rows


### PR DESCRIPTION
The audit found two data races on a live VT emulator that account for 150 of 179 race reports, and noted that `go test -race ./...` is clean for a bad reason: the races live in paths the unit tests never drive concurrently. Reaching them means building the real binary with `-race` and driving it through this suite.

That did not work, and the reason is not obvious. tuitest replaces the child's whole environment, so the binary ran with `GORACE` unset. The detector then wrote to stderr, which in this harness is the pty the assertions read: the report was painted into the terminal, shredded across the emulator's line wrapping, and lost among the frames.

Forwarding `GORACE` lets `log_path` send each process's findings to its own file, which is what makes a race reproducible enough to fix. Groundwork for the race fixes rather than a fix itself.