### PR TITLE
Stop the emulator asking about wrapping per character, and recycle scrollback rows

### DIFF
--- a/internal/vt/csi_mode.go
+++ b/internal/vt/csi_mode.go
@@ -120,6 +120,19 @@ func (e *Emulator) setMode(mode ansi.Mode, setting ansi.ModeSetting) {
 			e.syncSetAtNanos.Store(time.Now().UnixNano())
 		}
 	}
+	if mode == ansi.ModeAutoWrap {
+		e.cachedAutoWrap.Store(setting.IsSet())
+	}
+}
+
+// autoWrapMode reports DECAWM (?7) without touching the modes map.
+//
+// It exists for the callers that ask once per printed character or per line
+// feed; everything colder should keep using isModeSet, which reads the map that
+// remains authoritative. cachedAutoWrap is kept in step by setMode and
+// RestoreModes, the only two writers of that entry.
+func (e *Emulator) autoWrapMode() bool {
+	return e.cachedAutoWrap.Load()
 }
 
 // isModeSet returns true if the mode is set.

--- a/internal/vt/emulator.go
+++ b/internal/vt/emulator.go
@@ -51,6 +51,15 @@ type Emulator struct {
 	cachedAllMotion atomic.Bool
 	// Thread-safe cached synchronized-output flag (DEC 2026, updated on set/reset)
 	cachedSyncOutput atomic.Bool
+	// Thread-safe cached auto-wrap flag (DECAWM ?7, updated on set/reset).
+	//
+	// handleGrapheme consults auto-wrap once per printed character, and reading
+	// it out of the modes map cost an RWMutex round trip plus a lookup keyed by
+	// an interface, which profiled at 8% of the whole process during a `cat` of
+	// a large file: more than the cell write it guards. The map stays
+	// authoritative; this is a read-side shortcut for the one mode the hot loop
+	// asks about every character.
+	cachedAutoWrap atomic.Bool
 	// Unix-nanos timestamp of the last sync begin, for the present-anyway timeout
 	syncSetAtNanos atomic.Int64
 	// Thread-safe cached kitty keyboard flags (updated on push/pop/set/reset)
@@ -549,6 +558,11 @@ func (e *Emulator) RestoreModes(modes map[int]bool) {
 			e.modes[mode] = ansi.ModeSet
 		} else {
 			e.modes[mode] = ansi.ModeReset
+		}
+		// This is the one write path that bypasses setMode, so the read-side
+		// caches it maintains have to be refreshed here or they go stale.
+		if mode == ansi.ModeAutoWrap {
+			e.cachedAutoWrap.Store(enabled)
 		}
 	}
 }

--- a/internal/vt/screen.go
+++ b/internal/vt/screen.go
@@ -367,20 +367,19 @@ func (s *Screen) ScrollUp(n int) {
 
 	// Only save to scrollback if we're scrolling the main screen area
 	// (not a limited scroll region) and the scroll region starts at Y=0
-	if s.scrollback != nil && scroll.Min.Y == 0 && scroll.Min.X == 0 && scroll.Dx() == width {
-		// Save the top n lines to scrollback before they're deleted.
-		// extractLine allocates the line and hands over its only reference, so
-		// the ring takes it without a second copy.
-		for i := 0; i < n && i < scroll.Dy(); i++ {
-			y := scroll.Min.Y + i
-			line := extractLine(s.buf.Buffer, y, width)
-			s.scrollback.PushLineOwned(line, true)
-		}
-	}
+	save := s.scrollback != nil && scroll.Min.Y == 0 && scroll.Min.X == 0 && scroll.Dx() == width
 
 	x, y := s.CursorPosition()
 	s.setCursor(s.cur.X, 0, true)
-	if !s.rotateWholeScreenUp(n) {
+	if !s.rotateWholeScreenUp(n, save) {
+		// The rotation did not apply, so the departing rows stay where they are
+		// and have to be copied out before DeleteLine overwrites them.
+		if save {
+			for i := 0; i < n && i < scroll.Dy(); i++ {
+				line := extractLine(s.buf.Buffer, scroll.Min.Y+i, width)
+				s.scrollback.PushLineOwned(line, true)
+			}
+		}
 		s.DeleteLine(n)
 	}
 	s.setCursor(x, y, false)
@@ -401,9 +400,18 @@ func (s *Screen) ScrollUp(n int) {
 // slices that fall off the top as the new blank rows at the bottom, so nothing
 // is allocated and no cell moves.
 //
+// When save is set, the rows leaving the top go straight into the scrollback
+// instead of being copied there first, and the storage the ring evicts in
+// exchange becomes the new blank rows at the bottom. In the steady state of a
+// pane printing output that is a pure swap: no line is allocated and no cell is
+// copied for a scroll that also has to be retained. The ownership rule is the
+// one extractLine already established, that the ring holds a line nothing else
+// writes; the only new part is that the screen takes back storage the ring has
+// finished with.
+//
 // Every row is marked touched, because every row's index changed and the
 // renderer diffs by index.
-func (s *Screen) rotateWholeScreenUp(n int) bool {
+func (s *Screen) rotateWholeScreenUp(n int, save bool) bool {
 	lines := s.buf.Lines
 	height := len(lines)
 	area := s.scroll
@@ -431,6 +439,18 @@ func (s *Screen) rotateWholeScreenUp(n int) bool {
 	}
 	copy(recycled, lines[:n])
 	copy(lines, lines[n:])
+	if save {
+		for i, row := range recycled {
+			reuse := s.scrollback.PushLineOwnedRecycle(row, true)
+			if len(reuse) == len(row) {
+				recycled[i] = reuse
+			} else {
+				// Nothing evicted yet, or the ring is still holding lines from
+				// before a resize, so the row it gave back is the wrong width.
+				recycled[i] = make(uv.Line, len(row))
+			}
+		}
+	}
 	copy(lines[height-n:], recycled)
 
 	blank := uv.EmptyCell

--- a/internal/vt/scroll_rotate_test.go
+++ b/internal/vt/scroll_rotate_test.go
@@ -219,12 +219,14 @@ func TestScrollUpFillsScrollback(t *testing.T) {
 // TestScrollUpAllocatesOnlyTheRetainedLine pins the allocation cost of a
 // whole-screen scroll at exactly the line being retained.
 //
-// A scroll allocates once, in extractLine, for the row moving into the
-// scrollback ring. It used to allocate twice, because the ring then made a
-// defensive copy of a line that had no other referent; at 112 bytes per cell
-// and one line per terminal width that second copy was half of everything the
-// write path allocated. The rotation itself must add nothing: it moves line
-// headers and reuses the slices that fall off the top as the new blank rows.
+// While the ring still has room a scroll allocates once, for the row that has
+// to exist because the one leaving the top is now owned by the scrollback. It
+// used to allocate twice, because the ring then made a defensive copy of a line
+// that had no other referent; at 112 bytes per cell and one line per terminal
+// width that second copy was half of everything the write path allocated. The
+// rotation itself must add nothing: it moves line headers rather than cells.
+// Once the ring is full even that one allocation goes away, which
+// TestScrollUpRecyclesEvictedScrollbackStorage pins.
 func TestScrollUpAllocatesOnlyTheRetainedLine(t *testing.T) {
 	e := NewEmulator(80, 24)
 	fillScreen(e, 80, 24)
@@ -277,5 +279,103 @@ func TestAltScreenRetainsNothing(t *testing.T) {
 	}
 	if got, want := strings.TrimRight(b.String(), " "), "main-00"; got != want {
 		t.Errorf("oldest scrollback line is %q after the excursion, want %q", got, want)
+	}
+}
+
+// scrollbackText reads a retained line back as plain text.
+func scrollbackText(e *Emulator, i int) string {
+	var b strings.Builder
+	for _, c := range e.ScrollbackLine(i) {
+		b.WriteString(c.Content)
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+// TestScrollUpRecyclesEvictedScrollbackStorage pins the swap a full ring makes
+// possible: the row leaving the top of the screen becomes the newest scrollback
+// line, and the storage of the line the ring drops in exchange becomes the new
+// blank row at the bottom. Once the ring is full nothing is allocated at all.
+//
+// The correctness half matters more than the allocation half. The recycled
+// storage is handed to the screen, which immediately blanks it and then prints
+// into it, so if the ring could still reach it the oldest retained lines would
+// dissolve into whatever the pane printed next. Both directions are checked:
+// the retained lines still read back exactly, and a later screenful of output
+// does not disturb them.
+func TestScrollUpRecyclesEvictedScrollbackStorage(t *testing.T) {
+	const w, h, ring = 40, 8, 16
+
+	e := NewEmulator(w, h)
+	e.SetScrollbackMaxLines(ring)
+
+	// Enough lines that the ring wraps several times over.
+	const printed = 200
+	for i := range printed {
+		e.WriteString(fmt.Sprintf("line-%03d\r\n", i))
+	}
+
+	if got := e.ScrollbackLen(); got != ring {
+		t.Fatalf("scrollback holds %d lines, want the full ring of %d", got, ring)
+	}
+
+	// The oldest retained line is the one printed `ring` scrolls ago.
+	firstRetained := printed + 1 - h - ring
+	for i := range ring {
+		want := fmt.Sprintf("line-%03d", firstRetained+i)
+		if got := scrollbackText(e, i); got != want {
+			t.Errorf("scrollback line %d is %q, want %q", i, got, want)
+		}
+	}
+
+	// Repaint every row of the screen without scrolling, so nothing new is
+	// retained and the ring must read back exactly as it did. A recycled row
+	// the ring could still reach would take this text with it.
+	e.WriteString("\x1b[H\x1b[2J")
+	for y := range h {
+		e.WriteString(fmt.Sprintf("\x1b[%d;1H%s", y+1, strings.Repeat("Z", w)))
+	}
+	for i := range ring {
+		want := fmt.Sprintf("line-%03d", firstRetained+i)
+		if got := scrollbackText(e, i); got != want {
+			t.Fatalf("scrollback line %d is %q after a repaint, want %q: the ring still aliases screen storage", i, got, want)
+		}
+	}
+
+	// With the ring full, a scroll that retains a line allocates nothing: the
+	// line it evicts pays for the one it takes.
+	if got := testing.AllocsPerRun(200, func() {
+		e.WriteString("\x1b[S")
+	}); got > 0 {
+		t.Errorf("a whole-screen scroll into a full ring allocates %.1f times per call, want 0", got)
+	}
+}
+
+// TestScrollRegionStillRetainsLines pins the path the rotation does not take.
+// A DECSTBM region that starts at the top of the screen still feeds the
+// scrollback, and it does so through the copy that a non-rotating scroll needs,
+// because those rows stay on screen and keep being written.
+func TestScrollRegionStillRetainsLines(t *testing.T) {
+	const w, h = 40, 8
+
+	e := NewEmulator(w, h)
+	e.SetScrollbackMaxLines(4)
+
+	// A region covering all but the last row: top-anchored, so it retains, but
+	// not the whole buffer, so it cannot rotate.
+	e.WriteString(fmt.Sprintf("\x1b[1;%dr", h-1))
+	for i := range 12 {
+		e.WriteString(fmt.Sprintf("\x1b[%d;1Hkeep-%02d", min(i+1, h-1), i))
+		if i >= h-2 {
+			e.WriteString("\x1b[S")
+		}
+	}
+
+	if e.ScrollbackLen() == 0 {
+		t.Fatal("a top-anchored scroll region retained nothing")
+	}
+	for i := range e.ScrollbackLen() {
+		if got := scrollbackText(e, i); !strings.HasPrefix(got, "keep-") {
+			t.Errorf("scrollback line %d is %q, want a keep- line", i, got)
+		}
 	}
 }

--- a/internal/vt/scrollback.go
+++ b/internal/vt/scrollback.go
@@ -88,11 +88,33 @@ func (sb *Scrollback) PushLineWithWrap(line uv.Line, isSoftWrapped bool) {
 // line, and at 112 bytes per cell and terminal width per line that was the bulk
 // of everything the write path allocated.
 func (sb *Scrollback) PushLineOwned(line uv.Line, isSoftWrapped bool) {
+	sb.pushOwned(line, isSoftWrapped)
+}
+
+// PushLineOwnedRecycle is PushLineOwned that also hands back the line the ring
+// just evicted, so the caller can reuse its storage instead of allocating.
+//
+// It returns nil while the ring still has room, because nothing has been
+// evicted yet. The returned slice is unreachable through the scrollback once
+// this call returns: head has already moved past it. Callers must treat it as
+// uninitialised storage, since it still holds the evicted line's cells.
+func (sb *Scrollback) PushLineOwnedRecycle(line uv.Line, isSoftWrapped bool) uv.Line {
+	return sb.pushOwned(line, isSoftWrapped)
+}
+
+func (sb *Scrollback) pushOwned(line uv.Line, isSoftWrapped bool) uv.Line {
 	if len(line) == 0 {
-		return
+		return nil
 	}
 
 	lineCopy := line
+
+	// The slot about to be written holds the oldest line once the ring is full,
+	// and nothing can reach it after head advances below.
+	var evicted uv.Line
+	if sb.full {
+		evicted = sb.lines[sb.tail]
+	}
 
 	// Insert at tail position
 	sb.lines[sb.tail] = lineCopy
@@ -113,6 +135,8 @@ func (sb *Scrollback) PushLineOwned(line uv.Line, isSoftWrapped bool) {
 	if sb.tail == sb.head && len(lineCopy) > 0 {
 		sb.full = true
 	}
+
+	return evicted
 }
 
 // Len returns the number of lines currently in the scrollback buffer.

--- a/internal/vt/utf8.go
+++ b/internal/vt/utf8.go
@@ -159,7 +159,7 @@ func (e *Emulator) extendOpenGrapheme() {
 		x = max(x, 0)
 		if w := e.scr.Width(); x >= w {
 			x = w - 1
-			e.atPhantom = e.isModeSet(ansi.ModeAutoWrap)
+			e.atPhantom = e.autoWrapMode()
 		}
 		e.scr.setCursor(x, y, false)
 		e.openGrapheme.width = width
@@ -168,7 +168,7 @@ func (e *Emulator) extendOpenGrapheme() {
 
 // handleGrapheme handles UTF-8 graphemes.
 func (e *Emulator) handleGrapheme(content string, width int) {
-	awm := e.isModeSet(ansi.ModeAutoWrap)
+	awm := e.autoWrapMode()
 	cell := uv.Cell{
 		Content: content,
 		Width:   width,


### PR DESCRIPTION
This started as a hunt for a second bottleneck hiding behind the VT emulator. There isn't one. The emulator was, and still is, the bottleneck; it is now considerably cheaper.

## First, a correction

The premise for this work was a measurement claiming the previous scroll fix gave 4-7x in microbenchmarks while end-to-end `cat` time did not move at all (1.62 s before, 1.62 s after). **That does not reproduce.**

Measured on a repeatable harness (real tuios in a real PTY, host side drained to a byte counter, `cat` bracketed by the pane shell's own `date +%s.%N` so the figure does not depend on anything reaching the screen), 101x24 pane, 5.6 MB file, interleaved runs:

```
844c9d8 (pre-scroll-fix)   1.73 s
acf99de (post-scroll-fix)  0.66 s     2.6x
```

The scroll fix was worth 2.6x end-to-end. Whatever produced the flat number was measuring something else. Two facts rule out the usual suspects: tuios writes only 0.12 MB to the host across the whole 5.6 MB cat, so no host terminal can be the ceiling, and the raw PTY floor for the same file is 60-120 MB/s, so the PTY is not either.

## Where the time actually goes

Instrumenting the reader loop on a 657 ms baseline run: **591 ms inside `Emulator.Write`, 48 ms waiting on `ioMu` behind the compositor, 9 ms waiting for the PTY.** The reader goroutine is saturated. There is no hidden second stage.

Two leads closed rather than chased:

- **GC looked damning and is not on the critical path.** `scanObject` was 25% flat and 34% of all CPU, but `GOGC=off` cut CPU from 1.88 s to 1.46 s while making wall time *worse*, 0.79 s to 0.96 s. GC was soaking idle cores, with `gcDrainMarkWorkerIdle` accounting for 3.14 s of 4.77 s.
- **The render path costs 1.0 s of CPU per 0.66 s cat and never takes the fullscreen fast path during one**, because accumulating scrollback makes `windowNeedsScrollbar` disqualify it, so every frame goes through the compositor. It still only steals 48 ms of wall clock. `ansi.StringWidth` from lipgloss remains 23% of CPU, entirely render-side. That is a CPU and battery problem, not a throughput one, and it is left alone here.

## The two changes

**Auto-wrap was a mutex round trip per printed character.** `handleGrapheme` asked `isModeSet(ModeAutoWrap)` for every single character, and that is an RWMutex acquisition plus an interface-keyed map lookup, costing more than the cell write it guards: 1.15 s of 13.97 s of samples, 8% of the whole process. Auto-wrap now also lives in an atomic kept in step by `setMode` and `RestoreModes`, with the map still authoritative for everything cold.

**`ScrollUp` allocated a fresh 11 KiB pointer-rich `uv.Line` for every retained row**, then blanked the original. That is a swap wearing a disguise: the row leaving the top is exactly the row scrollback wants, and a full ring evicts one of identical shape in exchange. The screen row now goes straight into the ring and the evicted storage returns as the new blank bottom row. Zero allocations and zero cell copies in the steady state, falling back to allocating while the ring still has room or after a resize leaves it holding rows of the wrong width.

## Numbers

Five interleaved pairs, medians, 5.6 MB into a 101x24 pane:

| | wall | rate | tuios CPU | peak RSS |
| --- | --- | --- | --- | --- |
| before | 0.673 s | 8.3 MB/s | 1.75 s | 266 MB |
| after | 0.410 s | 13.7 MB/s | 0.80 s | 169 MB |

**1.64x wall, 2.2x less CPU, 36% less peak RSS.** At 16.8 MB, 1.97 s to 1.16 s. Afterwards the write is still 85% of wall, 347 ms of 407 ms, so the emulator remains the bottleneck, just a much cheaper one.

## On the risky half

Recycling rows between the screen and the scrollback ring is the change that can silently corrupt history, so it carries a test that drives a small ring several times around, checks every retained line reads back exactly, then repaints the whole screen without scrolling and checks the ring has not moved. It was verified as a real guard with a negative control: making the push hand back a line still in the ring fails it.

`go build`, `go vet`, `gofmt`, `go test ./...`, `go test -race` on vt/terminal/app, and the nested `e2e/tui` module all pass.