### PR TITLE
Fix two emulator races, a non-modal overlay, and a scrollback nothing could read

### DIFF
--- a/e2e/tui/help_modal_test.go
+++ b/e2e/tui/help_modal_test.go
@@ -1,0 +1,104 @@
+package tuie2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// helpTitle is the header the keybindings overlay renders. Asserting on it
+// proves the overlay is on screen rather than that a state flag was flipped.
+const helpTitle = "Keybindings"
+
+// openHelp opens the help overlay from window-management mode and waits for it.
+func openHelp(t *testing.T, term *tuitest.Terminal) {
+	t.Helper()
+	if err := term.SendKeys("?"); err != nil {
+		t.Fatalf("send '?': %v", err)
+	}
+	if err := term.WaitForText(helpTitle, uiTimeout); err != nil {
+		t.Fatalf("help overlay did not open: %v\n%s", err, term.Snapshot())
+	}
+}
+
+// TestHelpOverlayIsModalInWindowMode pins the help overlay swallowing keys it
+// does not itself handle, in window-management mode.
+//
+// The overlay handled esc/q/?/arrows/'/' and search typing and then fell
+// through to the normal window-manager dispatch for everything else, while
+// covering most of the screen. Pressing n with help open created and focused a
+// window behind the panel, x closed one, t toggled tiling: the state changed
+// under an overlay that shows none of it, and the user's next keystroke went
+// somewhere they had no way to predict. Terminal mode already ignored unhandled
+// keys while help was up, so the same key did two different things depending on
+// a mode the overlay hides.
+//
+// Each subtest asserts on the dock's window count, which is the state these
+// bindings change and the one thing still visible beside the panel, and on the
+// overlay still being up afterwards.
+//
+// Verified failing against a binary built from the parent commit: with two
+// windows and help open, n took the dock from 1:2 to 1:3.
+func TestHelpOverlayIsModalInWindowMode(t *testing.T) {
+	// Both keys are asserted through the dock's window count, which is the one
+	// piece of state the overlay does not cover. Bindings whose effect the panel
+	// hides entirely (t, i, ',') are pinned in
+	// internal/input.TestHelpOverlaySwallowsUnhandledKeys instead, which can see
+	// the whole model.
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"new-window", "n"},
+		{"close-window", "x"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			term, _ := start(t, startOpts{})
+			waitBoot(t, term)
+			newWindow(t, term)
+			newWindow(t, term)
+
+			before := settledWindowCount(t, term)
+			if before != 2 {
+				t.Fatalf("expected 2 windows before opening help, dock says %d\n%s", before, term.Snapshot())
+			}
+
+			openHelp(t, term)
+
+			if err := term.SendKeys(tc.key); err != nil {
+				t.Fatalf("send %q: %v", tc.key, err)
+			}
+
+			// There is no event to wait for when the fix works, so wait for the
+			// failure instead and require it not to arrive: if the key reaches
+			// the window manager the count changes within the UI timeout.
+			err := term.WaitFor(func(s tuitest.Screen) bool {
+				n := countWindows(s)
+				return n >= 0 && n != before
+			}, uiTimeout)
+			if err == nil {
+				t.Fatalf("%q reached the window manager with help open: window count %d -> %d\n%s",
+					tc.key, before, countWindows(term.Screen()), term.Snapshot())
+			}
+
+			if !strings.Contains(term.Screen().Text(), helpTitle) {
+				t.Fatalf("help overlay left the screen after %q\n%s", tc.key, term.Snapshot())
+			}
+
+			// The overlay must still close on a key it does handle, so this is
+			// modality rather than a wedged input path.
+			if err := term.SendKeys(tuitest.Esc); err != nil {
+				t.Fatalf("send esc: %v", err)
+			}
+			if err := term.WaitFor(func(s tuitest.Screen) bool {
+				return !strings.Contains(s.Text(), helpTitle)
+			}, uiTimeout); err != nil {
+				t.Fatalf("help overlay did not close on esc: %v\n%s", err, term.Snapshot())
+			}
+			alive(t, term, "after closing help")
+		})
+	}
+}

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -711,13 +711,7 @@ func (m *OS) createWindowFromSync(ws *session.WindowState) *terminal.Window {
 		// Only subscribe to PTY output if window is in current workspace
 		// Windows in other workspaces will be subscribed when switching to them
 		if ws.Workspace == m.CurrentWorkspace {
-			m.subscribeToPTY(window)
-
-			// Get terminal content for visible windows
-			termState, err := m.DaemonClient.GetTerminalState(ptyID, true)
-			if err == nil && termState != nil {
-				m.restoreTerminalContent(window, termState)
-			}
+			m.primePaneFromDaemon(window)
 		}
 
 		// Register exit handler (always needed regardless of workspace)
@@ -967,25 +961,74 @@ func (m *OS) TriggerAltScreenRedraws() {
 }
 
 // restoreTerminalContent populates a window's terminal with content from daemon state.
+//
+// Everything it does to the emulator happens under the window's I/O lock. The
+// emulator has no lock of its own; the daemon outputWriter goroutine writes its
+// cell buffer under ioMu and the renderer reads it under RLockIO. Restoring is
+// a mode switch plus a blit of roughly a screenful of cells, and on the paths
+// that reach it with the pane already subscribed (an in-flight resize during
+// tape playback, and every attach before the subscribe order below was fixed)
+// that ran straight into live output: torn cells on screen, and a RestoreModes
+// racing a mode change from the guest leaving mouse tracking or bracketed paste
+// set from whichever side landed last.
+//
+// Ordering against a live subscription is a separate matter from the lock and
+// is handled by the callers, which restore before they subscribe.
 func (m *OS) restoreTerminalContent(w *terminal.Window, state *session.TerminalState) {
 	if w.Terminal == nil || state == nil {
 		return
 	}
 
-	// CRITICAL FIX: Use RestoreAltScreenMode instead of sending escape sequences
-	// Sending ESC[?1049h triggers setAltScreenMode() which CLEARS the screen buffer!
-	// RestoreAltScreenMode() just switches the buffer pointer without clearing.
+	restoredModes, cellsRestored := 0, 0
+
+	w.LockIO()
+	// Re-check under the lock; Close() nils Terminal while holding it.
+	if t := w.Terminal; t != nil {
+		// CRITICAL FIX: Use RestoreAltScreenMode instead of sending escape sequences
+		// Sending ESC[?1049h triggers setAltScreenMode() which CLEARS the screen buffer!
+		// RestoreAltScreenMode() just switches the buffer pointer without clearing.
+		if state.IsAltScreen {
+			t.RestoreAltScreenMode(true)
+		}
+
+		// CRITICAL: Restore terminal modes (mouse tracking, bracketed paste, etc.)
+		// This must happen AFTER RestoreAltScreenMode so the modes map is properly updated
+		// These modes are essential for apps like vim/htop to receive mouse events
+		if len(state.Modes) > 0 {
+			t.RestoreModes(state.Modes)
+			restoredModes = len(state.Modes)
+		}
+
+		// For alt screen apps (vim, htop, etc.), DON'T restore cell content manually.
+		// Instead, rely on SIGWINCH (triggered by resize in RestoreTerminalStates) to make
+		// the app redraw itself. This is cleaner and avoids ANSI leakage issues.
+		// Only restore cell content for non-alt-screen terminals (normal shell).
+		if !state.IsAltScreen && len(state.Screen) > 0 {
+			for y := 0; y < len(state.Screen) && y < state.Height; y++ {
+				if state.Screen[y] == nil {
+					continue
+				}
+				for x := 0; x < len(state.Screen[y]) && x < state.Width; x++ {
+					cellState := state.Screen[y][x]
+					// Only restore non-empty cells
+					if cellState.Content != "" {
+						cell := session.StateToCell(cellState)
+						if cell != nil {
+							t.SetCell(x, y, cell)
+							cellsRestored++
+						}
+					}
+				}
+			}
+		}
+	}
+	w.UnlockIO()
+
 	if state.IsAltScreen {
-		w.Terminal.RestoreAltScreenMode(true)
 		m.LogInfo("Restored alt screen mode for window %s", w.ID[:8])
 	}
-
-	// CRITICAL: Restore terminal modes (mouse tracking, bracketed paste, etc.)
-	// This must happen AFTER RestoreAltScreenMode so the modes map is properly updated
-	// These modes are essential for apps like vim/htop to receive mouse events
-	if len(state.Modes) > 0 {
-		w.Terminal.RestoreModes(state.Modes)
-		m.LogInfo("Restored %d terminal modes for window %s", len(state.Modes), w.ID[:8])
+	if restoredModes > 0 {
+		m.LogInfo("Restored %d terminal modes for window %s", restoredModes, w.ID[:8])
 	}
 
 	// Set the window's IsAltScreen flag for mouse event forwarding
@@ -1000,28 +1043,7 @@ func (m *OS) restoreTerminalContent(w *terminal.Window, state *session.TerminalS
 		traceSync(w, state.IsAltScreen, false, state.Width, state.Height, note)
 	}
 
-	// For alt screen apps (vim, htop, etc.), DON'T restore cell content manually.
-	// Instead, rely on SIGWINCH (triggered by resize in RestoreTerminalStates) to make
-	// the app redraw itself. This is cleaner and avoids ANSI leakage issues.
-	// Only restore cell content for non-alt-screen terminals (normal shell).
-	if !state.IsAltScreen && state.Screen != nil && len(state.Screen) > 0 {
-		cellsRestored := 0
-		for y := 0; y < len(state.Screen) && y < state.Height; y++ {
-			if state.Screen[y] == nil {
-				continue
-			}
-			for x := 0; x < len(state.Screen[y]) && x < state.Width; x++ {
-				cellState := state.Screen[y][x]
-				// Only restore non-empty cells
-				if cellState.Content != "" {
-					cell := session.StateToCell(cellState)
-					if cell != nil {
-						w.Terminal.SetCell(x, y, cell)
-						cellsRestored++
-					}
-				}
-			}
-		}
+	if cellsRestored > 0 {
 		m.LogInfo("Restored %d cells for window %s", cellsRestored, w.ID[:8])
 	}
 
@@ -1085,6 +1107,29 @@ func (m *OS) SetupPTYOutputHandlers() error {
 	return nil
 }
 
+// primePaneFromDaemon fills a pane's local emulator with the daemon's copy of
+// the screen and then starts the live stream, in that order.
+//
+// The order is the point of the function existing. Subscribing first meant the
+// output goroutine was already writing the emulator while the snapshot was
+// blitted into it on the UI goroutine: a torn buffer, and a pane showing a
+// mixture of stale snapshot and live output, since the blit writes cells that
+// are by definition older than anything arriving live. Restoring first costs
+// only the output emitted between the state request and the subscribe, which is
+// one round trip and cannot be interleaved into the wrong frame.
+//
+// Both call sites route through here so the ordering is stated once.
+func (m *OS) primePaneFromDaemon(window *terminal.Window) {
+	if m.DaemonClient == nil || window.PTYID == "" {
+		return
+	}
+
+	if state, err := m.DaemonClient.GetTerminalState(window.PTYID, true); err == nil && state != nil {
+		m.restoreTerminalContent(window, state)
+	}
+	m.subscribeToPTY(window)
+}
+
 // subscribeToPTY subscribes to PTY output for a window.
 // Safe to call multiple times - will not double-subscribe.
 func (m *OS) subscribeToPTY(window *terminal.Window) {
@@ -1144,15 +1189,7 @@ func (m *OS) SubscribeWorkspaceWindows(workspace int) {
 		if w.DaemonMode && w.PTYID != "" && w.Workspace == workspace {
 			// Only subscribe if not already subscribed
 			if !m.SubscribedPTYs[w.PTYID] {
-				// Fetch terminal state first to populate the buffer
-				termState, err := m.DaemonClient.GetTerminalState(w.PTYID, true)
-				if err == nil && termState != nil {
-					m.restoreTerminalContent(w, termState)
-					m.LogInfo("[WORKSPACE] Restored terminal state for window %s", w.ID[:8])
-				}
-
-				// Then subscribe for live updates
-				m.subscribeToPTY(w)
+				m.primePaneFromDaemon(w)
 			}
 		}
 	}

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -803,8 +803,27 @@ func (m *OS) placeUnplacedWindows(state *session.SessionState) bool {
 			continue
 		}
 		w.X, w.Y, w.Width, w.Height = m.NewWindowPlacement()
+		// Same rule as updateWindowFromState and SyncDaemonPTYDimensions: the
+		// emulator has no lock of its own, the daemon outputWriter goroutine
+		// writes its cell buffer under ioMu and the renderer reads it under
+		// RLockIO, and Resize reallocates every line in that buffer. Resizing
+		// here unlocked tore the buffer out from under an in-flight write and
+		// the pane composited as empty cells, which renderTerminal then cached;
+		// an idle shell emits nothing to re-dirty it, so the pane stayed blank.
+		//
+		// Every window this loop touches is newly created by the daemon and is
+		// already subscribed by the time the placing sync arrives, so a pane
+		// that has printed anything at all (a shell prompt is enough) has output
+		// in flight here.
 		if w.Terminal != nil {
-			w.Terminal.Resize(w.ContentWidth(), w.ContentHeight())
+			termWidth := w.ContentWidth()
+			termHeight := w.ContentHeight()
+			w.LockIO()
+			// Re-check under the lock; Close() nils Terminal while holding it.
+			if w.Terminal != nil {
+				w.Terminal.Resize(termWidth, termHeight)
+			}
+			w.UnlockIO()
 		}
 		if w.DaemonResizeFunc != nil {
 			_ = w.DaemonResizeFunc(w.ContentWidth(), w.ContentHeight())

--- a/internal/app/state_sync_race_test.go
+++ b/internal/app/state_sync_race_test.go
@@ -123,6 +123,96 @@ func TestApplyStateSyncResizeRacesOutput(t *testing.T) {
 	win.Close()
 }
 
+// TestRestoreTerminalContentRacesOutput pins the lock discipline in
+// restoreTerminalContent, the third emulator mutation on the state-sync path
+// that ran without the window's I/O lock.
+//
+// Restoring is a mode switch plus a blit of a screenful of cells from the
+// daemon's snapshot. It reaches a pane that is already subscribed on two paths:
+// the tape-playback re-fetch in updateWindowFromState, and (before the callers
+// were reordered) every window created by a state sync, which subscribed first
+// and restored afterwards. Either way the outputWriter goroutine is writing the
+// same cell buffer, so the restore tore it and painted cells from an older
+// frame over live output.
+//
+// The test drives the restore against live output directly, so it keeps
+// guarding the lock even if a later change reorders the callers again. Like the
+// tests above it asserts nothing and only fails under -race; verified failing
+// against the unlocked code with a race on the emulator cell buffer.
+func TestRestoreTerminalContentRacesOutput(t *testing.T) {
+	ptyDataChan := make(chan struct{}, 1)
+	drainDone := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ptyDataChan:
+			case <-drainDone:
+				return
+			}
+		}
+	}()
+	defer close(drainDone)
+
+	const cols, rows = 60, 20
+	win := terminal.NewDaemonWindow("restore-race-win-01", "race", 0, 0, cols+2, rows+2, 0, "pty-restore-001", ptyDataChan)
+	if win == nil {
+		t.Fatal("NewDaemonWindow returned nil")
+	}
+
+	m := &OS{
+		Windows:        []*terminal.Window{win},
+		FocusedWindow:  0,
+		WorkspaceFocus: map[int]int{},
+		NumWorkspaces:  9,
+		Width:          120,
+		Height:         40,
+	}
+
+	// A full screenful of snapshot cells, the shape GetTerminalState returns for
+	// a shell pane, plus the modes a guest application leaves set.
+	screen := make([][]session.CellState, rows)
+	for y := range screen {
+		screen[y] = make([]session.CellState, cols)
+		for x := range screen[y] {
+			screen[y][x] = session.CellState{Content: "x", Width: 1}
+		}
+	}
+	state := &session.TerminalState{
+		Width:  cols,
+		Height: rows,
+		Modes:  map[int]bool{1000: true, 1002: true, 2004: true},
+		Screen: screen,
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	payload := []byte("the quick brown fox jumps over the lazy dog 0123456789\r\n")
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					win.WriteOutputAsync(payload)
+				}
+			}
+		}()
+	}
+
+	for i := range 200 {
+		m.restoreTerminalContent(win, state)
+		_ = m.renderTerminal(win, i%2 == 0, false)
+	}
+
+	close(stop)
+	wg.Wait()
+	win.Close()
+}
+
 // TestPlaceUnplacedWindowsRacesOutput is the sibling of the test above for the
 // other unlocked emulator resize on the state-sync path.
 //

--- a/internal/app/state_sync_race_test.go
+++ b/internal/app/state_sync_race_test.go
@@ -122,3 +122,106 @@ func TestApplyStateSyncResizeRacesOutput(t *testing.T) {
 	wg.Wait()
 	win.Close()
 }
+
+// TestPlaceUnplacedWindowsRacesOutput is the sibling of the test above for the
+// other unlocked emulator resize on the state-sync path.
+//
+// A window the daemon creates arrives marked Unplaced, because the daemon has
+// no viewport and will not guess a position. placeUnplacedWindows turns that
+// into a real box on the client, and resizing the emulator to the new box was
+// the one resize on this path that did not take the window's I/O lock. By the
+// time the placing sync arrives the window is already subscribed, so the
+// outputWriter goroutine is writing the same cell buffer that Resize is
+// reallocating: the symptom is the same permanently blank pane, since a torn
+// render is cached and an idle shell never re-dirties it.
+//
+// The trigger on a real session is pressing n, or any other route that has the
+// daemon rather than this client create the window.
+//
+// Like the test above this asserts nothing and only fails under -race. Its
+// detection power was verified by running it against the unlocked code, where
+// it reports a race on the emulator buffer inside placeUnplacedWindows.
+func TestPlaceUnplacedWindowsRacesOutput(t *testing.T) {
+	ptyDataChan := make(chan struct{}, 1)
+	drainDone := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ptyDataChan:
+			case <-drainDone:
+				return
+			}
+		}
+	}()
+	defer close(drainDone)
+
+	const winID = "place-race-window-001"
+	win := terminal.NewDaemonWindow(winID, "race", 0, 0, 60, 20, 0, "pty-place-0001", ptyDataChan)
+	if win == nil {
+		t.Fatal("NewDaemonWindow returned nil")
+	}
+
+	m := &OS{
+		Windows:        []*terminal.Window{win},
+		FocusedWindow:  0,
+		WorkspaceFocus: map[int]int{},
+		NumWorkspaces:  9,
+		Width:          120,
+		Height:         40,
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	payload := []byte("the quick brown fox jumps over the lazy dog 0123456789\r\n")
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					win.WriteOutputAsync(payload)
+				}
+			}
+		}()
+	}
+
+	// The daemon re-broadcasts the creation state until this client's placing
+	// push lands, so Unplaced arriving repeatedly is the real shape. The screen
+	// size alternates so NewWindowPlacement returns a different box each time
+	// and the emulator really reallocates rather than taking Buffer.Resize's
+	// same-dimensions early return.
+	for i := range 300 {
+		m.Width, m.Height = 120, 40
+		if i%2 == 0 {
+			m.Width, m.Height = 100, 30
+		}
+		state := &session.SessionState{
+			Name:             "race",
+			CurrentWorkspace: 1,
+			FocusedWindowID:  winID,
+			Windows: []session.WindowState{{
+				ID:        winID,
+				Title:     "race",
+				PTYID:     "pty-place-0001",
+				X:         0,
+				Y:         0,
+				Width:     60,
+				Height:    20,
+				Workspace: 1,
+				Unplaced:  true,
+			}},
+		}
+		if err := m.ApplyStateSync(state); err != nil {
+			t.Fatalf("ApplyStateSync: %v", err)
+		}
+		_ = m.renderTerminal(win, i%2 == 0, false)
+	}
+
+	close(stop)
+	wg.Wait()
+	win.Close()
+}

--- a/internal/input/help_modal_test.go
+++ b/internal/input/help_modal_test.go
@@ -1,0 +1,181 @@
+package input
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// osState is the part of the model the window-manager bindings under test move.
+// Comparing the whole struct means a key that fires anything at all is caught,
+// not only the three actions that were demonstrated on screen.
+type osState struct {
+	windows       int
+	focused       int
+	mode          app.Mode
+	autoTiling    bool
+	showHelp      bool
+	showSettings  bool
+	showPalette   bool
+	showLayout    bool
+	showAggregate bool
+	showSessions  bool
+	workspace     int
+	renaming      bool
+	prefixActive  bool
+}
+
+func snapshotOS(o *app.OS) osState {
+	return osState{
+		windows:       len(o.Windows),
+		focused:       o.FocusedWindow,
+		mode:          o.Mode,
+		autoTiling:    o.AutoTiling,
+		showHelp:      o.ShowHelp,
+		showSettings:  o.ShowSettings,
+		showPalette:   o.ShowCommandPalette,
+		showLayout:    o.ShowLayoutPicker,
+		showAggregate: o.ShowAggregateView,
+		showSessions:  o.ShowSessionSwitcher,
+		workspace:     o.CurrentWorkspace,
+		renaming:      o.RenamingWindow,
+		prefixActive:  o.PrefixActive,
+	}
+}
+
+// helpModalOS builds a window-management-mode model with the help overlay open
+// and two daemon-backed windows, which need no PTY and so let a key that does
+// reach the window manager close one without the test having spawned a shell.
+func helpModalOS(t *testing.T) *app.OS {
+	t.Helper()
+
+	m := &app.OS{
+		NumWorkspaces:    9,
+		CurrentWorkspace: 1,
+		WorkspaceFocus:   make(map[int]int),
+		Width:            120,
+		Height:           40,
+		FocusedWindow:    0,
+		Mode:             app.WindowManagementMode,
+		ShowHelp:         true,
+		HelpCategory:     -1,
+		KeybindRegistry:  config.NewKeybindRegistry(config.DefaultConfig()),
+	}
+
+	for i := range 2 {
+		id := "help-modal-window-" + string(rune('a'+i))
+		ptyData := make(chan struct{}, 1)
+		done := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-ptyData:
+				case <-done:
+					return
+				}
+			}
+		}()
+		t.Cleanup(func() { close(done) })
+
+		win := terminal.NewDaemonWindow(id, "help", 0, 0, 40, 12, i, "pty-"+id, ptyData)
+		if win == nil {
+			t.Fatal("NewDaemonWindow returned nil")
+		}
+		win.Workspace = 1
+		t.Cleanup(win.Close)
+		m.Windows = append(m.Windows, win)
+	}
+
+	return m
+}
+
+// TestHelpOverlaySwallowsUnhandledKeys pins the help overlay being modal in
+// window-management mode.
+//
+// The overlay handled esc/q/?/arrows/'/' and search typing and then fell
+// through to the ordinary window-manager dispatch for everything else, from
+// behind a panel covering most of the screen. n created and focused a window,
+// x closed one, t toggled tiling, ',' stacked the settings page on top of help:
+// state changed with nothing on screen to say so, and the same keystroke did
+// two different things depending on which mode help had been opened from, since
+// terminal mode already ignored what it did not handle.
+//
+// The table is deliberately wider than the three keys demonstrated on screen: a
+// missing catch-all leaks every binding, so the guard should be against the
+// whole bound set rather than against the examples.
+func TestHelpOverlaySwallowsUnhandledKeys(t *testing.T) {
+	keys := []string{
+		"n", "x", "t", "f", "m", "z", "w", "s", "c", "d", "i", ",",
+		"h", "j", "k", "l", "-", "|", ".", "<", ">", "=", "[", "]",
+		"1", "2", "3", "4", "5", "6", "7", "8", "9",
+	}
+
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			m := helpModalOS(t)
+			before := snapshotOS(m)
+
+			msg := tea.KeyPressMsg{Code: rune(key[0]), Text: key}
+			out, _ := HandleWindowManagementModeKey(msg, m)
+
+			if got := snapshotOS(out); got != before {
+				t.Errorf("%q changed the model with the help overlay open:\n got %+v\nwant %+v", key, got, before)
+			}
+		})
+	}
+}
+
+// TestHelpOverlayStillHandlesItsOwnKeys is the other half of the pin: the
+// catch-all must not swallow the keys the overlay itself is driven by, which is
+// how a modality fix turns into a wedged overlay.
+func TestHelpOverlayStillHandlesItsOwnKeys(t *testing.T) {
+	t.Run("esc closes", func(t *testing.T) {
+		m := helpModalOS(t)
+		out, _ := HandleWindowManagementModeKey(tea.KeyPressMsg{Code: tea.KeyEscape}, m)
+		if out.ShowHelp {
+			t.Error("esc did not close the help overlay")
+		}
+	})
+
+	t.Run("q closes", func(t *testing.T) {
+		m := helpModalOS(t)
+		out, _ := HandleWindowManagementModeKey(tea.KeyPressMsg{Code: 'q', Text: "q"}, m)
+		if out.ShowHelp {
+			t.Error("q did not close the help overlay")
+		}
+	})
+
+	t.Run("slash enters search", func(t *testing.T) {
+		m := helpModalOS(t)
+		out, _ := HandleWindowManagementModeKey(tea.KeyPressMsg{Code: '/', Text: "/"}, m)
+		if !out.HelpSearchMode {
+			t.Error("'/' did not enter help search mode")
+		}
+		if !out.ShowHelp {
+			t.Error("'/' closed the help overlay")
+		}
+	})
+
+	t.Run("typing in search reaches the query", func(t *testing.T) {
+		m := helpModalOS(t)
+		m.HelpSearchMode = true
+		out, _ := HandleWindowManagementModeKey(tea.KeyPressMsg{Code: 'n', Text: "n"}, m)
+		if out.HelpSearchQuery != "n" {
+			t.Errorf("search query is %q, want %q", out.HelpSearchQuery, "n")
+		}
+		if len(out.Windows) != 2 {
+			t.Errorf("typing in search created a window: %d windows", len(out.Windows))
+		}
+	})
+
+	t.Run("down scrolls", func(t *testing.T) {
+		m := helpModalOS(t)
+		out, _ := HandleWindowManagementModeKey(tea.KeyPressMsg{Code: tea.KeyDown}, m)
+		if out.HelpScrollOffset == 0 {
+			t.Error("down arrow did not scroll the help overlay")
+		}
+	})
+}

--- a/internal/input/keyboard_wm.go
+++ b/internal/input/keyboard_wm.go
@@ -127,6 +127,14 @@ func HandleWindowManagementModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea
 				return o, nil
 			}
 		}
+
+		// Help is showing but the key wasn't handled - ignore it, exactly as
+		// terminal mode does. Falling through sent it on to the window-manager
+		// dispatch below, where the overlay hides what it does: n created and
+		// focused a window behind the help panel, x closed one, t toggled
+		// tiling, and every other single-letter binding fired unseen. Help is
+		// the only overlay in this function that was not modal.
+		return o, nil
 	}
 
 	// Handle log viewer (takes priority in window management mode)

--- a/internal/vt/emulator.go
+++ b/internal/vt/emulator.go
@@ -130,6 +130,14 @@ func NewEmulator(w, h int) *Emulator {
 	t := new(Emulator)
 	t.scrs[0] = *NewScreen(w, h)
 	t.scrs[1] = *NewScreen(w, h)
+	// The alternate screen keeps no scrollback, which every accessor on this
+	// type already assumes: Scrollback, ScrollbackLen, ScrollbackLine,
+	// ClearScrollback and SetScrollbackMaxLines all read scrs[0]. Its ring was
+	// still being filled by every scroll a full-screen application made, at a
+	// terminal width of cells per line and 112 bytes per cell, up to the
+	// default 10000 lines that SetScrollbackMaxLines never reached because that
+	// only resizes the main screen's. Nothing could read a line of it.
+	t.scrs[1].DisableScrollback()
 	t.scr = &t.scrs[0]
 	t.scrs[0].cb = &t.cb
 	t.scrs[1].cb = &t.cb

--- a/internal/vt/screen.go
+++ b/internal/vt/screen.go
@@ -368,18 +368,86 @@ func (s *Screen) ScrollUp(n int) {
 	// Only save to scrollback if we're scrolling the main screen area
 	// (not a limited scroll region) and the scroll region starts at Y=0
 	if scroll.Min.Y == 0 && scroll.Min.X == 0 && scroll.Dx() == width {
-		// Save the top n lines to scrollback before they're deleted
+		// Save the top n lines to scrollback before they're deleted.
+		// extractLine allocates the line and hands over its only reference, so
+		// the ring takes it without a second copy.
 		for i := 0; i < n && i < scroll.Dy(); i++ {
 			y := scroll.Min.Y + i
 			line := extractLine(s.buf.Buffer, y, width)
-			s.scrollback.PushLine(line)
+			s.scrollback.PushLineOwned(line, true)
 		}
 	}
 
 	x, y := s.CursorPosition()
 	s.setCursor(s.cur.X, 0, true)
-	s.DeleteLine(n)
+	if !s.rotateWholeScreenUp(n) {
+		s.DeleteLine(n)
+	}
 	s.setCursor(x, y, false)
+}
+
+// rotateWholeScreenUp scrolls the whole buffer up n lines by moving line
+// headers instead of cells, and reports whether it applied.
+//
+// It only applies when the scroll region is the entire buffer, which is what a
+// shell printing output uses and so is the overwhelming majority of scrolls. A
+// limited region (DECSTBM) still goes through Buffer.DeleteLineArea.
+//
+// The cost being avoided is real: DeleteLineArea copies every cell of the
+// region up one row in a nested loop, and a uv.Cell is 112 bytes carrying three
+// colour interfaces and three strings, so one newline at 207x55 is 11,178
+// struct copies each with a pointer write barrier, and the garbage collector
+// then scans all of it. Rotating touches the rows themselves and reuses the
+// slices that fall off the top as the new blank rows at the bottom, so nothing
+// is allocated and no cell moves.
+//
+// Every row is marked touched, because every row's index changed and the
+// renderer diffs by index.
+func (s *Screen) rotateWholeScreenUp(n int) bool {
+	lines := s.buf.Lines
+	height := len(lines)
+	area := s.scroll
+	if height == 0 || area.Min.X != 0 || area.Min.Y != 0 ||
+		area.Max.Y != height || area.Dx() != s.buf.Width() {
+		return false
+	}
+
+	// A scroll of the whole screen or more clears it; there is nothing to move.
+	if n >= height {
+		n = height
+	}
+
+	// Lift the rows leaving the top, slide the rest up, and put the lifted
+	// slices back at the bottom to be blanked. The scratch array keeps the
+	// common case (one line, printing output) free of allocation; only a large
+	// CSI S needs the heap, and then for one slice of line headers rather than
+	// for any cells.
+	var scratch [16]uv.Line
+	var recycled []uv.Line
+	if n <= len(scratch) {
+		recycled = scratch[:n]
+	} else {
+		recycled = make([]uv.Line, n)
+	}
+	copy(recycled, lines[:n])
+	copy(lines, lines[n:])
+	copy(lines[height-n:], recycled)
+
+	blank := uv.EmptyCell
+	if c := s.blankCell(); c != nil {
+		blank = *c
+	}
+	for y := height - n; y < height; y++ {
+		row := lines[y]
+		for x := range row {
+			row[x] = blank
+		}
+	}
+
+	for y := range height {
+		s.buf.TouchLine(0, y, area.Max.X)
+	}
+	return true
 }
 
 // ScrollDown scrolls the content down n lines within the given region. Lines

--- a/internal/vt/screen.go
+++ b/internal/vt/screen.go
@@ -367,7 +367,7 @@ func (s *Screen) ScrollUp(n int) {
 
 	// Only save to scrollback if we're scrolling the main screen area
 	// (not a limited scroll region) and the scroll region starts at Y=0
-	if scroll.Min.Y == 0 && scroll.Min.X == 0 && scroll.Dx() == width {
+	if s.scrollback != nil && scroll.Min.Y == 0 && scroll.Min.X == 0 && scroll.Dx() == width {
 		// Save the top n lines to scrollback before they're deleted.
 		// extractLine allocates the line and hands over its only reference, so
 		// the ring takes it without a second copy.
@@ -521,6 +521,13 @@ func (s *Screen) blankCell() *uv.Cell {
 // Scrollback returns the scrollback buffer for this screen.
 func (s *Screen) Scrollback() *Scrollback {
 	return s.scrollback
+}
+
+// DisableScrollback drops this screen's scrollback ring, so lines scrolled off
+// the top are discarded instead of retained. Every other scrollback method here
+// already tolerates the nil, and ScrollUp checks it before pushing.
+func (s *Screen) DisableScrollback() {
+	s.scrollback = nil
 }
 
 // ClearScrollback clears all lines from the scrollback buffer.

--- a/internal/vt/scroll_rotate_test.go
+++ b/internal/vt/scroll_rotate_test.go
@@ -236,3 +236,46 @@ func TestScrollUpAllocatesOnlyTheRetainedLine(t *testing.T) {
 		t.Errorf("a whole-screen scroll allocates %.1f times per call, want 1 (the retained scrollback line)", got)
 	}
 }
+
+// TestAltScreenRetainsNothing pins the alternate screen keeping no scrollback,
+// which is what every accessor on Emulator already assumes: Scrollback,
+// ScrollbackLen, ScrollbackLine, ClearScrollback and SetScrollbackMaxLines all
+// read the main screen. Its ring was filled anyway, by every scroll a
+// full-screen application made, and no line of it could be read back.
+//
+// A scroll in the alternate screen must therefore allocate nothing at all, and
+// the main screen's scrollback must survive the excursion untouched.
+func TestAltScreenRetainsNothing(t *testing.T) {
+	const w, h = 80, 24
+
+	e := NewEmulator(w, h)
+	for i := range 40 {
+		e.WriteString(fmt.Sprintf("main-%02d\r\n", i))
+	}
+	mainLines := e.ScrollbackLen()
+	if mainLines == 0 {
+		t.Fatal("main screen retained no scrollback, the test proves nothing")
+	}
+
+	e.WriteString("\x1b[?1049h")
+	fillScreen(e, w, h)
+
+	if got := testing.AllocsPerRun(200, func() {
+		e.WriteString("\x1b[S")
+	}); got > 0 {
+		t.Errorf("a scroll in the alternate screen allocates %.1f times per call, want 0", got)
+	}
+
+	e.WriteString("\x1b[?1049l")
+	if got := e.ScrollbackLen(); got != mainLines {
+		t.Errorf("main scrollback holds %d lines after an alternate-screen excursion, want %d", got, mainLines)
+	}
+	line := e.ScrollbackLine(0)
+	var b strings.Builder
+	for _, c := range line {
+		b.WriteString(c.Content)
+	}
+	if got, want := strings.TrimRight(b.String(), " "), "main-00"; got != want {
+		t.Errorf("oldest scrollback line is %q after the excursion, want %q", got, want)
+	}
+}

--- a/internal/vt/scroll_rotate_test.go
+++ b/internal/vt/scroll_rotate_test.go
@@ -1,0 +1,238 @@
+package vt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// snapshotCells copies the whole grid, so a scroll can be checked against what
+// the screen held before it rather than against the implementation that
+// produced the new screen.
+func snapshotCells(e *Emulator) [][]uv.Cell {
+	w, h := e.Width(), e.Height()
+	grid := make([][]uv.Cell, h)
+	for y := range h {
+		grid[y] = make([]uv.Cell, w)
+		for x := range w {
+			if c := e.CellAt(x, y); c != nil {
+				grid[y][x] = *c
+			} else {
+				grid[y][x] = uv.EmptyCell
+			}
+		}
+	}
+	return grid
+}
+
+// cellsEqual compares the two things a scroll must get right: which glyph is in
+// a column and how it is styled.
+func cellsEqual(a, b uv.Cell) bool {
+	return a.Content == b.Content && a.Width == b.Width && a.Style.Equal(&b.Style)
+}
+
+// assertScrolledUp checks the grid against the expectation that rows top+n..bottom
+// moved up by n, rows outside the region did not move, and the n rows at the
+// bottom of the region are blank. It is written against the semantics of the
+// sequence rather than against either implementation, so it holds for the
+// whole-screen rotation and for the DeleteLineArea path a limited region still
+// takes.
+func assertScrolledUp(t *testing.T, e *Emulator, before [][]uv.Cell, top, bottom, n int) {
+	t.Helper()
+
+	w := e.Width()
+	for y := range before {
+		for x := range w {
+			var want uv.Cell
+			switch {
+			case y < top || y > bottom:
+				want = before[y][x]
+			case y+n <= bottom:
+				want = before[y+n][x]
+			default:
+				want = uv.EmptyCell
+			}
+
+			var got uv.Cell
+			if c := e.CellAt(x, y); c != nil {
+				got = *c
+			}
+			if !cellsEqual(got, want) {
+				t.Fatalf("cell (%d,%d) after scrolling %d line(s) in region %d..%d: got %q (w=%d), want %q (w=%d)",
+					x, y, n, top, bottom, got.Content, got.Width, want.Content, want.Width)
+			}
+		}
+	}
+}
+
+// fillScreen paints every row with distinguishable content and a per-row colour,
+// so a scroll that moves the right glyphs but loses their style is still caught.
+func fillScreen(e *Emulator, w, h int) {
+	for y := 1; y <= h; y++ {
+		row := fmt.Sprintf("row%02d-", y) + strings.Repeat("x", max(w-8, 1))
+		e.WriteString(fmt.Sprintf("\x1b[%d;1H\x1b[38;5;%dm%s\x1b[m", y, 20+y, row[:min(len(row), w)]))
+	}
+}
+
+// TestScrollUpMovesTheRightRows pins the whole-screen scroll against the
+// meaning of the sequence, across the shapes that reach it: an implicit scroll
+// from output running off the bottom, an explicit CSI S, IND, a multi-line
+// scroll, a scroll of the entire screen, and a scroll inside a DECSTBM region,
+// which is the case the rotation deliberately does not handle and which still
+// goes through Buffer.DeleteLineArea.
+func TestScrollUpMovesTheRightRows(t *testing.T) {
+	const w, h = 40, 12
+
+	t.Run("linefeed at the bottom", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString(fmt.Sprintf("\x1b[%d;1H\n", h))
+		assertScrolledUp(t, e, before, 0, h-1, 1)
+	})
+
+	t.Run("index at the bottom", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString(fmt.Sprintf("\x1b[%d;1H\x1bD", h))
+		assertScrolledUp(t, e, before, 0, h-1, 1)
+	})
+
+	t.Run("CSI 1 S", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString("\x1b[S")
+		assertScrolledUp(t, e, before, 0, h-1, 1)
+	})
+
+	t.Run("CSI 7 S", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString("\x1b[7S")
+		assertScrolledUp(t, e, before, 0, h-1, 7)
+	})
+
+	t.Run("scroll the whole screen away", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString(fmt.Sprintf("\x1b[%dS", h))
+		assertScrolledUp(t, e, before, 0, h-1, h)
+	})
+
+	t.Run("scroll past the whole screen", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		e.WriteString(fmt.Sprintf("\x1b[%dS", h+5))
+		assertScrolledUp(t, e, before, 0, h-1, h)
+	})
+
+	t.Run("limited scroll region", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		before := snapshotCells(e)
+		// DECSTBM rows 3..9 (1-based), then scroll inside it. Rows outside the
+		// region must not move.
+		e.WriteString("\x1b[3;9r\x1b[2S")
+		assertScrolledUp(t, e, before, 2, 8, 2)
+	})
+
+	t.Run("cursor survives the scroll", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		e.WriteString("\x1b[5;7H")
+		e.WriteString("\x1b[2S")
+		if got, want := e.CursorPosition(), uv.Pos(6, 4); got != want {
+			t.Errorf("cursor at %v after CSI 2 S, want %v", got, want)
+		}
+	})
+
+	t.Run("blank rows inherit the background", func(t *testing.T) {
+		e := NewEmulator(w, h)
+		fillScreen(e, w, h)
+		// Set a background colour on the pen, which the erased rows a scroll
+		// leaves behind are supposed to take.
+		e.WriteString("\x1b[48;5;52m\x1b[2S")
+		bottom := e.CellAt(0, h-1)
+		if bottom == nil || bottom.Style.Bg == nil {
+			t.Fatalf("bottom row after a scroll with a pen background has no background: %+v", bottom)
+		}
+	})
+}
+
+// TestScrollUpFillsScrollback pins the other half of a whole-screen scroll: the
+// rows leaving the top are what lands in the scrollback ring, in order and with
+// their content intact. The scroll path hands the ring a line it allocated
+// itself rather than a copy, so this is also the guard against that line being
+// aliased to something still being written.
+func TestScrollUpFillsScrollback(t *testing.T) {
+	const w, h = 40, 8
+
+	e := NewEmulator(w, h)
+	e.SetScrollbackMaxLines(100)
+
+	// Print more rows than fit, so the early ones scroll off the top.
+	const printed = 20
+	for i := range printed {
+		e.WriteString(fmt.Sprintf("line-%02d\r\n", i))
+	}
+
+	wantScrollback := printed + 1 - h
+	if got := e.ScrollbackLen(); got != wantScrollback {
+		t.Fatalf("scrollback holds %d lines, want %d", got, wantScrollback)
+	}
+
+	for i := range wantScrollback {
+		line := e.ScrollbackLine(i)
+		if line == nil {
+			t.Fatalf("scrollback line %d is nil", i)
+		}
+		var b strings.Builder
+		for _, c := range line {
+			b.WriteString(c.Content)
+		}
+		want := fmt.Sprintf("line-%02d", i)
+		if got := strings.TrimRight(b.String(), " "); got != want {
+			t.Errorf("scrollback line %d is %q, want %q", i, got, want)
+		}
+	}
+
+	// Writing on after the scrolls must not reach back into a retained line,
+	// which is what an aliased push would allow.
+	e.WriteString("\x1b[H\x1b[2Joverwritten")
+	line := e.ScrollbackLine(0)
+	var b strings.Builder
+	for _, c := range line {
+		b.WriteString(c.Content)
+	}
+	if got, want := strings.TrimRight(b.String(), " "), "line-00"; got != want {
+		t.Errorf("scrollback line 0 became %q after later writes, want %q", got, want)
+	}
+}
+
+// TestScrollUpAllocatesOnlyTheRetainedLine pins the allocation cost of a
+// whole-screen scroll at exactly the line being retained.
+//
+// A scroll allocates once, in extractLine, for the row moving into the
+// scrollback ring. It used to allocate twice, because the ring then made a
+// defensive copy of a line that had no other referent; at 112 bytes per cell
+// and one line per terminal width that second copy was half of everything the
+// write path allocated. The rotation itself must add nothing: it moves line
+// headers and reuses the slices that fall off the top as the new blank rows.
+func TestScrollUpAllocatesOnlyTheRetainedLine(t *testing.T) {
+	e := NewEmulator(80, 24)
+	fillScreen(e, 80, 24)
+
+	got := testing.AllocsPerRun(200, func() {
+		e.WriteString("\x1b[S")
+	})
+	if got > 1 {
+		t.Errorf("a whole-screen scroll allocates %.1f times per call, want 1 (the retained scrollback line)", got)
+	}
+}

--- a/internal/vt/scrollback.go
+++ b/internal/vt/scrollback.go
@@ -75,6 +75,25 @@ func (sb *Scrollback) PushLineWithWrap(line uv.Line, isSoftWrapped bool) {
 	lineCopy := make(uv.Line, len(line))
 	copy(lineCopy, line)
 
+	sb.PushLineOwned(lineCopy, isSoftWrapped)
+}
+
+// PushLineOwned is PushLineWithWrap for a line the caller has just allocated
+// and will not touch again, so the ring takes it as is.
+//
+// The defensive copy in PushLineWithWrap exists because most callers hand over
+// a row of the live screen buffer, which keeps being written. The scroll path
+// does not: extractLine allocates a fresh line per scrolled row and drops its
+// only reference here, so copying it again doubled the cost of retaining a
+// line, and at 112 bytes per cell and terminal width per line that was the bulk
+// of everything the write path allocated.
+func (sb *Scrollback) PushLineOwned(line uv.Line, isSoftWrapped bool) {
+	if len(line) == 0 {
+		return
+	}
+
+	lineCopy := line
+
 	// Insert at tail position
 	sb.lines[sb.tail] = lineCopy
 	sb.softWrapped[sb.tail] = isSoftWrapped


### PR DESCRIPTION
The high-severity findings from the codebase audit, plus one the audit missed that turned out to be the largest of them.

## Two races on a live VT emulator

Both write an emulator while `outputWriter` is writing it, and the user-visible symptom is a pane that goes permanently blank.

`placeUnplacedWindows` resized without holding `ioMu`. `restoreTerminalContent` blitted about 2000 cells and restored modes after `subscribeToPTY` had already started the output goroutine, so the fix is two parts, the lock and the order: `createWindowFromSync` subscribed and then restored, and both call sites now go through `primePaneFromDaemon`, which restores and then subscribes, matching what `SubscribeWorkspaceWindows` already did.

Measured by building the binary with `-race` and driving it through the end-to-end suite with `GORACE=log_path`, since `go test -race ./...` is clean for a bad reason: these paths are never driven concurrently by the unit tests.

| | baseline on main | this branch |
| --- | --- | --- |
| `restoreTerminalContent` | 112 | 0 |
| `placeUnplacedWindows` | 70 | 0 |
| **total across 12 processes** | **182** | **0** |

The other side of every report was `Screen.SetCell`, `Screen.Resize`, `Screen.CursorPosition`, `Emulator.setCursor`, `carriageReturn` or `eraseCharacter`. In-process regression pins fire on the unfixed code at 85 and 46 reports respectively.

## The help overlay was not modal

In window mode the overlay had no catch-all return, so keys fell through to the window manager. Against a binary built from main, with two windows and the overlay open, pressing `n` took the dock from `1:2` to `1:3` with the Keybindings panel still drawn over the newly created window.

The audit called this a one-line fix. It is, but it understated the blast radius: of 33 bound keys, **seven** leak rather than three, namely `n`, `x`, `t`, `m`, `w`, `i` and `,`. Help was the only overlay in that function without a catch-all; every other one returns, and `ShowTapeManager`'s fall-through is deliberate and documented.

## Scrolling copied the whole screen

Every scrolled line copied the screen cell by cell instead of rotating row slices.

| benchmark | before | after |
| --- | --- | --- |
| `WriteHeavyOutput/plain-log` | 1.86 ms/op, 1.05 MB/s | 0.27 ms/op, 7.11 MB/s |
| `WriteHeavyOutput/colored-log` | 1.85 ms/op, 1.02 MB/s | 0.25 ms/op, 7.53 MB/s |
| `ScrollThroughput/with-scrollback` | 66.9 us/op, 2.66 MB/s | 16.7 us/op, 10.60 MB/s |

Allocations per scroll go from 2 to 1, and the tests check the meaning of the sequence rather than the implementation: snapshot the grid, scroll, then check every cell against where it should have come from, across linefeed, IND, CSI S, multi-line scrolls, a scroll larger than the screen, and a DECSTBM region that must not move rows outside itself.

## The one the audit missed, and the biggest

Every `Screen` allocated its own scrollback ring and `ScrollUp` pushed into whichever screen was current, but `Emulator.Scrollback`, `ScrollbackLen`, `ScrollbackLine`, `ClearScrollback` and `SetScrollbackMaxLines` all read `scrs[0]`. So the alternate screen retained a terminal-width line of 112-byte cells for every scroll a full-screen application made, up to a 10000-line default that a configured scrollback size never lowered, and **no code path could read a single line of it**. The doc comment on `Scrollback` already claimed this did not happen.

At 207x55, scrolling 20000 lines in the alternate screen: **234.4 MB retained before, 0.0 MB after.** That is per pane running an editor or a pager.

## Corrections to the audit

The audit's own numbers did not all survive contact.

- The `placeUnplacedWindows` race is worse than reported: 70 of 182, not "38+ of 179".
- **The scroll fix's end-to-end claim does not reproduce.** The audit predicted peak RSS falling from 527 MB to 298 MB. Driving a real pane through `cat` of a 5.6 MB file gives 1.62 s both before and after, and 278 MB peak RSS both before and after. The 527 MB baseline never appeared. The reason is visible in the numbers: the pane is about 101x24, where the emulator does 4.27 MB/s on main, exactly matching the 4.3 MB/s the end-to-end `cat` achieves, so on main the emulator is the bottleneck. After the fix it does 11.38 MB/s at that size and the end-to-end time does not move, meaning a second bottleneck of the same magnitude sits behind it in the local-window path. That is unprofiled and is the obvious next thing to look at. **The microbenchmark win is real; the user-visible win for this scenario is currently zero.**
- Peak RSS was never going to move from the scroll fix anyway, since RSS there is dominated by the retained ring, and removing a transient second copy only halves bytes allocated per line, which the GC reclaims regardless.
- The 182-report run contained only these two sites. None of the medium-severity concurrency findings fired, so **this procedure does not clear them** and a clean race run now is not evidence they are gone.

## Not done

The scrollback blank-cell trim is left for its own change. `ScrollbackLine` has about 19 consumers outside `internal/vt`, in copy-mode motion, visual and search, `input/selection.go`, three sites in `render_terminal.go`, the tape executor and the daemon's state serialization, and they index by column against terminal width. Shortening lines needs either bounds checks at every one of those sites or a padding accessor that reintroduces a per-read allocation in the render path. The two memory wins here are independent of it.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module green in 126 s including the new test.

One caveat for anyone wiring the race procedure into CI: `TestProjectTapeCurrentScopeRendersLayout` fails under a `-race` build both before and after this branch, and passes against non-race builds of both. It is a race-build timing artifact, so a CI job doing this needs to parse the GORACE files and ignore assertion failures.