### PR TITLE
Keep drawing while a notification is on screen

### DIFF
--- a/e2e/tui/altscreen_test.go
+++ b/e2e/tui/altscreen_test.go
@@ -25,7 +25,7 @@ func setupAltScreenLeftTile(t *testing.T, term *tuitest.Terminal) []string {
 	if err := term.SendKeys(altScreenCmd(markers...), tuitest.Enter); err != nil {
 		t.Fatalf("start alt-screen fixture: %v", err)
 	}
-	waitForAll(t, term, 15*time.Second, "alt-screen fixture never painted", markers...)
+	waitForAll(t, term, shellTimeout, "alt-screen fixture never painted", markers...)
 	leaveTerminalMode(t, term)
 
 	// A second window steals focus, so the alt-screen pane renders through the

--- a/e2e/tui/daemon_tiling_test.go
+++ b/e2e/tui/daemon_tiling_test.go
@@ -73,7 +73,7 @@ func geomOverlap(a, b winRect) bool {
 func waitForSettledGeometry(t *testing.T, base string, n int) []winRect {
 	t.Helper()
 	var prev []winRect
-	deadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(shellTimeout)
 	stableSince := 0
 	for time.Now().Before(deadline) {
 		out, err := tuiosCLI(t, base, "list-windows", "--json")

--- a/e2e/tui/freeze_test.go
+++ b/e2e/tui/freeze_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Gaurav-Gosain/tuitest"
 )
@@ -41,7 +40,7 @@ func TestSustainedOutputKeepsRendering(t *testing.T) {
 	// the PTY reader is taking the exclusive lock continuously while the UI
 	// goroutine renders.
 	runInShell(t, term, "mkdir -p /tmp/tuios-e2e-ls && (cd /tmp/tuios-e2e-ls && for i in $(seq 1 200); do : > f$i; done) && echo SETUP-DONE",
-		"SETUP-DONE", 30*time.Second)
+		"SETUP-DONE", soakTimeout)
 
 	const rounds = 6
 	for i := 1; i <= rounds; i++ {
@@ -53,7 +52,7 @@ func TestSustainedOutputKeepsRendering(t *testing.T) {
 		if err := term.SendKeys(cmd, tuitest.Enter); err != nil {
 			t.Fatalf("round %d: send: %v", i, err)
 		}
-		if err := term.WaitForText(marker, 20*time.Second); err != nil {
+		if err := term.WaitForText(marker, shellTimeout); err != nil {
 			t.Fatalf("UI stopped rendering at round %d/%d: %q never appeared. "+
 				"This is the render/IO lock reentry freeze: the UI goroutine is parked "+
 				"on a second read lock behind the PTY writer.\nerr: %v\n%s",

--- a/e2e/tui/harness_test.go
+++ b/e2e/tui/harness_test.go
@@ -90,6 +90,23 @@ const (
 	bootTimeout = 20 * time.Second
 	// uiTimeout covers an ordinary UI reaction to a keystroke.
 	uiTimeout = 10 * time.Second
+	// shellTimeout covers a whole shell command: typed in, forked, run, and its
+	// output back on screen through the daemon. That is why it is longer than an
+	// ordinary UI reaction, and it is the budget behind every `echo MARKER`
+	// assertion in the suite.
+	shellTimeout = 20 * time.Second
+	// soakTimeout is shellTimeout for the tests that keep the pane busy while
+	// the assertion waits (soak, freeze), where the output being waited for is
+	// queued behind everything else those tests are generating.
+	soakTimeout = 30 * time.Second
+	// bulkTimeout covers a pane producing thousands of lines of scrollback,
+	// which is bounded by how fast the emulator can consume them rather than by
+	// any UI reaction.
+	bulkTimeout = 60 * time.Second
+	// terminalModeProbe is the per-attempt budget in enterTerminalMode, which
+	// retries. It is deliberately short: a swallowed 'i' is worth retrying
+	// rather than waiting out.
+	terminalModeProbe = 3 * time.Second
 )
 
 // tuiosBin is the binary under test, resolved once by TestMain.
@@ -318,7 +335,7 @@ func enterTerminalMode(t *testing.T, term *tuitest.Terminal) {
 		if err := term.SendKeys("i"); err != nil {
 			t.Fatalf("send 'i': %v", err)
 		}
-		if err := term.WaitForText("Terminal Mode", 3*time.Second); err == nil {
+		if err := term.WaitForText("Terminal Mode", terminalModeProbe); err == nil {
 			time.Sleep(insertGuard + 150*time.Millisecond)
 			return
 		}

--- a/e2e/tui/interactive_test.go
+++ b/e2e/tui/interactive_test.go
@@ -89,7 +89,7 @@ func TestFocusCycleWithRapidKeyRepeat(t *testing.T) {
 		waitWindowCount(t, term, i, fmt.Sprintf("creating window %d", i))
 		enterTerminalMode(t, term)
 		marker := fmt.Sprintf("WINMARK-%d", i)
-		runInShell(t, term, fmt.Sprintf("echo WINMARK-$((%d))", i), marker, 20*time.Second)
+		runInShell(t, term, fmt.Sprintf("echo WINMARK-$((%d))", i), marker, shellTimeout)
 		markers = append(markers, marker)
 		leaveTerminalMode(t, term)
 	}
@@ -112,7 +112,7 @@ func TestFocusCycleWithRapidKeyRepeat(t *testing.T) {
 		}
 	}
 	alive(t, term, "during rapid focus cycling")
-	waitForAll(t, term, 15*time.Second, "after 40 rapid focus changes", markers...)
+	waitForAll(t, term, shellTimeout, "after 40 rapid focus changes", markers...)
 
 	// Backwards too, since previous-window is a separate action.
 	for range 20 {
@@ -120,7 +120,7 @@ func TestFocusCycleWithRapidKeyRepeat(t *testing.T) {
 			t.Fatalf("rapid prev: %v", err)
 		}
 	}
-	waitForAll(t, term, 15*time.Second, "after 20 rapid previous-window changes", markers...)
+	waitForAll(t, term, shellTimeout, "after 20 rapid previous-window changes", markers...)
 
 	// The UI must still take input after the storm.
 	leaveTerminalMode(t, term)
@@ -133,7 +133,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 	waitBoot(t, term)
 	newWindow(t, term)
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo WS1MARK-$((1+0))", "WS1MARK-1", 20*time.Second)
+	runInShell(t, term, "echo WS1MARK-$((1+0))", "WS1MARK-1", shellTimeout)
 	leaveTerminalMode(t, term)
 
 	// Workspace 2 must be empty and must not show workspace 1's pane.
@@ -150,7 +150,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 	// A window created here belongs to workspace 2.
 	newWindow(t, term)
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo WS2MARK-$((1+1))", "WS2MARK-2", 20*time.Second)
+	runInShell(t, term, "echo WS2MARK-$((1+1))", "WS2MARK-2", shellTimeout)
 	leaveTerminalMode(t, term)
 
 	// Back to workspace 1: its pane must return, and workspace 2's must not.
@@ -173,7 +173,7 @@ func TestMinimizeAndRestore(t *testing.T) {
 	waitBoot(t, term)
 	newWindow(t, term)
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo MINMARK-$((20+3))", "MINMARK-23", 20*time.Second)
+	runInShell(t, term, "echo MINMARK-$((20+3))", "MINMARK-23", shellTimeout)
 	leaveTerminalMode(t, term)
 
 	for i := range 3 {
@@ -206,7 +206,7 @@ func TestZoomToggle(t *testing.T) {
 
 	newWindow(t, term)
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo ZOOMMARK-$((50+5))", "ZOOMMARK-55", 20*time.Second)
+	runInShell(t, term, "echo ZOOMMARK-$((50+5))", "ZOOMMARK-55", shellTimeout)
 	leaveTerminalMode(t, term)
 	newWindow(t, term)
 	waitWindowCount(t, term, 2, "before zooming")
@@ -245,7 +245,7 @@ func TestResizeKeepsPaneContent(t *testing.T) {
 
 	newWindow(t, term)
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo RESIZEMARK-$((3*3))", "RESIZEMARK-9", 20*time.Second)
+	runInShell(t, term, "echo RESIZEMARK-$((3*3))", "RESIZEMARK-9", shellTimeout)
 	leaveTerminalMode(t, term)
 	newWindow(t, term)
 	waitWindowCount(t, term, 2, "before resizing")
@@ -256,7 +256,7 @@ func TestResizeKeepsPaneContent(t *testing.T) {
 			t.Fatalf("resize to %dx%d failed (tuios likely died): %v\n%s",
 				size[0], size[1], err, term.Snapshot())
 		}
-		if err := term.WaitForText("RESIZEMARK-9", 15*time.Second); err != nil {
+		if err := term.WaitForText("RESIZEMARK-9", shellTimeout); err != nil {
 			t.Fatalf("pane content lost at %dx%d: %v\n%s",
 				size[0], size[1], err, term.Snapshot())
 		}
@@ -301,7 +301,7 @@ func TestTwoClientsSeeConsistentState(t *testing.T) {
 		t.Fatalf("c1 echo: %v", err)
 	}
 	for name, c := range map[string]*tuitest.Terminal{"client1": c1, "client2": c2} {
-		if err := c.WaitForText("SHAREDMARK-56", 20*time.Second); err != nil {
+		if err := c.WaitForText("SHAREDMARK-56", shellTimeout); err != nil {
 			t.Fatalf("%s never saw pane output produced through client1: %v\n%s",
 				name, err, c.Snapshot())
 		}
@@ -324,7 +324,7 @@ func TestTwoClientsSeeConsistentState(t *testing.T) {
 	for name, c := range map[string]*tuitest.Terminal{"client1": c1, "client2": c2} {
 		if err := c.WaitFor(func(s tuitest.Screen) bool {
 			return countWindows(s) == 2
-		}, 20*time.Second); err != nil {
+		}, shellTimeout); err != nil {
 			t.Fatalf("%s never saw the window created on client1 (count %d): %v\n%s",
 				name, countWindows(c.Screen()), err, c.Snapshot())
 		}

--- a/e2e/tui/scroll_test.go
+++ b/e2e/tui/scroll_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Gaurav-Gosain/tuitest"
 )
@@ -29,7 +28,7 @@ func TestScrolledOutputRendersCorrectly(t *testing.T) {
 	// the tail can be identified exactly rather than by counting.
 	const last = 400
 	runInShell(t, term, fmt.Sprintf("for i in $(seq 1 %d); do echo \"LINE-$i-END\"; done", last),
-		fmt.Sprintf("LINE-%d-END", last), 60*time.Second)
+		fmt.Sprintf("LINE-%d-END", last), bulkTimeout)
 
 	// The final lines must be the ones on screen: a pane that scrolled but
 	// rendered a stale cache would be showing earlier lines instead.
@@ -49,7 +48,7 @@ func TestScrolledOutputRendersCorrectly(t *testing.T) {
 	}
 
 	// The pane must still be live after the scroll, not frozen on a final frame.
-	runInShell(t, term, "echo POST-SCROLL-$((6*7))", "POST-SCROLL-42", 20*time.Second)
+	runInShell(t, term, "echo POST-SCROLL-$((6*7))", "POST-SCROLL-42", shellTimeout)
 
 	// And it must survive losing and regaining focus, which is when a stale or
 	// discarded cached layer would show itself.
@@ -77,7 +76,7 @@ func TestScrollbackModeShowsEarlierOutput(t *testing.T) {
 
 	const last = 300
 	runInShell(t, term, fmt.Sprintf("for i in $(seq 1 %d); do echo \"SB-$i-END\"; done", last),
-		fmt.Sprintf("SB-%d-END", last), 60*time.Second)
+		fmt.Sprintf("SB-%d-END", last), bulkTimeout)
 	leaveTerminalMode(t, term)
 
 	// Ctrl+B [ enters copy mode over the scrollback. Motions are vim's, so the

--- a/e2e/tui/showkeys_fastpath_test.go
+++ b/e2e/tui/showkeys_fastpath_test.go
@@ -46,7 +46,7 @@ func TestShowKeysOverlayFullscreenWindow(t *testing.T) {
 	}
 	if err := term.WaitFor(func(s tuitest.Screen) bool {
 		return strings.Contains(showkeysRow(s), "Q")
-	}, 4*time.Second); err != nil {
+	}, uiTimeout); err != nil {
 		t.Fatalf("keycast never showed 'Q' typed into a fullscreen window: %v\n%s", err, term.Snapshot())
 	}
 	alive(t, term, "after fullscreen keycast check")

--- a/e2e/tui/soak_test.go
+++ b/e2e/tui/soak_test.go
@@ -141,7 +141,7 @@ func TestSoakMixedActivity(t *testing.T) {
 			t.Fatalf("cycle %d: send burst: %v", cycle, err)
 		}
 		// A frozen UI never shows this, so the hang check is per cycle.
-		if err := term.WaitForText(marker, 30*time.Second); err != nil {
+		if err := term.WaitForText(marker, soakTimeout); err != nil {
 			t.Fatalf("UI stopped rendering during soak cycle %d/%d: %q never appeared: %v\n%s",
 				cycle, cycles, marker, err, term.Snapshot())
 		}
@@ -219,7 +219,7 @@ func TestSoakMixedActivity(t *testing.T) {
 
 	// Finally, the UI must still work after the whole soak.
 	enterTerminalMode(t, term)
-	runInShell(t, term, "echo SOAK-FINAL-$((11*11))", "SOAK-FINAL-121", 30*time.Second)
+	runInShell(t, term, "echo SOAK-FINAL-$((11*11))", "SOAK-FINAL-121", soakTimeout)
 	alive(t, term, "at the end of the soak")
 }
 

--- a/e2e/tui/tape_autorun_test.go
+++ b/e2e/tui/tape_autorun_test.go
@@ -188,7 +188,7 @@ func TestProjectTapeCurrentScopeRendersLayout(t *testing.T) {
 	if err := term.WaitFor(func(s tuitest.Screen) bool {
 		txt := s.Text()
 		return contains(txt, "editormark-6") && contains(txt, "servermark-56")
-	}, 20*time.Second); err != nil {
+	}, shellTimeout); err != nil {
 		t.Fatalf("both panes' command output did not render: %v\n%s", err, term.Snapshot())
 	}
 	waitWindowCount(t, term, 2, "after building the current-scope layout")

--- a/internal/app/notification_frame_test.go
+++ b/internal/app/notification_frame_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNotificationKeepsTheFrameDrawing is the regression test for a toast that
+// never comes down.
+//
+// Notifications expire on a wall-clock timer, but the only thing that retires
+// one is CleanupNotifications, and that runs while a frame is being composed.
+// The maintenance tick used to have no reason to compose a frame just because a
+// notification was on screen, so once the session went quiet - no animation, no
+// PTY output, no keystroke - the last frame drawn was served from the render
+// cache indefinitely, with whatever toast happened to be up still painted over
+// the panes underneath it.
+//
+// This is how a project tape that split a pane and echoed into it could finish
+// correctly and still show an empty pane: the tape's own "Trusted ..." toast was
+// sitting exactly where the new pane's first lines were, the panes then went
+// idle, and no later frame ever replaced that one.
+func TestNotificationKeepsTheFrameDrawing(t *testing.T) {
+	win := newTestWindow(t, "notif-frame-0001", 60, 34)
+	m := newTestOS(win)
+	m.Width, m.Height = 120, 40
+
+	// Baseline: an idle session with nothing on screen may skip the frame.
+	if _, _ = m.Update(TickerMsg(time.Now())); !m.renderSkipped {
+		t.Fatal("an idle tick with nothing on screen should skip the frame")
+	}
+
+	m.ShowNotification("built the layout", "info", 40*time.Millisecond)
+	if _, _ = m.Update(TickerMsg(time.Now())); m.renderSkipped {
+		t.Fatal("a tick with a notification on screen skipped the frame; the toast would stay painted over the panes under it")
+	}
+
+	// Once it has expired and been retired, ticks may go back to skipping.
+	time.Sleep(60 * time.Millisecond)
+	m.CleanupNotifications()
+	if len(m.Notifications) != 0 {
+		t.Fatalf("expected the notification to have expired, got %d", len(m.Notifications))
+	}
+	if _, _ = m.Update(TickerMsg(time.Now())); !m.renderSkipped {
+		t.Error("a tick with no notification left should skip the frame again")
+	}
+}
+
+// TestFinishedScriptExitDrawsOnce covers the same class of freeze for the tape
+// completion indicator. maybeExitFinishedScript takes "DONE" off screen, and its
+// return value exists so the tick that does it draws; ignoring it left the
+// indicator in the cached frame with nothing scheduled to redraw.
+func TestFinishedScriptExitDrawsOnce(t *testing.T) {
+	win := newTestWindow(t, "script-done-0001", 60, 34)
+	m := newTestOS(win)
+	m.Width, m.Height = 120, 40
+	m.ScriptMode = true
+	m.ScriptFinishedTime = time.Now().Add(-2 * scriptDoneLinger)
+
+	if _, _ = m.Update(TickerMsg(time.Now())); m.renderSkipped {
+		t.Fatal("the tick that left script mode skipped the frame; the DONE indicator would stay on screen")
+	}
+	if m.ScriptMode {
+		t.Fatal("expected the finished script's mode to have been left")
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -285,6 +285,16 @@ type OS struct {
 	// passes, whichever comes first.
 	ScriptWaitRegex    *regexp.Regexp
 	ScriptWaitDeadline time.Time
+	// Pane-readiness gate. A tape command that creates a pane (Split, NewWindow,
+	// SmartSplit) does not create it here: in a daemon session it asks the daemon
+	// and the pane arrives later, on a state push. Until it does, the focused
+	// window is still the old one, so the next Type would be typed into the pane
+	// the tape just split away from. ScriptAwaitWindows is the window count
+	// playback must see before it dispatches anything else, and
+	// ScriptAwaitDeadline bounds the wait so a pane that never arrives stalls the
+	// tape for a few seconds rather than forever.
+	ScriptAwaitWindows  int
+	ScriptAwaitDeadline time.Time
 	// Tape manager UI
 	ShowTapeManager    bool              // True when showing tape manager overlay
 	TapeManager        *TapeManagerState // Tape manager state

--- a/internal/app/os_tape_executor.go
+++ b/internal/app/os_tape_executor.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"image/color"
 	"regexp"
@@ -57,6 +58,8 @@ func (m *OS) exitScriptMode() {
 	m.ScriptFinishedTime = time.Time{}
 	m.ScriptWaitRegex = nil
 	m.ScriptWaitDeadline = time.Time{}
+	m.ScriptAwaitWindows = 0
+	m.ScriptAwaitDeadline = time.Time{}
 	m.RemoteScriptIndex = 0
 	m.RemoteScriptTotal = 0
 }
@@ -169,9 +172,55 @@ func (m *OS) SendToWindow(windowID string, data []byte) error {
 	return fmt.Errorf("window not found: %s", windowID)
 }
 
+// scriptWindowWait is how long tape playback will wait for a pane it asked for
+// to actually exist before giving up on it. It is generous because the pane is
+// created by the daemon on a loaded machine, and bounded because a tape that
+// stalls forever is worse than one that reports what went wrong.
+const scriptWindowWait = 5 * time.Second
+
+// awaitNewWindow arms the pane-readiness gate for a pane this command just
+// asked for. Playback holds the next command until the window set has grown or
+// the deadline passes; see the ScriptAwaitWindows field and its use in Update.
+//
+// It is armed after the request rather than inside AddWindow so it measures the
+// growth caused by this command only, and so the non-tape paths that create
+// windows never touch playback state.
+func (m *OS) awaitNewWindow(before int) {
+	m.ScriptAwaitWindows = before + 1
+	m.ScriptAwaitDeadline = time.Now().Add(scriptWindowWait)
+}
+
+// scriptPaneReady reports whether tape playback may dispatch its next command.
+// It is false only while a pane an earlier command asked for has not turned up
+// yet, and it stops being false either when the pane arrives or when the wait
+// runs out of time.
+//
+// The timeout is reported, not swallowed: a tape that carries on typing into
+// the pane it meant to split away from produces a layout that looks built and
+// is not, and the only way anyone finds out is if something says so.
+func (m *OS) scriptPaneReady() bool {
+	if m.ScriptAwaitWindows == 0 {
+		return true
+	}
+	if len(m.Windows) >= m.ScriptAwaitWindows {
+		m.ScriptAwaitWindows = 0
+		return true
+	}
+	if time.Now().Before(m.ScriptAwaitDeadline) {
+		return false
+	}
+	m.ScriptAwaitWindows = 0
+	m.ShowNotification(
+		"Tape: the new pane never appeared; the rest of the tape will run in the current pane",
+		"error", config.NotificationDuration*2)
+	return true
+}
+
 // CreateNewWindow creates a new window with an optional name.
 func (m *OS) CreateNewWindow() error {
+	before := len(m.Windows)
 	m.AddWindow("")
+	m.awaitNewWindow(before)
 	m.MarkAllDirty()
 	return nil
 }
@@ -183,7 +232,9 @@ func (m *OS) CreateNewWindow() error {
 // returns (the daemon creates it and pushes it back), so naming it by position
 // would name whatever happened to be last.
 func (m *OS) CreateNewWindowWithName(name string) error {
+	before := len(m.Windows)
 	m.AddWindow(name)
+	m.awaitNewWindow(before)
 	m.MarkAllDirty()
 	return nil
 }
@@ -415,15 +466,18 @@ func (m *OS) CloseWindowByName(name string) error {
 	return nil
 }
 
-// SwitchWorkspace switches to a workspace.
+// SwitchWorkspace switches to a workspace. An out-of-range workspace is an
+// error rather than a silent no-op, so a tape asking for workspace 12 in a
+// nine-workspace session says so instead of appearing to work.
 func (m *OS) SwitchWorkspace(workspace int) error {
-	if workspace >= 1 && workspace <= m.NumWorkspaces {
-		recorder := m.TapeRecorder
-		m.TapeRecorder = nil
-		m.SwitchToWorkspace(workspace)
-		m.TapeRecorder = recorder
-		m.MarkAllDirty()
+	if workspace < 1 || workspace > m.NumWorkspaces {
+		return fmt.Errorf("workspace %d is out of range (1-%d)", workspace, m.NumWorkspaces)
 	}
+	recorder := m.TapeRecorder
+	m.TapeRecorder = nil
+	m.SwitchToWorkspace(workspace)
+	m.TapeRecorder = recorder
+	m.MarkAllDirty()
 	return nil
 }
 
@@ -595,10 +649,12 @@ func (m *OS) SnapByDirection(direction string) error {
 	}
 
 	if m.FocusedWindow < 0 || m.FocusedWindow >= len(m.Windows) {
-		return nil
+		return errNoFocusedWindow
 	}
 
-	quarter := SnapTopLeft
+	// An unrecognized direction used to fall through to SnapTopLeft, so a typo
+	// snapped the window somewhere the tape never asked for.
+	var quarter SnapQuarter
 	switch direction {
 	case "left":
 		quarter = SnapLeft
@@ -608,6 +664,8 @@ func (m *OS) SnapByDirection(direction string) error {
 		m.Snap(m.FocusedWindow, SnapTopLeft)
 		m.MarkAllDirty()
 		return nil
+	default:
+		return fmt.Errorf("invalid snap direction: %s (use: left, right, fullscreen)", direction)
 	}
 
 	m.Snap(m.FocusedWindow, quarter)
@@ -647,12 +705,28 @@ func (m *OS) MoveAndFollowWorkspaceByID(windowID string, workspace int) error {
 	return fmt.Errorf("window not found: %s", windowID)
 }
 
+// errTilingOff is what the BSP commands report when tiling is off. They used to
+// return nil and do nothing, so a tape whose EnableTiling had not taken effect
+// silently skipped every Split and then typed the next command into whatever
+// pane happened to be focused. A tape command that quietly does nothing is the
+// worst kind of failure to debug, so it says so instead.
+var errTilingOff = errors.New("tiling is not enabled; run EnableTiling before this command")
+
+// errNoFocusedWindow is what the commands that act on the focused window report
+// when there is not one, rather than returning nil and doing nothing.
+var errNoFocusedWindow = errors.New("no focused window")
+
 // SplitHorizontal splits the focused window horizontally.
 func (m *OS) SplitHorizontal() error {
 	if !m.AutoTiling {
-		return nil
+		return errTilingOff
 	}
+	if m.GetFocusedWindow() == nil {
+		return errNoFocusedWindow
+	}
+	before := len(m.Windows)
 	m.SplitFocusedHorizontal()
+	m.awaitNewWindow(before)
 	m.MarkAllDirty()
 	return nil
 }
@@ -660,9 +734,14 @@ func (m *OS) SplitHorizontal() error {
 // SplitVertical splits the focused window vertically.
 func (m *OS) SplitVertical() error {
 	if !m.AutoTiling {
-		return nil
+		return errTilingOff
 	}
+	if m.GetFocusedWindow() == nil {
+		return errNoFocusedWindow
+	}
+	before := len(m.Windows)
 	m.SplitFocusedVertical()
+	m.awaitNewWindow(before)
 	m.MarkAllDirty()
 	return nil
 }
@@ -670,7 +749,7 @@ func (m *OS) SplitVertical() error {
 // RotateSplit rotates the split direction at the focused window.
 func (m *OS) RotateSplit() error {
 	if !m.AutoTiling {
-		return nil
+		return errTilingOff
 	}
 	m.RotateFocusedSplit()
 	m.MarkAllDirty()
@@ -680,7 +759,7 @@ func (m *OS) RotateSplit() error {
 // EqualizeSplitsExec equalizes all split ratios.
 func (m *OS) EqualizeSplitsExec() error {
 	if !m.AutoTiling {
-		return nil
+		return errTilingOff
 	}
 	m.EqualizeSplits()
 	m.MarkAllDirty()
@@ -690,7 +769,7 @@ func (m *OS) EqualizeSplitsExec() error {
 // Preselect sets the preselection direction for the next window.
 func (m *OS) Preselect(direction string) error {
 	if !m.AutoTiling {
-		return nil
+		return errTilingOff
 	}
 	switch direction {
 	case "left":
@@ -829,7 +908,7 @@ func (m *OS) ShowNotificationCmd(message, notificationType string) error {
 // FocusDirection focuses a window in a direction (for BSP tiling).
 func (m *OS) FocusDirection(direction string) error {
 	if m.FocusedWindow < 0 || m.FocusedWindow >= len(m.Windows) {
-		return nil
+		return errNoFocusedWindow
 	}
 
 	focusedWindow := m.Windows[m.FocusedWindow]
@@ -848,10 +927,11 @@ func (m *OS) FocusDirection(direction string) error {
 		return fmt.Errorf("invalid direction: %s (use: left, right, up, down)", direction)
 	}
 
-	if targetIndex >= 0 {
-		m.FocusWindow(targetIndex)
-		m.MarkAllDirty()
+	if targetIndex < 0 {
+		return fmt.Errorf("no window %s of the focused one", direction)
 	}
+	m.FocusWindow(targetIndex)
+	m.MarkAllDirty()
 
 	return nil
 }
@@ -864,7 +944,15 @@ func (m *OS) ToggleZoomExec() error {
 
 // SmartSplitFocusedExec performs a smart split on the focused window (tape executor interface).
 func (m *OS) SmartSplitFocusedExec() error {
+	if !m.AutoTiling {
+		return errTilingOff
+	}
+	if m.GetFocusedWindow() == nil {
+		return errNoFocusedWindow
+	}
+	before := len(m.Windows)
 	m.SmartSplitFocused()
+	m.awaitNewWindow(before)
 	return nil
 }
 

--- a/internal/app/os_tape_executor_test.go
+++ b/internal/app/os_tape_executor_test.go
@@ -563,3 +563,63 @@ func TestApplyStateSyncSkipsInvalidWindows(t *testing.T) {
 		t.Errorf("Windows count = %d, want 0", len(m.Windows))
 	}
 }
+
+// TestSplitWithoutTilingIsLoud pins that the BSP commands report tiling being
+// off instead of returning nil. They used to do nothing at all, so a tape whose
+// EnableTiling had not taken effect skipped every Split silently and then typed
+// the next command into whatever pane was still focused, producing a layout that
+// looked built and was not.
+func TestSplitWithoutTilingIsLoud(t *testing.T) {
+	m := focusedOS(t, "")
+	m.AutoTiling = false
+
+	for name, call := range map[string]func() error{
+		"SplitVertical":   m.SplitVertical,
+		"SplitHorizontal": m.SplitHorizontal,
+		"RotateSplit":     m.RotateSplit,
+		"EqualizeSplits":  m.EqualizeSplitsExec,
+		"SmartSplit":      m.SmartSplitFocusedExec,
+	} {
+		if err := call(); err == nil {
+			t.Errorf("%s with tiling off returned nil; it must say why it did nothing", name)
+		}
+	}
+}
+
+// TestScriptPaneReadyWaitsThenGivesUp covers the pane-readiness gate playback
+// holds the next command on. A pane a tape asked for arrives asynchronously in a
+// daemon session, and until it does the focused window is still the pane the
+// tape split away from.
+func TestScriptPaneReadyWaitsThenGivesUp(t *testing.T) {
+	m := focusedOS(t, "")
+
+	// Nothing pending: playback runs.
+	if !m.scriptPaneReady() {
+		t.Fatal("playback blocked with no pane pending")
+	}
+
+	// A pane was asked for and has not arrived: playback waits.
+	m.awaitNewWindow(len(m.Windows))
+	if m.scriptPaneReady() {
+		t.Fatal("playback ran on while the pane it asked for did not exist")
+	}
+
+	// The wait is bounded, and running out of it is reported, not swallowed.
+	m.ScriptAwaitDeadline = time.Now().Add(-time.Millisecond)
+	if !m.scriptPaneReady() {
+		t.Fatal("playback stayed blocked past the deadline")
+	}
+	if len(m.Notifications) != 1 {
+		t.Fatalf("a pane that never arrived produced %d notifications, want 1", len(m.Notifications))
+	}
+
+	// The pane arriving clears the gate without a complaint.
+	m.awaitNewWindow(len(m.Windows))
+	m.Windows = append(m.Windows, m.Windows[0])
+	if !m.scriptPaneReady() {
+		t.Fatal("playback stayed blocked after the pane arrived")
+	}
+	if m.ScriptAwaitWindows != 0 {
+		t.Error("the gate was not disarmed once the pane arrived")
+	}
+}

--- a/internal/app/tape_run.go
+++ b/internal/app/tape_run.go
@@ -178,6 +178,8 @@ func (m *OS) startTapePlayback(commands []tape.Command, workspace int) {
 	m.ScriptMode = true
 	m.ScriptPaused = false
 	m.ScriptFinishedTime = time.Time{}
+	m.ScriptAwaitWindows = 0
+	m.ScriptAwaitDeadline = time.Time{}
 	m.ScriptExecutor = tape.NewCommandExecutor(m)
 }
 

--- a/internal/app/tapemanager.go
+++ b/internal/app/tapemanager.go
@@ -386,6 +386,8 @@ func (m *OS) TapeManagerPlaySelected() {
 	m.ScriptMode = true
 	m.ScriptPaused = false
 	m.ScriptFinishedTime = time.Time{}
+	m.ScriptAwaitWindows = 0
+	m.ScriptAwaitDeadline = time.Time{}
 
 	// Create executor
 	m.ScriptExecutor = tape.NewCommandExecutor(m)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -523,8 +523,10 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 		// Leave script mode once a finished script's completion indicator has
 		// been shown. This re-arms Ctrl+P (the palette binding), which is
-		// intercepted for script pause/resume while ScriptMode is set.
-		m.maybeExitFinishedScript()
+		// intercepted for script pause/resume while ScriptMode is set. It also
+		// takes the indicator off screen, so the tick that does it has to draw:
+		// nothing else is guaranteed to follow it.
+		leftScriptMode := m.maybeExitFinishedScript()
 
 		// Handle script playback if in script mode
 		cmds := []tea.Cmd{TickCmd()}
@@ -598,6 +600,18 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		hasAnimations := m.HasActiveAnimations()
 		needsDockTick := config.NeedsDockTick()
 
+		// A notification on screen is a reason to keep drawing. Notifications
+		// expire on a wall-clock timer, but nothing retires them except
+		// CleanupNotifications, which only runs while a frame is being composed.
+		// With no other reason to draw, the toast that happened to be up when the
+		// session went quiet is served from the render cache forever, sitting on
+		// top of whatever is underneath it. That is how a tape that splits a pane
+		// and echoes into it could finish correctly and still show an empty pane:
+		// the last frame drawn was the one with the tape's own toasts covering
+		// the new pane, and no later frame ever replaced it.
+		hasNotifications := len(m.Notifications) > 0
+		needsScriptFrame := m.ScriptMode || leftScriptMode
+
 		// Determine next tick rate
 		var nextTick tea.Cmd
 		if m.InteractionMode {
@@ -607,7 +621,7 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			// cost smoothness without limiting the motion flood, since motion
 			// events drove their own renders regardless of the tick rate.
 			nextTick = TickCmd()
-		} else if hasAnimations || m.PrefixActive || m.ScriptMode || needsDockTick {
+		} else if hasAnimations || m.PrefixActive || needsScriptFrame || needsDockTick || hasNotifications {
 			nextTick = TickCmd() // Normal FPS when things need periodic updates
 		} else {
 			nextTick = IdleTickCmd() // Slow idle tick (process cleanup, etc.)
@@ -620,7 +634,8 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		hasBackgroundChanges := m.MarkTerminalsWithNewContent()
 
 		// Render on tick if something periodic needs visual updates OR background windows changed
-		needsRender := hadAnimations || hasAnimations || m.InteractionMode || m.PrefixActive || needsDockTick || hasBackgroundChanges
+		needsRender := hadAnimations || hasAnimations || m.InteractionMode || m.PrefixActive ||
+			needsDockTick || hasBackgroundChanges || hasNotifications || leftScriptMode
 		if !needsRender {
 			m.renderSkipped = true
 			if len(cmds) > 1 {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -539,6 +539,16 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 					return m, TickCmd()
 				}
 
+				// Hold the next command until a pane the previous one asked for
+				// actually exists. In a daemon session Split and NewWindow only
+				// send the request; the pane arrives later on a state push, and
+				// until it does GetFocusedWindowID still names the pane the tape
+				// was splitting away from, so the next Type would be typed into
+				// the wrong pane.
+				if !m.scriptPaneReady() {
+					return m, TickCmd()
+				}
+
 				// Check if we're blocking on a WaitUntilRegex condition from a
 				// previously dispatched command.
 				if m.ScriptWaitRegex != nil && !m.checkScriptWaitRegex() {

--- a/internal/tape/executor.go
+++ b/internal/tape/executor.go
@@ -108,9 +108,10 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 
 	switch cmd.Type {
 	case CommandTypeType:
-		if len(cmd.Args) > 0 {
-			return ce.executor.SendToWindow(ce.executor.GetFocusedWindowID(), []byte(cmd.Args[0]))
+		if len(cmd.Args) == 0 {
+			return errMissingArg("Type", "the text to type")
 		}
+		return ce.executor.SendToWindow(ce.executor.GetFocusedWindowID(), []byte(cmd.Args[0]))
 
 	case CommandTypeEnter:
 		// Windows requires \r\n, Unix accepts \n
@@ -179,22 +180,26 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 		return ce.executor.PrevWindow()
 
 	case CommandTypeFocusWindow:
-		if len(cmd.Args) > 0 && cmd.Args[0] != "" {
-			// Try as name first (more user-friendly), fall back to ID
-			if err := ce.executor.FocusWindowByName(cmd.Args[0]); err != nil {
-				// If name lookup fails, try as ID
-				return ce.executor.FocusWindowByID(cmd.Args[0])
-			}
-			return nil
+		if len(cmd.Args) == 0 || cmd.Args[0] == "" {
+			return errMissingArg("Focus", "a window name or id")
 		}
+		// Try as name first (more user-friendly), fall back to ID
+		if err := ce.executor.FocusWindowByName(cmd.Args[0]); err != nil {
+			// If name lookup fails, try as ID
+			return ce.executor.FocusWindowByID(cmd.Args[0])
+		}
+		return nil
 
 	case CommandTypeRenameWindow:
-		if len(cmd.Args) >= 2 {
-			// Two args: old name, new name
-			return ce.executor.RenameWindowByName(cmd.Args[0], cmd.Args[1])
-		} else if len(cmd.Args) == 1 {
+		switch len(cmd.Args) {
+		case 0:
+			return errMissingArg("RenameWindow", "a new name")
+		case 1:
 			// One arg: rename focused window
 			return ce.executor.RenameWindowByID(ce.executor.GetFocusedWindowID(), cmd.Args[0])
+		default:
+			// Two args: old name, new name
+			return ce.executor.RenameWindowByName(cmd.Args[0], cmd.Args[1])
 		}
 
 	case CommandTypeMinimizeWindow:
@@ -230,16 +235,17 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 
 	// BSP Tiling
 	case CommandTypeSplit:
-		if len(cmd.Args) > 0 {
-			direction := strings.ToLower(cmd.Args[0])
-			switch direction {
-			case "horizontal", "h":
-				return ce.executor.SplitHorizontal()
-			case "vertical", "v":
-				return ce.executor.SplitVertical()
-			}
+		if len(cmd.Args) == 0 {
+			return errMissingArg("Split", "horizontal or vertical")
 		}
-		return nil
+		switch strings.ToLower(cmd.Args[0]) {
+		case "horizontal", "h":
+			return ce.executor.SplitHorizontal()
+		case "vertical", "v":
+			return ce.executor.SplitVertical()
+		default:
+			return fmt.Errorf("unknown Split direction %q (use horizontal or vertical)", cmd.Args[0])
+		}
 
 	case CommandTypeRotateSplit:
 		return ce.executor.RotateSplit()
@@ -248,49 +254,48 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 		return ce.executor.EqualizeSplitsExec()
 
 	case CommandTypePreselect:
-		if len(cmd.Args) > 0 {
-			return ce.executor.Preselect(strings.ToLower(cmd.Args[0]))
+		if len(cmd.Args) == 0 {
+			return errMissingArg("Preselect", "left, right, up or down")
 		}
-		return nil
+		return ce.executor.Preselect(strings.ToLower(cmd.Args[0]))
 
 	// Workspace
 	case CommandTypeSwitchWS:
-		if len(cmd.Args) > 0 {
-			ws := 0
-			_, _ = fmt.Sscanf(cmd.Args[0], "%d", &ws)
-			return ce.executor.SwitchWorkspace(ws)
+		ws, err := workspaceArg("Switch", cmd)
+		if err != nil {
+			return err
 		}
+		return ce.executor.SwitchWorkspace(ws)
 
 	case CommandTypeMoveToWS:
-		if len(cmd.Args) > 0 {
-			ws := 0
-			_, _ = fmt.Sscanf(cmd.Args[0], "%d", &ws)
-			return ce.executor.MoveWindowToWorkspaceByID(ce.executor.GetFocusedWindowID(), ws)
+		ws, err := workspaceArg("MoveToWorkspace", cmd)
+		if err != nil {
+			return err
 		}
+		return ce.executor.MoveWindowToWorkspaceByID(ce.executor.GetFocusedWindowID(), ws)
 
 	case CommandTypeMoveAndFollowWS:
-		if len(cmd.Args) > 0 {
-			ws := 0
-			_, _ = fmt.Sscanf(cmd.Args[0], "%d", &ws)
-			return ce.executor.MoveAndFollowWorkspaceByID(ce.executor.GetFocusedWindowID(), ws)
+		ws, err := workspaceArg("MoveAndFollow", cmd)
+		if err != nil {
+			return err
 		}
+		return ce.executor.MoveAndFollowWorkspaceByID(ce.executor.GetFocusedWindowID(), ws)
 
 	case CommandTypeKeyCombo:
-		if len(cmd.Args) > 0 {
-			comboStr := cmd.Args[0]
-			// Handle Alt+N / alt+N for workspace switching (case-insensitive)
-			lowerCombo := strings.ToLower(comboStr)
-			if len(lowerCombo) >= 5 && (lowerCombo[:4] == "alt+" || lowerCombo[:4] == "opt+") {
-				wsStr := comboStr[4:]
-				ws := 0
-				if _, err := fmt.Sscanf(wsStr, "%d", &ws); err == nil && ws >= 1 && ws <= 9 {
-					return ce.executor.SwitchWorkspace(ws)
-				}
-			}
-			// For other key combos, convert to proper bytes and send to the focused window
-			keyBytes := convertKeyComboToBytes(comboStr)
-			return ce.executor.SendToWindow(ce.executor.GetFocusedWindowID(), keyBytes)
+		if len(cmd.Args) == 0 {
+			return errMissingArg("key combo", "a combination such as ctrl+b")
 		}
+		comboStr := cmd.Args[0]
+		// Handle Alt+N / alt+N for workspace switching (case-insensitive)
+		lowerCombo := strings.ToLower(comboStr)
+		if len(lowerCombo) >= 5 && (lowerCombo[:4] == "alt+" || lowerCombo[:4] == "opt+") {
+			ws := 0
+			if _, err := fmt.Sscanf(comboStr[4:], "%d", &ws); err == nil && ws >= 1 && ws <= 9 {
+				return ce.executor.SwitchWorkspace(ws)
+			}
+		}
+		// For other key combos, convert to proper bytes and send to the focused window
+		return ce.executor.SendToWindow(ce.executor.GetFocusedWindowID(), convertKeyComboToBytes(comboStr))
 
 	case CommandTypeWait, CommandTypeWaitUntilRegex:
 		// Wait (a Sleep alias) and WaitUntilRegex are handled by the interactive
@@ -320,64 +325,84 @@ func (ce *CommandExecutor) Execute(cmd *Command) error {
 		return ce.executor.ShowCommandPaletteExec()
 
 	case CommandTypeSaveLayout:
-		if len(cmd.Args) > 0 {
-			return ce.executor.SaveLayoutExec(cmd.Args[0])
+		if len(cmd.Args) == 0 {
+			return errMissingArg("SaveLayout", "a layout name")
 		}
-		return nil
+		return ce.executor.SaveLayoutExec(cmd.Args[0])
 
 	case CommandTypeLoadLayout:
-		if len(cmd.Args) > 0 {
-			return ce.executor.LoadLayoutExec(cmd.Args[0])
+		if len(cmd.Args) == 0 {
+			return errMissingArg("LoadLayout", "a layout name")
 		}
-		return nil
+		return ce.executor.LoadLayoutExec(cmd.Args[0])
 
 	// Config commands
 	case CommandTypeSetConfig:
-		if len(cmd.Args) >= 2 {
-			return ce.executor.SetConfig(cmd.Args[0], cmd.Args[1])
+		if len(cmd.Args) < 2 {
+			return errMissingArg("Set", "a config path and a value")
 		}
-		return nil
+		return ce.executor.SetConfig(cmd.Args[0], cmd.Args[1])
 
 	case CommandTypeSetTheme:
-		if len(cmd.Args) > 0 {
-			return ce.executor.SetTheme(cmd.Args[0])
+		if len(cmd.Args) == 0 {
+			return errMissingArg("SetTheme", "a theme name")
 		}
-		return nil
+		return ce.executor.SetTheme(cmd.Args[0])
 
 	case CommandTypeSetDockbarPosition:
-		if len(cmd.Args) > 0 {
-			return ce.executor.SetDockbarPosition(cmd.Args[0])
+		if len(cmd.Args) == 0 {
+			return errMissingArg("SetDockbarPosition", "top or bottom")
 		}
-		return nil
+		return ce.executor.SetDockbarPosition(cmd.Args[0])
 
 	case CommandTypeSetBorderStyle:
-		if len(cmd.Args) > 0 {
-			return ce.executor.SetBorderStyle(cmd.Args[0])
+		if len(cmd.Args) == 0 {
+			return errMissingArg("SetBorderStyle", "a border style name")
 		}
-		return nil
+		return ce.executor.SetBorderStyle(cmd.Args[0])
 
 	case CommandTypeShowNotification:
-		if len(cmd.Args) > 0 {
-			notifType := "info"
-			if len(cmd.Args) > 1 {
-				notifType = cmd.Args[1]
-			}
-			return ce.executor.ShowNotificationCmd(cmd.Args[0], notifType)
+		if len(cmd.Args) == 0 {
+			return errMissingArg("Notify", "a message")
 		}
-		return nil
+		notifType := "info"
+		if len(cmd.Args) > 1 {
+			notifType = cmd.Args[1]
+		}
+		return ce.executor.ShowNotificationCmd(cmd.Args[0], notifType)
 
 	case CommandTypeFocusDirection:
-		if len(cmd.Args) > 0 {
-			return ce.executor.FocusDirection(strings.ToLower(cmd.Args[0]))
+		if len(cmd.Args) == 0 {
+			return errMissingArg("FocusDirection", "left, right, up or down")
 		}
-		return nil
+		return ce.executor.FocusDirection(strings.ToLower(cmd.Args[0]))
 
 	// Other command types are handled elsewhere or ignored
 	default:
 		return nil
 	}
+}
 
-	return nil
+// errMissingArg reports a tape command that was given no argument to act on.
+// These used to fall through to a bare `return nil`, so a mistyped or truncated
+// command in a tape did nothing at all and reported nothing at all, which is
+// indistinguishable from the command having worked.
+func errMissingArg(command, want string) error {
+	return fmt.Errorf("%s needs %s", command, want)
+}
+
+// workspaceArg parses a workspace number argument. The parse error used to be
+// discarded, so a non-numeric argument became workspace 0 and the command was
+// dropped on the floor by the range check downstream.
+func workspaceArg(command string, cmd *Command) (int, error) {
+	if len(cmd.Args) == 0 {
+		return 0, errMissingArg(command, "a workspace number")
+	}
+	ws, err := strconv.Atoi(strings.TrimSpace(cmd.Args[0]))
+	if err != nil {
+		return 0, fmt.Errorf("%s: %q is not a workspace number", command, cmd.Args[0])
+	}
+	return ws, nil
 }
 
 // repeatCount returns the trailing repeat count of a basic key command, taken

--- a/internal/tape/executor_test.go
+++ b/internal/tape/executor_test.go
@@ -50,3 +50,54 @@ func TestRepeatCount(t *testing.T) {
 		})
 	}
 }
+
+// nopExecutor records nothing and does nothing; it exists so Execute's argument
+// checks can be exercised without an app.
+type nopExecutor struct{ Executor }
+
+func (nopExecutor) GetFocusedWindowID() string                      { return "w1" }
+func (nopExecutor) SendToWindow(_ string, _ []byte) error           { return nil }
+func (nopExecutor) SplitHorizontal() error                          { return nil }
+func (nopExecutor) SplitVertical() error                            { return nil }
+func (nopExecutor) SwitchWorkspace(_ int) error                     { return nil }
+func (nopExecutor) FocusWindowByName(_ string) error                { return nil }
+func (nopExecutor) FocusWindowByID(_ string) error                  { return nil }
+func (nopExecutor) Preselect(_ string) error                        { return nil }
+func (nopExecutor) SaveLayoutExec(_ string) error                   { return nil }
+func (nopExecutor) SetConfig(_, _ string) error                     { return nil }
+func (nopExecutor) ShowNotificationCmd(_, _ string) error           { return nil }
+func (nopExecutor) RenameWindowByID(_, _ string) error              { return nil }
+func (nopExecutor) MoveWindowToWorkspaceByID(_ string, _ int) error { return nil }
+
+// TestExecuteRejectsUnusableCommands pins that a command with nothing to act on
+// reports the problem. Every one of these used to fall through to a bare
+// `return nil`, which is indistinguishable from having worked, so a truncated or
+// mistyped line in a tape did nothing and said nothing.
+func TestExecuteRejectsUnusableCommands(t *testing.T) {
+	ce := NewCommandExecutor(nopExecutor{})
+
+	tests := []struct {
+		name string
+		cmd  Command
+	}{
+		{"Type with no text", Command{Type: CommandTypeType}},
+		{"Split with no direction", Command{Type: CommandTypeSplit}},
+		{"Split with a bad direction", Command{Type: CommandTypeSplit, Args: []string{"sideways"}}},
+		{"Focus with no target", Command{Type: CommandTypeFocusWindow}},
+		{"Preselect with no direction", Command{Type: CommandTypePreselect}},
+		{"RenameWindow with no name", Command{Type: CommandTypeRenameWindow}},
+		{"SaveLayout with no name", Command{Type: CommandTypeSaveLayout}},
+		{"Set with no value", Command{Type: CommandTypeSetConfig, Args: []string{"a.b"}}},
+		{"Notify with no message", Command{Type: CommandTypeShowNotification}},
+		{"Switch with no workspace", Command{Type: CommandTypeSwitchWS}},
+		{"Switch with a non-numeric workspace", Command{Type: CommandTypeSwitchWS, Args: []string{"main"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ce.Execute(&tt.cmd); err == nil {
+				t.Error("Execute returned nil; an unusable command must report why it did nothing")
+			}
+		})
+	}
+}


### PR DESCRIPTION
`TestProjectTapeCurrentScopeRendersLayout` has been failing on CI and passing on re-run. It is not flaky, and it is not a timeout: raising its budget from 20 s to 90 s still failed, at 92.64 s. Saturating the CPU reproduces it 3 times out of 3.

## The pane was never empty. It was covered.

The obvious reading of the failure is that the second pane's shell never started, since the screen shows no prompt and no output for the whole wait. That reading is wrong. Instrumenting the client shows every link in the chain working:

```
[2.848] ScriptCommand Split args=[vertical]  focused=0a7a0185 nwin=1
[2.851] createWindowFromSync id=c7805abf pty=... ws=1         <- pane exists
[2.855] PTYDATA win=c7805abf "\x1b[?2004h$ \r\x1b[K\r$ "      <- shell prompt arrives
[3.806] ScriptCommand Type args=[echo servermark-$((7*8))]    <- typed into the right pane
[3.715] PTYDATA win=c7805abf "\rservermark-56\r\n"            <- output arrives
[5.048] refreshAllPanes win=c7805abf nonempty=38              <- content in the emulator
```

`tuios capture-pane` on the daemon confirmed `servermark-56` in the new pane. The client had the content in its own emulator the whole time.

What failed was the last step. Logging every `View()`:

```
[5.079] VIEW skipped=false notifs=2
[5.180] VIEW skipped=true  notifs=2
... 175 more identical lines ...
[22.809] VIEW skipped=true  notifs=2      <- the test gives up here
```

Composition stopped at t=5.079 s and the render cache was served for the next 17 seconds. That frozen frame had the tape's own toasts drawn over the right half of the screen, exactly on top of the new pane's first three lines.

## Why the freeze sustains itself

Notifications expire on a wall-clock timer, but the only thing that retires one is `CleanupNotifications`, which runs **inside frame composition** (`render_overlays.go:614`). The tick's `needsRender` had no term for "a notification is on screen". With the panes idle, nothing drew, so nothing cleaned up, so the toast stayed, forever. `NotificationDuration` is 1500 ms; the frozen frame was still showing those toasts at t=22 s.

Proof it was the render loop and not the model: adding a bare 2-second `tea.Tick` that only forces an Update/View cycle made the test pass 7/7 with no other change, and removing it made it fail 3/3.

A notification on screen is now a reason to draw. Separately, `maybeExitFinishedScript` already returned whether it left script mode, and the caller was discarding it, so the tape's DONE indicator froze the same way.

## Also here

**A bounded pane-readiness gate.** `Split`, `NewWindow` and `SmartSplit` only *ask* the daemon for a pane, and `SendIntent` is fire-and-forget. Playback now holds the next command until the window set actually grows, bounded at 5 s with a loud error on timeout. This is hardening rather than the root cause: in every log captured, the pane arrived first, because the split animation happens to give the daemon about a second. With `DisableAnimations` in a tape that gap collapses to a single tick, and the race is real even though it could not be forced in six loaded runs.

**A silent no-op audit, which found a lot.** `Split`, `RotateSplit`, `EqualizeSplits`, `Preselect` and `SmartSplit` all returned `nil` when tiling was off. `Snap` fell through to the top-left quarter for any unrecognised direction. `FocusDirection` did nothing when no window lay that way. The workspace commands discarded the `Sscanf` error, so `Switch "main"` silently became workspace 0 and was then dropped by a range check that also returned `nil`. Eleven commands did nothing at all when given no argument. All of these now return errors, which playback already surfaces as notifications. A tape command that quietly does nothing is a bad failure mode on its own.

**Timeout consolidation.** 22 inline literals in `e2e/tui` moved onto four named tiers plus `terminalModeProbe`. No budget was shortened; the 15 s waits became 20 s and everything else kept its value. An inline literal is what disguised this bug as flakiness, so this is worth doing on its own.

## Verification

| | before | after |
| --- | --- | --- |
| the test, CPU saturated | fail 3/3 | pass 5/5, and again after the e2e refactor |
| full `e2e/tui`, CPU saturated | | pass, 126 s then 153 s |

New regression tests `TestNotificationKeepsTheFrameDrawing` and `TestFinishedScriptExitDrawsOnce` both fail on `origin/main` and pass here, verified with a negative control. Plus unit coverage for the readiness gate and the argument checks.

**The 20 s budget was never wrong.** The test was waiting on a frame that was never going to be drawn.