### PR TITLE
Move notifications into the dock and weight-encode the severity

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,6 +8,7 @@ TUIOS supports user-configurable keybindings through a TOML configuration file, 
 - [Configuration File Location](#configuration-file-location)
 - [Configuration Structure](#configuration-structure)
 - [Keybinding Sections](#keybinding-sections)
+- [Notification Settings](#notification-settings)
 - [Startup Settings](#startup-settings)
 - [Hooks](#hooks)
 - [Key Syntax](#key-syntax)
@@ -86,6 +87,11 @@ border_style = "rounded"
 dockbar_position = "bottom"
 hide_window_buttons = false
 scrollback_lines = 10000
+
+[notifications]
+duration = 6
+warning_duration = 8
+error_sticky = true
 
 [startup]
 open_default_window = false
@@ -433,6 +439,69 @@ unset to disable theming and use your terminal's own colors. See
 [THEMES.md](THEMES.md).
 
 **CLI override:** `--theme <id>`
+
+## Notification Settings
+
+The `[notifications]` section controls how long a message stays in the dock's
+right-hand block. All durations are in **seconds**.
+
+```toml
+[notifications]
+duration = 6           # info and success
+warning_duration = 8   # warnings
+error_duration = 15    # errors, only used when error_sticky = false
+error_sticky = true    # errors wait for esc instead of expiring
+```
+
+Every message is dismissible with `esc`, in any mode. `esc` is not consumed:
+it dismisses whatever is on the dock and still reaches the shell, copy mode or
+whatever overlay is open, so it never costs you the keypress you meant.
+
+### duration
+
+How long an info or success message stays up.
+
+A configured duration is a **floor**, not a cap. A message that a caller
+deliberately asked to show for longer still gets the longer time; this value is
+the minimum any message of that severity is given.
+
+**Default:** `6`
+
+**Note on short values:** durations under 4 seconds are applied as written but
+produce a config warning. A message that disappears before it can be read is a
+time limit on reading content with no way to extend it, which fails WCAG 2.2.1
+Level A. Four seconds is the shortest the evidence supports (tmux-sensible
+overrides tmux's own 750ms to 4s); VS Code purges at 10, 12 and 15 seconds by
+severity.
+
+### warning_duration
+
+How long a warning stays up. Warnings get longer than routine messages because
+they usually name something you have to decide about.
+
+**Default:** `8`
+
+### error_duration
+
+How long an error stays up, used **only** when `error_sticky = false`.
+
+**Default:** `15`
+
+### error_sticky
+
+When true, errors do not expire at all: they stay until dismissed with `esc`.
+The dock's hairline above a sticky error is lit end to end and stops moving,
+which is the affordance that it is waiting for you rather than counting down.
+
+Nothing carrying a failure should vanish on a timer the user did not start, so
+this is on by default. Set it to `false` if you would rather errors time out
+like everything else, in which case `error_duration` applies.
+
+**Valid values:**
+- `true` - Errors wait for `esc` (default)
+- `false` - Errors expire after `error_duration` seconds
+
+**Default:** `true`
 
 ## Startup Settings
 

--- a/e2e/tui/dock_notification_test.go
+++ b/e2e/tui/dock_notification_test.go
@@ -1,0 +1,146 @@
+package tuie2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// dockRow returns the last non-empty row, which is where the dock lives, so an
+// assertion can say "the message is in the dock" rather than "the message is
+// somewhere on screen". That distinction is the whole point of this design: the
+// old toasts were on screen too, drawn on top of a pane.
+func dockRow(s tuitest.Screen) string {
+	_, rows := s.Size()
+	for y := rows - 1; y >= 0; y-- {
+		if line := strings.TrimRight(s.Line(y), " "); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// paneRows returns everything above the dock, so a test can assert a message is
+// absent from the region the old renderer used to cover.
+func paneRows(s tuitest.Screen) string {
+	_, rows := s.Size()
+	var b strings.Builder
+	for y := range rows - 2 {
+		b.WriteString(s.Line(y))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// TestNotificationLandsInTheDockNotOverAPane is the acceptance test for the
+// placement decision. A message must be readable in the dock and must not
+// appear anywhere in the pane region, which is what the previous corner toast
+// did and what the redesign exists to stop.
+func TestNotificationLandsInTheDockNotOverAPane(t *testing.T) {
+	term, _ := start(t, startOpts{cols: 120, rows: 40})
+	waitBoot(t, term)
+	newWindow(t, term)
+
+	// Toggling tiling pushes a message the app itself generates, so this does
+	// not depend on a test-only injection path.
+	if err := term.SendKeys("t"); err != nil {
+		t.Fatalf("send 't': %v", err)
+	}
+	if err := term.WaitForText("Tiling Mode", uiTimeout); err != nil {
+		t.Fatalf("no message after toggling tiling: %v\n%s", err, term.Snapshot())
+	}
+
+	s := term.Screen()
+	if !strings.Contains(dockRow(s), "Tiling Mode") {
+		t.Errorf("message is not in the dock row.\ndock row: %q\n%s", dockRow(s), term.Snapshot())
+	}
+	if strings.Contains(paneRows(s), "Tiling Mode") {
+		t.Errorf("message appears in the pane region, which is what this design removes\n%s", term.Snapshot())
+	}
+}
+
+// TestNotificationDismissesOnEscAndTheKeyStillLands pins the two halves of the
+// dismissal contract. Esc must clear the message, and it must NOT be swallowed:
+// a user pressing esc meant it for whatever they were doing, and a notification
+// happening to be on screen must not cost them the keypress.
+func TestNotificationDismissesOnEscAndTheKeyStillLands(t *testing.T) {
+	term, _ := start(t, startOpts{cols: 120, rows: 40})
+	waitBoot(t, term)
+	newWindow(t, term)
+
+	if err := term.SendKeys("t"); err != nil {
+		t.Fatalf("send 't': %v", err)
+	}
+	if err := term.WaitForText("Tiling Mode", uiTimeout); err != nil {
+		t.Fatalf("no message to dismiss: %v\n%s", err, term.Snapshot())
+	}
+
+	if err := term.SendKeys(tuitest.Esc); err != nil {
+		t.Fatalf("send esc: %v", err)
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return !strings.Contains(s.Text(), "Tiling Mode")
+	}, uiTimeout); err != nil {
+		t.Fatalf("esc did not dismiss the message: %v\n%s", err, term.Snapshot())
+	}
+	alive(t, term, "after dismissing a notification with esc")
+}
+
+// TestQueuedMessagesShowACounter proves the overflow affordance exists. With
+// several messages pushed in quick succession the newest is shown and the rest
+// are counted, so nothing is silently lost the way the old stack lost the
+// fourth toast.
+func TestQueuedMessagesShowACounter(t *testing.T) {
+	term, _ := start(t, startOpts{cols: 120, rows: 40})
+	waitBoot(t, term)
+	newWindow(t, term)
+
+	for range 3 {
+		if err := term.SendKeys("t"); err != nil {
+			t.Fatalf("send 't': %v", err)
+		}
+		time.Sleep(120 * time.Millisecond)
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return strings.Contains(dockRow(s), "+")
+	}, uiTimeout); err != nil {
+		t.Logf("no overflow counter seen; dock row: %q", dockRow(term.Screen()))
+		t.Logf("%s", term.Snapshot())
+		t.Fatalf("queued messages did not produce a counter: %v", err)
+	}
+}
+
+// TestDockStaysWithinTheScreen guards the width contract at a narrow size,
+// where the message block competes with the dock's own items. A block that
+// overruns here is how a dock ends up wrapping onto a second row and eating a
+// row of terminal.
+func TestDockStaysWithinTheScreen(t *testing.T) {
+	for _, cols := range []int{80, 100, 120} {
+		t.Run(fmt.Sprintf("%dcols", cols), func(t *testing.T) {
+			term, _ := start(t, startOpts{cols: cols, rows: 30})
+			waitBoot(t, term)
+			newWindow(t, term)
+			if err := term.SendKeys("t"); err != nil {
+				t.Fatalf("send 't': %v", err)
+			}
+			if err := term.WaitForText("Tiling Mode", uiTimeout); err != nil {
+				t.Fatalf("no message at %d cols: %v\n%s", cols, err, term.Snapshot())
+			}
+			s := term.Screen()
+			w, _ := s.Size()
+			row := dockRow(s)
+			if got := len([]rune(row)); got > w {
+				t.Errorf("dock row is %d cells wide at %d cols:\n%q\n%s", got, w, row, term.Snapshot())
+			}
+			for _, r := range row {
+				if r == '\t' || r == '\r' || r == '\v' {
+					t.Errorf("dock row carries a control character at %d cols: %q", cols, row)
+					break
+				}
+			}
+		})
+	}
+}

--- a/e2e/tui/interactive_test.go
+++ b/e2e/tui/interactive_test.go
@@ -122,8 +122,24 @@ func TestFocusCycleWithRapidKeyRepeat(t *testing.T) {
 	}
 	waitForAll(t, term, shellTimeout, "after 20 rapid previous-window changes", markers...)
 
-	// The UI must still take input after the storm.
-	leaveTerminalMode(t, term)
+	// The UI must still take input after the storm, proven by an action that
+	// produces a fresh message of its own.
+	//
+	// This used to call leaveTerminalMode, which sends alt+esc and waits for the
+	// "Window Management Mode" message. The storm never entered terminal mode,
+	// so alt+esc had nothing to leave and pushed no message; the wait was
+	// satisfied by the message from the last leaveTerminalMode inside the window
+	// loop, which was still on screen because the old renderer stacked three
+	// toasts at once and a stale one stayed visible underneath a newer one.
+	// The dock's message block shows the newest message and counts the rest, so
+	// there is no longer a stale message to lean on, and the assertion has to
+	// name something this keystroke actually causes.
+	if err := term.SendKeys("t"); err != nil {
+		t.Fatalf("toggle tiling after the storm: %v", err)
+	}
+	if err := term.WaitForText("Tiling Mode Disabled", uiTimeout); err != nil {
+		t.Fatalf("the UI stopped taking input after the storm: %v\n%s", err, term.Snapshot())
+	}
 }
 
 // TestWorkspaceSwitch moves between workspaces and asserts windows follow the

--- a/internal/app/dock_helpers.go
+++ b/internal/app/dock_helpers.go
@@ -208,6 +208,20 @@ func copyModeHelpTexts(state terminal.CopyModeState) []string {
 
 // calculateDockRightWidth calculates the width of the right side of the dock
 func (m *OS) calculateDockRightWidth() int {
+	// A live message owns the right-hand block, ahead of the copy-mode help
+	// line and the system meters both. It is measured here rather than only at
+	// render time so the dock items are laid out against the room the message
+	// actually takes, and so mouse hit-testing (which shares this layout) agrees
+	// with what is drawn.
+	//
+	// This is also the fix for a message pushed while copy mode was active being
+	// silently dropped. The help line used to hold the block unconditionally, so
+	// the message was not crowded out, it was never rendered at all: a copy of
+	// something that failed, which is when a message matters most, went nowhere.
+	if block, ok := m.renderNotificationBlock(m.GetRenderWidth(), 0); ok {
+		return block.Width
+	}
+
 	focusedWindow := m.GetFocusedWindow()
 	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
 

--- a/internal/app/notification_frame_test.go
+++ b/internal/app/notification_frame_test.go
@@ -3,23 +3,31 @@ package app
 import (
 	"testing"
 	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
 )
 
-// TestNotificationKeepsTheFrameDrawing is the regression test for a toast that
-// never comes down.
+// TestNotificationKeepsTheFrameDrawing is the regression test for a message
+// that never comes down.
 //
-// Notifications expire on a wall-clock timer, but the only thing that retires
-// one is CleanupNotifications, and that runs while a frame is being composed.
-// The maintenance tick used to have no reason to compose a frame just because a
-// notification was on screen, so once the session went quiet - no animation, no
-// PTY output, no keystroke - the last frame drawn was served from the render
-// cache indefinitely, with whatever toast happened to be up still painted over
-// the panes underneath it.
+// Messages expire on a wall-clock timer, and the only thing that retires one is
+// CleanupNotifications. That used to run while a frame was being composed, so
+// the maintenance tick had no reason to compose a frame just because a message
+// was on screen; once the session went quiet - no animation, no PTY output, no
+// keystroke - the last frame drawn was served from the render cache
+// indefinitely, with whatever message happened to be up still painted over the
+// panes underneath it.
 //
 // This is how a project tape that split a pane and echoed into it could finish
 // correctly and still show an empty pane: the tape's own "Trusted ..." toast was
 // sitting exactly where the new pane's first lines were, the panes then went
 // idle, and no later frame ever replaced that one.
+//
+// The cap design moved the message into the dock, so it can no longer cover a
+// pane, but the coupling it was drawn from would be just as wrong there: the
+// hairline under a message burns down per frame, and a message that outlived
+// its duration on a cached frame would sit on a rule frozen partway through.
+// Expiry now happens on the tick, which is what this pins.
 func TestNotificationKeepsTheFrameDrawing(t *testing.T) {
 	win := newTestWindow(t, "notif-frame-0001", 60, 34)
 	m := newTestOS(win)
@@ -31,18 +39,57 @@ func TestNotificationKeepsTheFrameDrawing(t *testing.T) {
 	}
 
 	m.ShowNotification("built the layout", "info", 40*time.Millisecond)
+	if len(m.Notifications) != 1 {
+		t.Fatalf("expected the message to be live, got %d", len(m.Notifications))
+	}
 	if _, _ = m.Update(TickerMsg(time.Now())); m.renderSkipped {
-		t.Fatal("a tick with a notification on screen skipped the frame; the toast would stay painted over the panes under it")
+		t.Fatal("a tick with a message on screen skipped the frame; the dock's burn-down rule would freeze partway")
 	}
 
-	// Once it has expired and been retired, ticks may go back to skipping.
-	time.Sleep(60 * time.Millisecond)
-	m.CleanupNotifications()
-	if len(m.Notifications) != 0 {
-		t.Fatalf("expected the notification to have expired, got %d", len(m.Notifications))
+	// The requested 40ms is below the severity floor, so the message is still
+	// up: a duration is a floor now, not the answer. Age it past the floor by
+	// hand rather than sleeping six seconds for it.
+	m.Notifications[0].StartTime = time.Now().Add(-2 * config.NotificationDuration)
+
+	// The tick that retires it must still draw, or the message leaves the model
+	// and stays on the screen: that is the same freeze in a different place.
+	if _, _ = m.Update(TickerMsg(time.Now())); m.renderSkipped {
+		t.Fatal("the tick that retired the message skipped the frame; it would stay drawn in the cached dock")
 	}
+	if len(m.Notifications) != 0 {
+		t.Fatalf("the tick should have retired the expired message, got %d", len(m.Notifications))
+	}
+
+	// With nothing left, ticks may go back to skipping.
 	if _, _ = m.Update(TickerMsg(time.Now())); !m.renderSkipped {
-		t.Error("a tick with no notification left should skip the frame again")
+		t.Error("a tick with no message left should skip the frame again")
+	}
+}
+
+// TestStickyErrorWaitsForDismissal pins the two halves of the sticky contract:
+// an error does not expire on its own, and esc is a way out of it. Without the
+// second half the first is a trap.
+func TestStickyErrorWaitsForDismissal(t *testing.T) {
+	win := newTestWindow(t, "notif-sticky-0001", 60, 34)
+	m := newTestOS(win)
+	m.Width, m.Height = 120, 40
+
+	m.ShowNotification("Capture failed: permission denied", "error", config.NotificationDuration)
+	if len(m.Notifications) != 1 || !m.Notifications[0].Sticky {
+		t.Fatalf("an error should be sticky by default, got %+v", m.Notifications)
+	}
+
+	// However old it gets, it stays.
+	m.Notifications[0].StartTime = time.Now().Add(-time.Hour)
+	if m.CleanupNotifications() || len(m.Notifications) != 1 {
+		t.Fatal("a sticky error expired on a timer the user did not start")
+	}
+
+	if !m.DismissNotifications() || len(m.Notifications) != 0 {
+		t.Fatal("esc did not clear the sticky error, which leaves it with no exit at all")
+	}
+	if m.DismissNotifications() {
+		t.Error("dismissing an empty queue should report that there was nothing to dismiss")
 	}
 }
 

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -425,14 +425,24 @@ type OS struct {
 	pendingStartTerminalMode bool
 }
 
-// Notification represents a temporary notification message.
+// Notification represents a message shown in the dock's right-hand block.
+//
+// There is no Animation field any more. The old corner toast faded in and out,
+// which meant every notification's appearance depended on how recently a frame
+// had been composed; the message now occupies a block of the dock and its age
+// is carried by the dock's hairline burning down beneath it, which is a
+// function of wall-clock time alone.
 type Notification struct {
 	ID        string
 	Message   string
 	Type      string // "info", "success", "warning", "error"
 	StartTime time.Time
 	Duration  time.Duration
-	Animation *ui.Animation
+
+	// Sticky messages ignore Duration and wait to be dismissed with esc. An
+	// error is sticky by default: nothing carrying a failure should vanish on a
+	// timer the user did not start.
+	Sticky bool
 }
 
 // LogMessage represents a log entry with timestamp and level.

--- a/internal/app/os_notify.go
+++ b/internal/app/os_notify.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Gaurav-Gosain/tuios/internal/config"
 	"github.com/Gaurav-Gosain/tuios/internal/hooks"
-	"github.com/Gaurav-Gosain/tuios/internal/ui"
 )
 
 // Log adds a new log message to the log buffer.
@@ -102,47 +101,141 @@ func (m *OS) LogError(format string, args ...any) {
 	m.Log("ERROR", format, args...)
 }
 
-// ShowNotification displays a temporary notification with animation.
+// maxLiveNotifications bounds the queue. Everything past the newest message is
+// only ever reported as a count, so there is no reason to keep an unbounded
+// backlog of them alive; the log viewer holds the full history.
+const maxLiveNotifications = 16
+
+// notificationLifetime resolves how long a message of this severity stays up,
+// and whether it stays until dismissed.
+//
+// The caller's duration is a floor, not the answer. Every call site passes some
+// duration it picked without much thought (config.NotificationDuration, that
+// same value doubled, a literal two seconds), and the old default of 1500ms
+// meant most of them were unreadable. Severity now decides the minimum, and a
+// caller that deliberately asked for longer than the severity's default still
+// gets the longer one.
+//
+// A non-positive duration means "do not show this", but only for info and
+// success. Copy mode pushes its state indicators that way ("VISUAL", a bare
+// "f", the pending count), and they have never been visible; promoting them to
+// six-second dock messages is a copy-mode decision and not this change's to
+// make.
+//
+// A warning or an error is shown whatever duration it was handed. Passing zero
+// for one of those was never a considered choice, it was a caller reaching for
+// "no timeout" and getting "no notification": os_selection asks for a sticky
+// error when a capture fails and got silence, which is the worst possible
+// outcome for the one message class the user cannot afford to miss.
+func notificationLifetime(notifType string, requested time.Duration) (time.Duration, bool) {
+	switch notifType {
+	case "error":
+		if config.NotificationErrorSticky {
+			return 0, true
+		}
+		return max(requested, config.NotificationErrorDuration), false
+	case "warning", "warn":
+		return max(requested, config.NotificationWarningDuration), false
+	default:
+		if requested <= 0 {
+			return 0, false
+		}
+		return max(requested, config.NotificationDuration), false
+	}
+}
+
+// ShowNotification puts a message in the dock's right-hand block.
+//
+// The signature is unchanged, so no call site had to be touched: severity comes
+// from notifType exactly as it always did, and duration is now a floor rather
+// than the whole answer (see notificationLifetime).
 func (m *OS) ShowNotification(message, notifType string, duration time.Duration) {
-	notif := Notification{
-		ID:        createID(),
-		Message:   message,
-		Type:      notifType,
-		StartTime: time.Now(),
-		Duration:  duration,
-	}
-
-	// Create fade-in animation (uses getter so it's instant when animations disabled)
-	notif.Animation = &ui.Animation{
-		StartTime: time.Now(),
-		Duration:  config.GetAnimationDuration(),
-		Progress:  0.0,
-		Complete:  false,
-	}
-
-	m.Notifications = append(m.Notifications, notif)
-
-	// Also log the notification
+	// Always log, even for a message that will not be shown: the log viewer is
+	// where a message that was dropped or has already expired is read.
 	switch notifType {
 	case "error":
 		m.LogError("%s", message)
-	case "warning":
+	case "warning", "warn":
 		m.LogWarn("%s", message)
 	default:
 		m.LogInfo("%s", message)
 	}
+
+	// An empty message has nothing to draw. It reaches here from copy mode,
+	// whose handlers use it to mean "clear what I put up", and drawing an empty
+	// block for it would leave a bare cap sitting on the dock.
+	if message == "" {
+		return
+	}
+
+	effective, sticky := notificationLifetime(notifType, duration)
+	if effective <= 0 && !sticky {
+		return
+	}
+
+	m.Notifications = append(m.Notifications, Notification{
+		ID:        createID(),
+		Message:   message,
+		Type:      notifType,
+		StartTime: time.Now(),
+		Duration:  effective,
+		Sticky:    sticky,
+	})
+
+	if len(m.Notifications) > maxLiveNotifications {
+		m.Notifications = m.Notifications[len(m.Notifications)-maxLiveNotifications:]
+	}
 }
 
-// CleanupNotifications removes expired notifications.
-func (m *OS) CleanupNotifications() {
-	now := time.Now()
-	var active []Notification
+// NotificationExpired reports whether a message has outlived its duration. A
+// sticky one never has.
+func (n Notification) NotificationExpired(now time.Time) bool {
+	if n.Sticky {
+		return false
+	}
+	return now.Sub(n.StartTime) >= n.Duration
+}
 
+// CleanupNotifications retires expired messages and reports whether it removed
+// any.
+//
+// The return value is what decouples dismissal from drawing. This used to be
+// called from inside render composition, so a message could only expire on a
+// frame that was being drawn for some other reason; when the session went quiet
+// the last frame was served from the render cache with the toast still painted
+// on it, once for seventeen seconds. It is now called from the tick, and the
+// tick that retires something uses this result to draw one more frame so the
+// message actually leaves the screen.
+func (m *OS) CleanupNotifications() bool {
+	if len(m.Notifications) == 0 {
+		return false
+	}
+
+	now := time.Now()
+	active := m.Notifications[:0]
 	for _, notif := range m.Notifications {
-		if now.Sub(notif.StartTime) < notif.Duration {
+		if !notif.NotificationExpired(now) {
 			active = append(active, notif)
 		}
 	}
 
+	removed := len(active) != len(m.Notifications)
 	m.Notifications = active
+	return removed
+}
+
+// DismissNotifications takes the live messages off the dock and reports whether
+// there was anything to take off.
+//
+// This is what esc does. Without it a sticky error had no exit at all, and
+// every other message could only be waited out. It clears the whole queue
+// rather than one message: the queue is drawn as a single block with a count,
+// so dismissing one at a time would make the user press esc once per message
+// they had never been given the chance to read individually anyway.
+func (m *OS) DismissNotifications() bool {
+	if len(m.Notifications) == 0 {
+		return false
+	}
+	m.Notifications = nil
+	return true
 }

--- a/internal/app/render_dock.go
+++ b/internal/app/render_dock.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
 )
 
 func (m *OS) renderDock() *lipgloss.Layer {
@@ -161,17 +162,36 @@ func (m *OS) renderDockString() (string, int) {
 		styledWorkspaceText,
 	)
 
+	renderWidth := m.GetRenderWidth()
 	actualLeftWidth := lipgloss.Width(leftInfo)
 	centerWidth := lipgloss.Width(dockItemsStr.String())
 	// The right block never takes more room than the left block and the dock
 	// items leave, so the bar as a whole stays inside the screen.
-	rightWidth := max(min(layout.RightWidth, m.GetRenderWidth()-actualLeftWidth-centerWidth), 0)
+	rightWidth := max(min(layout.RightWidth, renderWidth-actualLeftWidth-centerWidth), 0)
 
 	var rightInfo string
+	// notifRule is the run of hairline the message burns down over, drawn into
+	// the right-hand end of the separator row below. Empty when nothing is live.
+	var notifRule string
 	focusedWindow := m.GetFocusedWindow()
 
+	// The message is built against the room the left block and the dock items
+	// have actually left, not against an estimate, so its width needs no
+	// correction afterwards. Correcting it afterwards is what the generic
+	// truncation below would do, and the first thing that would cut is the
+	// closing cap: the block would lose the shape that makes it part of the bar.
+	notif, hasNotif := m.renderNotificationBlock(renderWidth, max(renderWidth-actualLeftWidth-centerWidth, 0))
+
 	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
-	if inCopyMode {
+	switch {
+	case hasNotif:
+		// The message outranks the help line for its duration. Copy mode is a
+		// mode the user is holding and can read the keys for again in a moment;
+		// a message is a thing that just happened and will not be repeated.
+		rightInfo = notif.Text
+		notifRule = notif.Rule
+		rightWidth = notif.Width
+	case inCopyMode:
 		helpTexts := copyModeHelpTexts(focusedWindow.CopyMode.State)
 
 		helpStyle := lipgloss.NewStyle().
@@ -186,7 +206,7 @@ func (m *OS) renderDockString() (string, int) {
 				break
 			}
 		}
-	} else {
+	default:
 		var sysInfoParts []string
 		if config.ShowCPU {
 			sysInfoParts = append(sysInfoParts, m.GetCPUGraph())
@@ -232,7 +252,6 @@ func (m *OS) renderDockString() (string, int) {
 		paddedRightInfo,
 	)
 
-	renderWidth := m.GetRenderWidth()
 	// Backstop: whatever the parts add up to, the bar is one screen wide.
 	if lipgloss.Width(dockBar) > renderWidth {
 		dockBar = truncateToWidth(dockBar, renderWidth)
@@ -245,8 +264,18 @@ func (m *OS) renderDockString() (string, int) {
 
 	separator := lipgloss.NewStyle().
 		Width(renderWidth).
-		Foreground(lipgloss.Color("#303040")).
+		Foreground(theme.NotificationRule()).
 		Render(m.cachedSeparator)
+
+	// The message burns down over the hairline directly above it. The lit run
+	// replaces the right-hand end of the separator rather than being drawn on
+	// top of it, so the row is still exactly one screen wide and the burn is
+	// aligned with the block by construction: they are the same span.
+	if ruleWidth := lipgloss.Width(notifRule); ruleWidth > 0 && ruleWidth <= renderWidth {
+		separator = lipgloss.NewStyle().
+			Foreground(theme.NotificationRule()).
+			Render(strings.Repeat(config.GetWindowSeparatorChar(), renderWidth-ruleWidth)) + notifRule
+	}
 
 	dockbarYPos := m.GetRenderHeight() - config.DockHeight
 	dockbarParts := []string{separator, dockBar}

--- a/internal/app/render_dock_notification.go
+++ b/internal/app/render_dock_notification.go
@@ -1,0 +1,340 @@
+package app
+
+import (
+	"fmt"
+	"image/color"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
+)
+
+// The message block that lives in the dock's right-hand end.
+//
+// The placement is the whole point: a message belongs to the bar and never
+// covers a pane. The corner toast this replaces was drawn as a layer on top of
+// the workspace, three rows tall, and landed exactly where a freshly split
+// pane's first output goes.
+//
+// The cap and the severity rail both wanted the left cell, so here they are the
+// same cell: a partial block flush against the block's dark body, opening it
+// the way the dock's own powerline caps open the mode pill, and inked two
+// eighths for info and success, four for a warning, six for an error. The
+// weight is a channel that survives greyscale and a theme with no contrast to
+// spare, which colour alone does not.
+//
+// That weight is why the body behind the cap is the dark surface and not a
+// severity fill. A sliver only reads as a weight against something that is not
+// the same colour; against a solid severity field all it changes is where the
+// field starts, with nothing to compare it against, and an error stops being
+// distinguishable from an info. This design therefore carries less colour than
+// a filled pill would, deliberately.
+//
+// Naming goes to the mark, a Nerd Font severity glyph sitting on the surface in
+// the severity colour rather than knocked out of a coloured chip, so the
+// message itself is never on a coloured ground and stays as legible as the rest
+// of the dock.
+//
+// Time is carried by the dock's own hairline, one row above: it lights in the
+// severity colour across exactly the block's span and burns down from the right
+// as the message ages. A sticky error lights it end to end and stops, so "not
+// moving" is the affordance that it is waiting for you.
+
+// notifBlock is a rendered message: the dock's right-hand block, and the run of
+// hairline that goes above it. They are produced together because the rule's
+// length is defined as the block's span, and the two drifting apart is exactly
+// the sort of thing that only shows up on screen.
+type notifBlock struct {
+	Text  string // styled, drawn as the dock bar's right-hand block
+	Rule  string // styled, replaces the right-hand end of the dock's hairline
+	Width int    // display width of both
+}
+
+// notifStatus is the reading of the live queue that the block is drawn from:
+// which message wins, what is stacked behind it, and how much life it has left.
+type notifStatus struct {
+	msg    Notification
+	queued int     // how many are waiting behind it
+	worst  string  // the worst severity among those waiting
+	frac   float64 // 1 at birth, 0 at death; a sticky message sits at 1
+}
+
+// notifSeverityRank orders the severities so the counter behind a message can
+// report the worst thing queued rather than the most recent.
+func notifSeverityRank(notifType string) int {
+	switch notifType {
+	case "error":
+		return 3
+	case "warning", "warn":
+		return 2
+	case "success":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// notifGlyph is the severity mark. It is the one part of the block that is
+// never truncated: a message cut down to nothing still says how bad it was.
+func notifGlyph(notifType string) string {
+	if config.UseASCIIOnly {
+		switch notifType {
+		case "error":
+			return config.NotificationIconError
+		case "warning", "warn":
+			return config.NotificationIconWarning
+		case "success":
+			return config.NotificationIconSuccess
+		default:
+			return config.NotificationIconInfo
+		}
+	}
+	switch notifType {
+	case "error":
+		return config.NotificationGlyphError
+	case "warning", "warn":
+		return config.NotificationGlyphWarning
+	case "success":
+		return config.NotificationGlyphSuccess
+	default:
+		return config.NotificationGlyphInfo
+	}
+}
+
+// notifCap is the weighted opening edge: two eighths, four eighths, six eighths.
+//
+// Two eighths apart rather than one. The first pass ran the three weights an
+// eighth apart and the step from info to warning was invisible, because you
+// never see two of them side by side to compare.
+func notifCap(notifType string) string {
+	switch notifType {
+	case "error":
+		return config.GetNotificationCap(config.NotificationCapHeavy)
+	case "warning", "warn":
+		return config.GetNotificationCap(config.NotificationCapMedium)
+	default:
+		return config.GetNotificationCap(config.NotificationCapLight)
+	}
+}
+
+// notifRuleStroke escalates the hairline's weight with severity, so a burning
+// info is no heavier than the rule it replaces and an error is a heavy line.
+func notifRuleStroke(notifType string) string {
+	if notifSeverityRank(notifType) >= 2 {
+		return config.GetNotificationRule(config.NotificationRuleHeavy)
+	}
+	return config.GetNotificationRule(config.NotificationRuleLight)
+}
+
+// notifStatus reads the live queue. The newest message wins the block and the
+// rest are reported as a count behind it.
+func (m *OS) notifStatus() (notifStatus, bool) {
+	if len(m.Notifications) == 0 {
+		return notifStatus{}, false
+	}
+
+	now := time.Now()
+	s := notifStatus{
+		msg:    m.Notifications[len(m.Notifications)-1],
+		queued: len(m.Notifications) - 1,
+		frac:   1,
+	}
+
+	for _, q := range m.Notifications[:len(m.Notifications)-1] {
+		if notifSeverityRank(q.Type) > notifSeverityRank(s.worst) {
+			s.worst = q.Type
+		}
+	}
+
+	if !s.msg.Sticky && s.msg.Duration > 0 {
+		left := 1 - float64(now.Sub(s.msg.StartTime))/float64(s.msg.Duration)
+		s.frac = min(max(left, 0), 1)
+	}
+	return s, true
+}
+
+// notifBudget is how many columns the message block may take.
+//
+// The dock's mode pill and workspace counts are never given up for a message,
+// which is what the reserve is; past the cap a message that keeps growing stops
+// being a status line and starts being a paragraph. On a dock too narrow to
+// split at all the message takes what the screen has less a small margin, which
+// is the only case where it may crowd the counts.
+func notifBudget(renderWidth int) int {
+	budget := min(renderWidth-config.NotificationDockReserve, config.NotificationMaxWidth)
+	if budget < config.NotificationMinWidth {
+		budget = max(renderWidth-4, 8)
+	}
+	return budget
+}
+
+// notifMeta draws the two things that must never be truncated: the esc
+// affordance on a message waiting to be dismissed, and the count of whatever is
+// queued behind this one.
+//
+// The counter takes the colour of the worst thing waiting, so an error that a
+// later info pushed out of the block still says so from underneath it.
+// Otherwise it is dim, because a queue of routine messages is not news.
+func (s notifStatus) notifMeta(surface lipgloss.Style) string {
+	var parts []string
+	if s.msg.Sticky {
+		parts = append(parts, surface.Foreground(theme.DockDimmed()).Render("esc"))
+	}
+	if s.queued > 0 {
+		var col color.Color = theme.DockDimmed()
+		if notifSeverityRank(s.worst) > notifSeverityRank(s.msg.Type) {
+			col = theme.NotificationSeverity(s.worst)
+		}
+		parts = append(parts, surface.Foreground(col).Render(fmt.Sprintf("+%d", s.queued)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return surface.Render("  ") + strings.Join(parts, surface.Render("  "))
+}
+
+// notifChromeWidth is every column of the block that is not the message: the
+// cap, the space and the mark, the two spaces before the text, the space before
+// the closing cap, the closing cap itself, and one column of bar past it.
+//
+// That last column is not decoration. Without it the block runs flush to the
+// right edge of the screen and the closing cap stops reading as a cap at all.
+const notifChromeWidth = 8
+
+// renderNotificationBlock builds the dock's message block and the run of
+// hairline above it, or reports false when nothing is live.
+//
+// avail is the room the rest of the dock has actually left, which is the
+// smaller of the two limits in play: the design's own budget says how wide a
+// message should ever get, and avail says how wide it can get here. Pass 0 for
+// avail to ask only what the design wants, which is what the layout pass does
+// before the dock items have been measured.
+//
+// Width is a hard contract, not an aspiration: the returned Width is what the
+// dock reserves, what the rule is drawn to, and what the block actually
+// measures. The old renderer clamped the message with MaxWidth after the fact,
+// which cut whatever happened to be last, and what was last was the closing cap.
+func (m *OS) renderNotificationBlock(renderWidth, avail int) (notifBlock, bool) {
+	s, ok := m.notifStatus()
+	if !ok {
+		return notifBlock{}, false
+	}
+
+	sev := theme.NotificationSeverity(s.msg.Type)
+	surface := lipgloss.NewStyle().Background(theme.NotificationBg())
+
+	// The cap's foreground is the severity and its background is the block's
+	// dark body, so the weighted sliver is read against the body rather than
+	// against a field of its own colour.
+	lead := surface.Foreground(sev).Render(notifCap(s.msg.Type))
+	mark := surface.Foreground(sev).Render(" " + notifGlyph(s.msg.Type))
+
+	// The closing cap is the dock's usual trick, inverted: its foreground is
+	// the colour of the segment it closes and its background is whatever the
+	// segment sits on, which for the dock's right-hand end is the bar itself.
+	tail := lipgloss.NewStyle().Foreground(theme.NotificationBg()).
+		Render(config.GetDockPillRightChar())
+
+	budget := notifBudget(renderWidth)
+	if avail > 0 {
+		// One column short of what is left, so the opening cap always has a
+		// column of bar in front of it. At 80 columns with two minimized
+		// windows in the dock the spacers collapse to nothing and the cap
+		// butted straight against the dock items' truncation dots, which reads
+		// as one run-on shape rather than as a message arriving in the bar.
+		//
+		// Never below the chrome, though: a budget that cannot hold the cap,
+		// the mark and the closing cap would have the block quietly overrun it,
+		// and a contract that is broken in the tight case is not a contract. A
+		// dock with fewer columns than that free is already overfull, and the
+		// bar's own one-screen backstop is what handles it.
+		budget = min(budget, max(avail-1, notifChromeWidth))
+	}
+
+	// The meta gives way before the message does only when it has to: the
+	// counter outranks the esc affordance, because a buried error is news and a
+	// dismissal hint the user has seen before is not.
+	meta := s.notifMeta(surface)
+	if notifChromeWidth+lipgloss.Width(meta) > budget {
+		bare := s
+		bare.msg.Sticky = false
+		meta = bare.notifMeta(surface)
+	}
+	if notifChromeWidth+lipgloss.Width(meta) > budget {
+		meta = ""
+	}
+
+	room := budget - notifChromeWidth - lipgloss.Width(meta)
+	text := notifFit(s.msg.Message, room)
+	body := surface.Foreground(theme.NotificationFg()).Render("  " + text)
+
+	// The final column is bare bar, not surface: it is the gap between the
+	// closing cap and the edge of the screen.
+	block := lead + mark + body + meta + surface.Render(" ") + tail + " "
+	width := lipgloss.Width(block)
+
+	return notifBlock{Text: block, Rule: notifBurnRule(s, width), Width: width}, true
+}
+
+// notifFit truncates the message, and only the message. The severity mark, the
+// esc affordance and the overflow counter are the parts you cannot afford to
+// lose, so they are measured out of the room before this is called and this
+// takes whatever is left, including nothing.
+func notifFit(message string, room int) string {
+	if room <= 0 {
+		return ""
+	}
+	if lipgloss.Width(message) <= room {
+		return message
+	}
+	// Below four columns there is no room for an ellipsis and a character of
+	// message both, so the ellipsis alone says the message was cut.
+	if room < 4 {
+		return truncateToWidth("...", room)
+	}
+	return strings.TrimRight(truncateToWidth(message, room-3), " ") + "..."
+}
+
+// notifBurnRule lights the dock's hairline across the message's span and
+// shortens it from the right as the message ages, so what is left of the rule
+// is what is left of the message.
+//
+// A sticky message sits at full length and does not move. That is the
+// affordance, and it is the reason the burn is on the rule rather than in a
+// cell of its own: a line that has stopped is legible as stopped at a glance,
+// where a single character that has stopped changing is not.
+func notifBurnRule(s notifStatus, span int) string {
+	if span <= 0 {
+		return ""
+	}
+
+	lit := notifLitSpan(s.frac, span)
+
+	burnt := lipgloss.NewStyle().Foreground(theme.NotificationSeverity(s.msg.Type)).
+		Render(strings.Repeat(notifRuleStroke(s.msg.Type), lit))
+	rest := lipgloss.NewStyle().Foreground(theme.NotificationRule()).
+		Render(strings.Repeat(config.GetWindowSeparatorChar(), span-lit))
+	return burnt + rest
+}
+
+// notifLitSpan is how many of the rule's cells are still lit at this fraction
+// of a message's life.
+//
+// It is separate from the styling because for an info message the lit stroke
+// and the unlit stroke are the same character, distinguished only by colour, so
+// this is the only place the burn can be read as a number rather than looked
+// at. A message with any life left keeps at least one lit cell: a rule that has
+// gone completely dark while its message is still on the dock reads as a
+// message that has already been dealt with.
+func notifLitSpan(frac float64, span int) int {
+	if span <= 0 {
+		return 0
+	}
+	lit := int(float64(span)*frac + 0.5)
+	if frac > 0 && lit < 1 {
+		lit = 1
+	}
+	return min(max(lit, 0), span)
+}

--- a/internal/app/render_dock_notification_test.go
+++ b/internal/app/render_dock_notification_test.go
@@ -1,0 +1,372 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// notifTestOS is an OS wide enough to draw a dock, with nothing else on it.
+func notifTestOS(t testing.TB, width int) *OS {
+	t.Helper()
+	win := newTestWindow(t, "notif-render-0001", 60, 20)
+	win.Workspace = 1
+	m := newTestOS(win)
+	m.Width, m.Height = width, 40
+	m.CurrentWorkspace = 1
+	return m
+}
+
+// notifWidths are the widths every geometry assertion is run at. 80 is there
+// because that is where the dock is tight enough for the message and the mode
+// pill to be fighting over the same columns, which is where the old renderer's
+// after-the-fact clamp did its damage.
+var notifWidths = []int{40, 60, 80, 100, 120, 200}
+
+// TestNotificationBlockStaysInsideItsBudget is the geometry contract.
+//
+// The block's width is what the dock reserves for it, what the burn rule is
+// drawn to, and what the block itself measures. The old renderer had no such
+// contract: it clamped a rendered box with MaxWidth and let whatever was last
+// fall off the end, so a long message on a narrow screen lost its closing cap
+// and the box stopped reading as a shape at all.
+func TestNotificationBlockStaysInsideItsBudget(t *testing.T) {
+	messages := []string{
+		"ok",
+		"Layout saved: development",
+		strings.Repeat("a message far longer than any dock will ever hold ", 6),
+	}
+
+	for _, width := range notifWidths {
+		for _, sev := range []string{"info", "success", "warning", "error"} {
+			for _, message := range messages {
+				m := notifTestOS(t, width)
+				m.ShowNotification(message, sev, config.NotificationDuration)
+
+				block, ok := m.renderNotificationBlock(width, 0)
+				if !ok {
+					t.Fatalf("width %d, %s: no block for a live message", width, sev)
+				}
+
+				budget := notifBudget(width)
+				if block.Width > budget {
+					t.Errorf("width %d, %s: block is %d columns, budget is %d",
+						width, sev, block.Width, budget)
+				}
+				if got := lipgloss.Width(block.Text); got != block.Width {
+					t.Errorf("width %d, %s: block measures %d but reports %d", width, sev, got, block.Width)
+				}
+				if block.Width > width {
+					t.Errorf("width %d, %s: block is wider than the screen (%d)", width, sev, block.Width)
+				}
+			}
+		}
+	}
+}
+
+// TestNotificationRuleMatchesTheBlockSpan pins the rule to the block.
+//
+// The burn is legible only because it runs across exactly the span the message
+// occupies: that is what makes "how much rule is left" mean "how much message
+// is left" rather than being a bar of its own somewhere on the dock. A rule
+// that is a column longer or shorter than the block is a rule that is lying.
+func TestNotificationRuleMatchesTheBlockSpan(t *testing.T) {
+	for _, width := range notifWidths {
+		for _, sev := range []string{"info", "success", "warning", "error"} {
+			m := notifTestOS(t, width)
+			m.ShowNotification("Layout applied: development", sev, config.NotificationDuration)
+
+			block, ok := m.renderNotificationBlock(width, 0)
+			if !ok {
+				t.Fatalf("width %d, %s: no block for a live message", width, sev)
+			}
+			if got := lipgloss.Width(block.Rule); got != block.Width {
+				t.Errorf("width %d, %s: rule spans %d columns, block spans %d", width, sev, got, block.Width)
+			}
+		}
+	}
+}
+
+// TestNotificationBurnsDownAndStickyDoesNot covers what the rule is for.
+//
+// A timed message's lit run shortens as it ages, and a sticky one's does not
+// move at all. "Not moving" is the affordance that the message is waiting for
+// you, so a sticky error whose rule crept downwards would be saying the
+// opposite of what is true.
+func TestNotificationBurnsDownAndStickyDoesNot(t *testing.T) {
+	const width = 120
+
+	m := notifTestOS(t, width)
+	m.ShowNotification("Building project session", "info", 10*time.Second)
+
+	fresh, _ := m.renderNotificationBlock(width, 0)
+	freshStatus, _ := m.notifStatus()
+	freshLit := notifLitSpan(freshStatus.frac, fresh.Width)
+
+	m.Notifications[0].StartTime = time.Now().Add(-8 * time.Second)
+	aged, _ := m.renderNotificationBlock(width, 0)
+	agedStatus, _ := m.notifStatus()
+	agedLit := notifLitSpan(agedStatus.frac, aged.Width)
+
+	if agedLit >= freshLit {
+		t.Errorf("the rule did not burn down: %d lit cells when fresh, %d when nearly expired", freshLit, agedLit)
+	}
+	if agedLit < 1 {
+		t.Error("a message still on screen should keep at least one lit cell, or it reads as already gone")
+	}
+	if fresh.Rule == aged.Rule {
+		t.Error("the rendered rule did not change as the message aged")
+	}
+
+	// A sticky error lights the rule end to end and stays there.
+	s := notifTestOS(t, width)
+	s.ShowNotification("Failed to save layout", "error", config.NotificationDuration)
+	if !s.Notifications[0].Sticky {
+		t.Fatal("an error should be sticky by default")
+	}
+
+	before, _ := s.renderNotificationBlock(width, 0)
+	beforeStatus, _ := s.notifStatus()
+	if got := notifLitSpan(beforeStatus.frac, before.Width); got != before.Width {
+		t.Errorf("a sticky error should light the whole span: %d of %d", got, before.Width)
+	}
+
+	s.Notifications[0].StartTime = time.Now().Add(-time.Hour)
+	after, _ := s.renderNotificationBlock(width, 0)
+	afterStatus, _ := s.notifStatus()
+	if got := notifLitSpan(afterStatus.frac, after.Width); got != after.Width {
+		t.Errorf("a sticky error's rule moved after an hour: %d of %d lit", got, after.Width)
+	}
+	if before.Rule != after.Rule {
+		t.Error("a sticky error's rule must not move; a rule that has stopped is the affordance that it is waiting for you")
+	}
+}
+
+// TestNotificationTruncationCutsTheMessageNotTheSeverity is the truncation
+// contract: whatever has to go, the severity does not.
+//
+// The old renderer sliced the message with a byte offset and then clamped the
+// whole box, so a narrow dock could take the icon, the trailing padding, or the
+// middle of a multi-byte character. A message cut down to nothing must still
+// say how bad it was, because that is the part the user acts on.
+func TestNotificationTruncationCutsTheMessageNotTheSeverity(t *testing.T) {
+	long := strings.Repeat("failed to reach the daemon and could not recover ", 5)
+
+	for _, width := range notifWidths {
+		for _, sev := range []string{"info", "success", "warning", "error"} {
+			m := notifTestOS(t, width)
+			m.ShowNotification(long, sev, config.NotificationDuration)
+
+			block, ok := m.renderNotificationBlock(width, 0)
+			if !ok {
+				t.Fatalf("width %d, %s: no block for a live message", width, sev)
+			}
+			plain := stripANSIForTrace(block.Text)
+
+			if glyph := notifGlyph(sev); !strings.Contains(plain, glyph) {
+				t.Errorf("width %d, %s: truncation took the severity mark: %q", width, sev, plain)
+			}
+			if cap := notifCap(sev); !strings.Contains(plain, cap) {
+				t.Errorf("width %d, %s: truncation took the severity cap: %q", width, sev, plain)
+			}
+			if !strings.Contains(plain, config.GetDockPillRightChar()) {
+				t.Errorf("width %d, %s: truncation took the closing cap: %q", width, sev, plain)
+			}
+			if !strings.Contains(plain, "...") {
+				t.Errorf("width %d, %s: a cut message should say it was cut: %q", width, sev, plain)
+			}
+			if strings.Contains(plain, long) {
+				t.Errorf("width %d, %s: the message was not actually truncated: %q", width, sev, plain)
+			}
+		}
+	}
+}
+
+// TestSeverityCapsAreDistinctWeights is the greyscale check.
+//
+// Severity has to survive a screenshot with no colour in it, which is what the
+// weighted cap is for. Three severities sharing a weight would put the whole
+// channel back on hue, which is the failure the prototype found when the
+// weights were an eighth apart instead of two.
+func TestSeverityCapsAreDistinctWeights(t *testing.T) {
+	info, warn, err := notifCap("info"), notifCap("warning"), notifCap("error")
+	if notifCap("success") != info {
+		t.Error("success and info should share the light cap; they are both routine")
+	}
+	if info == warn || warn == err || info == err {
+		t.Errorf("the three cap weights must differ: info %q, warning %q, error %q", info, warn, err)
+	}
+}
+
+// TestQueuedErrorIsStillIndicatedWhenBuried is the overflow contract.
+//
+// The newest message wins the block, which means a later info can push an error
+// out of sight. The counter behind it takes the colour of the worst thing
+// waiting precisely so that this is still visible; without it the error would
+// be gone from the screen with nothing saying it had ever arrived.
+func TestQueuedErrorIsStillIndicatedWhenBuried(t *testing.T) {
+	const width = 120
+
+	m := notifTestOS(t, width)
+	m.ShowNotification("Failed to save layout: permission denied", "error", config.NotificationDuration)
+	m.ShowNotification("Window created (2 total)", "info", config.NotificationDuration)
+
+	block, ok := m.renderNotificationBlock(width, 0)
+	if !ok {
+		t.Fatal("no block for a live message")
+	}
+	plain := stripANSIForTrace(block.Text)
+
+	if !strings.Contains(plain, "Window created") {
+		t.Errorf("the newest message should hold the block: %q", plain)
+	}
+	if !strings.Contains(plain, "+1") {
+		t.Errorf("the buried error should be counted: %q", plain)
+	}
+
+	// The counter is drawn in the worst queued severity, not the dim default,
+	// which is the part that says the thing behind is worth going back for.
+	s, _ := m.notifStatus()
+	if s.worst != "error" {
+		t.Errorf("worst queued severity = %q, want error", s.worst)
+	}
+
+	// Several more messages do not change the shape, only the count.
+	for i := 0; i < 4; i++ {
+		m.ShowNotification("Client joined", "info", config.NotificationDuration)
+	}
+	block, _ = m.renderNotificationBlock(width, 0)
+	plain = stripANSIForTrace(block.Text)
+	if !strings.Contains(plain, "+5") {
+		t.Errorf("a queue of six should report five behind the newest: %q", plain)
+	}
+	if lipgloss.Width(block.Text) > notifBudget(width) {
+		t.Errorf("a queue pushed the block over budget: %d", lipgloss.Width(block.Text))
+	}
+}
+
+// TestNotificationOutranksCopyModeHelp is the collision fix.
+//
+// Copy mode used to hold the dock's right-hand block unconditionally, so a
+// message pushed while it was active was not crowded out, it was never drawn:
+// "Yanked 240 chars" and any failure behind it went nowhere. A message is a
+// thing that just happened and will not repeat; the help line is a reminder the
+// user can have back in a moment.
+func TestNotificationOutranksCopyModeHelp(t *testing.T) {
+	const width = 120
+
+	m := notifTestOS(t, width)
+	win := m.Windows[0]
+	win.CopyMode = &terminal.CopyMode{Active: true, State: terminal.CopyModeNormal}
+
+	dock, _ := m.renderDockString()
+	if !strings.Contains(stripANSIForTrace(dock), "hjkl") {
+		t.Fatal("copy mode should hold the dock's right block when nothing else does")
+	}
+
+	m.ShowNotification("Yanked 240 chars", "success", config.NotificationDuration)
+	dock, _ = m.renderDockString()
+	plain := stripANSIForTrace(dock)
+
+	if !strings.Contains(plain, "Yanked 240 chars") {
+		t.Errorf("a message pushed during copy mode was dropped: %q", plain)
+	}
+	if strings.Contains(plain, "hjkl:move") {
+		t.Errorf("the help line should give the block up for a live message: %q", plain)
+	}
+
+	// And it comes back when the message goes.
+	m.DismissNotifications()
+	dock, _ = m.renderDockString()
+	if !strings.Contains(stripANSIForTrace(dock), "hjkl") {
+		t.Error("the copy-mode help line did not come back after the message was dismissed")
+	}
+}
+
+// TestDockStaysOneScreenWideWithAMessage is the containment check on the whole
+// bar rather than the block alone. The dock is composed of a left block, the
+// window pills and the right block, and a message that fits its own budget can
+// still push the bar past the screen if the budget ignored what the rest of the
+// dock is already using.
+func TestDockStaysOneScreenWideWithAMessage(t *testing.T) {
+	long := strings.Repeat("a very long failure message that keeps going ", 4)
+
+	for _, width := range notifWidths {
+		m := notifTestOS(t, width)
+		m.ShowNotification(long, "error", config.NotificationDuration)
+
+		dock, _ := m.renderDockString()
+		for i, line := range strings.Split(dock, "\n") {
+			if got := lipgloss.Width(line); got != width {
+				t.Errorf("width %d: dock row %d is %d columns", width, i, got)
+			}
+		}
+	}
+}
+
+// TestNotificationLifetimeFloorsAndStickiness pins the durations.
+//
+// 1500ms was a WCAG 2.2.1 Level A failure: a time limit on reading content with
+// none of the six exemptions. The floor is per severity, a caller asking for
+// longer still gets longer, and an error does not run on a timer at all.
+func TestNotificationLifetimeFloorsAndStickiness(t *testing.T) {
+	tests := []struct {
+		name      string
+		notifType string
+		requested time.Duration
+		want      time.Duration
+		sticky    bool
+	}{
+		{"info takes the floor", "info", 1500 * time.Millisecond, config.NotificationDuration, false},
+		{"success takes the floor", "success", time.Second, config.NotificationDuration, false},
+		{"a longer request wins", "info", time.Minute, time.Minute, false},
+		{"warning has its own floor", "warning", time.Second, config.NotificationWarningDuration, false},
+		{"error waits to be dismissed", "error", time.Second, 0, true},
+		{"a zero-duration error is still shown", "error", 0, 0, true},
+		{"a zero-duration info is not shown", "info", 0, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, sticky := notificationLifetime(tc.notifType, tc.requested)
+			if got != tc.want || sticky != tc.sticky {
+				t.Errorf("notificationLifetime(%q, %v) = %v, sticky %v; want %v, sticky %v",
+					tc.notifType, tc.requested, got, sticky, tc.want, tc.sticky)
+			}
+		})
+	}
+
+	// The severity floors themselves must clear the accessibility minimum, or
+	// the defaults are back where they started.
+	if config.NotificationDuration < 4*time.Second {
+		t.Errorf("the default message lifetime is %v, under the 4s readability floor", config.NotificationDuration)
+	}
+}
+
+// TestNotificationNeverCoversAPane is the placement decision, asserted rather
+// than assumed. The corner toast was drawn as a layer over the workspace and
+// landed on the panes it was reporting about; the message block is part of the
+// dock and contributes no layer at all.
+func TestNotificationNeverCoversAPane(t *testing.T) {
+	m := notifTestOS(t, 120)
+	m.ShowNotification("Recording saved: demo.tape", "success", config.NotificationDuration)
+
+	for _, layer := range m.renderOverlays() {
+		if id := layer.GetID(); strings.HasPrefix(id, "notif") {
+			t.Errorf("a message produced an overlay layer %q; it belongs to the dock", id)
+		}
+		if strings.Contains(stripANSIForTrace(layer.GetContent()), "Recording saved") {
+			t.Errorf("a message was drawn over the workspace in layer %q", layer.GetID())
+		}
+	}
+
+	// And it is in the dock, which is the other half of the same claim.
+	dock, _ := m.renderDockString()
+	if !strings.Contains(stripANSIForTrace(dock), "Recording saved") {
+		t.Error("the message is not in the dock either; it went nowhere")
+	}
+}

--- a/internal/app/render_overlays.go
+++ b/internal/app/render_overlays.go
@@ -610,81 +610,13 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 		layers = append(layers, whichKeyLayer)
 	}
 
-	if len(m.Notifications) > 0 {
-		m.CleanupNotifications()
-
-		notifY := 1
-		notifSpacing := 4
-		for i, notif := range m.Notifications {
-			if i >= 3 {
-				break
-			}
-
-			opacity := 1.0
-			if notif.Animation != nil {
-				elapsed := time.Since(notif.Animation.StartTime)
-				if elapsed < notif.Animation.Duration {
-					opacity = float64(elapsed) / float64(notif.Animation.Duration)
-				}
-			}
-
-			timeLeft := notif.Duration - time.Since(notif.StartTime)
-			if timeLeft < config.NotificationFadeOutDuration {
-				opacity *= float64(timeLeft) / float64(config.NotificationFadeOutDuration)
-			}
-
-			if opacity <= 0 {
-				continue
-			}
-
-			var bgColor, fgColor, icon string
-			switch notif.Type {
-			case "error":
-				bgColor = "#dc2626"
-				fgColor = "#ffffff"
-				icon = config.NotificationIconError
-			case "warning":
-				bgColor = "#d97706"
-				fgColor = "#ffffff"
-				icon = config.NotificationIconWarning
-			case "success":
-				bgColor = "#16a34a"
-				fgColor = "#ffffff"
-				icon = config.NotificationIconSuccess
-			default:
-				bgColor = "#2563eb"
-				fgColor = "#ffffff"
-				icon = config.NotificationIconInfo
-			}
-
-			maxNotifWidth := min(max(m.GetRenderWidth()-8, 20), 60)
-
-			message := notif.Message
-			maxMessageLen := maxNotifWidth - 10
-			if len(message) > maxMessageLen {
-				message = message[:maxMessageLen-3] + "..."
-			}
-
-			notifContent := fmt.Sprintf(" %s  %s ", icon, message)
-
-			notifBox := lipgloss.NewStyle().
-				Background(lipgloss.Color(bgColor)).
-				Foreground(lipgloss.Color(fgColor)).
-				Padding(1, 2).
-				Bold(true).
-				MaxWidth(maxNotifWidth).
-				Render(notifContent)
-
-			notifX := max(m.GetRenderWidth()-lipgloss.Width(notifBox)-2, 0)
-			currentY := notifY + (i * notifSpacing)
-
-			notifLayer := lipgloss.NewLayer(notifBox).
-				X(notifX).Y(currentY).Z(config.ZIndexNotifications).
-				ID(fmt.Sprintf("notif-%s", notif.ID))
-
-			layers = append(layers, notifLayer)
-		}
-	}
+	// Notifications are no longer drawn here. They live in the dock's right-hand
+	// block (see renderNotificationBlock), which is the placement decision: a
+	// message never covers a pane, and it is never retired by a frame being
+	// composed. Retiring one used to happen right here, inside render
+	// composition, which is why a toast could sit on screen for seventeen seconds
+	// after it expired whenever the session went quiet enough that no further
+	// frame was drawn. Expiry belongs to the tick now.
 
 	focusedWindow := m.GetFocusedWindow()
 	if focusedWindow != nil && focusedWindow.CopyMode != nil &&

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -610,15 +610,21 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		hasAnimations := m.HasActiveAnimations()
 		needsDockTick := config.NeedsDockTick()
 
-		// A notification on screen is a reason to keep drawing. Notifications
-		// expire on a wall-clock timer, but nothing retires them except
-		// CleanupNotifications, which only runs while a frame is being composed.
-		// With no other reason to draw, the toast that happened to be up when the
-		// session went quiet is served from the render cache forever, sitting on
-		// top of whatever is underneath it. That is how a tape that splits a pane
-		// and echoes into it could finish correctly and still show an empty pane:
-		// the last frame drawn was the one with the tape's own toasts covering
-		// the new pane, and no later frame ever replaced it.
+		// Messages expire here, on the tick, and not inside render composition.
+		//
+		// They used to be retired by the renderer, which meant expiry could only
+		// happen on a frame that was already being drawn for some other reason.
+		// Once a session went quiet the last frame was served from the render
+		// cache with the expired toast still painted on it, for as long as
+		// nothing else happened; seventeen seconds was the recorded case, and a
+		// project tape finishing correctly while its own banner covered the pane
+		// it had just built was the symptom that found it.
+		//
+		// The tick that retires something draws one more frame so the message
+		// actually leaves the screen, which is what notifExpired carries. A live
+		// message is a reason to keep drawing regardless, because the hairline
+		// under it is burning down and that is a per-frame change.
+		notifExpired := m.CleanupNotifications()
 		hasNotifications := len(m.Notifications) > 0
 		needsScriptFrame := m.ScriptMode || leftScriptMode
 
@@ -645,7 +651,7 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 		// Render on tick if something periodic needs visual updates OR background windows changed
 		needsRender := hadAnimations || hasAnimations || m.InteractionMode || m.PrefixActive ||
-			needsDockTick || hasBackgroundChanges || hasNotifications || leftScriptMode
+			needsDockTick || hasBackgroundChanges || hasNotifications || notifExpired || leftScriptMode
 		if !needsRender {
 			m.renderSkipped = true
 			if len(cmds) > 1 {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -39,12 +39,42 @@ const (
 
 	// FastAnimationDuration is the duration for snapping and window swapping animations
 	FastAnimationDuration = 200 * time.Millisecond
+)
 
-	// NotificationFadeOutDuration is the fade out duration for notifications
-	NotificationFadeOutDuration = 500 * time.Millisecond
+// =============================================================================
+// Notification Lifetimes
+// =============================================================================
 
-	// NotificationDuration is the default duration notifications remain visible
-	NotificationDuration = 1500 * time.Millisecond
+// How long a message stays on the dock is a WCAG 2.2.1 question, not a taste
+// question: a message that goes away on its own is a time limit on reading
+// content, and none of the six exemptions (real-time, essential, 20-hour, and
+// so on) apply to a status line. The old 1500ms failed that outright. These are
+// the shortest values the field supports: tmux-sensible overrides tmux's own
+// 750ms to 4s, VS Code purges info at 10s, warnings at 12s and errors at 15s,
+// and Nielsen's attention limit is 10s.
+//
+// They are vars, not consts, because [notifications] in the user config sets
+// them (see ApplyNotificationConfig). Errors do not expire at all by default:
+// nothing carrying a failure should vanish on a timer the user did not start.
+// Every one of them is dismissible with esc, which is what keeps the sticky
+// case from being a trap.
+var (
+	// NotificationDuration is how long an info or success message stays up. It
+	// is also the floor for any duration a caller asks for; a caller wanting
+	// longer still gets longer.
+	NotificationDuration = 6 * time.Second
+
+	// NotificationWarningDuration is how long a warning stays up.
+	NotificationWarningDuration = 8 * time.Second
+
+	// NotificationErrorDuration is how long an error stays up when
+	// NotificationErrorSticky is off.
+	NotificationErrorDuration = 15 * time.Second
+
+	// NotificationErrorSticky makes errors wait for a dismissal instead of
+	// expiring. The dock's rule stops burning down when this is what is on
+	// screen, which is the affordance that it is waiting for you.
+	NotificationErrorSticky = true
 )
 
 // =============================================================================
@@ -127,20 +157,20 @@ const (
 	// DockItemWidth is the base width of a dock item
 	DockItemWidth = 6
 
-	// MaxNotificationWidth is the maximum width of notification messages
-	MaxNotificationWidth = 60
+	// NotificationMaxWidth caps the dock's message block. Past about seventy
+	// columns a message that keeps growing stops being a status line and starts
+	// being a paragraph, so the rest is truncated instead.
+	NotificationMaxWidth = 72
 
-	// MinNotificationWidth is the minimum width of notification messages
-	MinNotificationWidth = 20
+	// NotificationDockReserve is what the message block leaves the rest of the
+	// dock: enough for the mode pill and the workspace counts, which are never
+	// given up for a message.
+	NotificationDockReserve = 18
 
-	// NotificationMargin is the margin from screen edge for notifications
-	NotificationMargin = 8
-
-	// NotificationSpacing is the vertical spacing between notifications
-	NotificationSpacing = 4
-
-	// MaxVisibleNotifications is the maximum number of notifications shown at once
-	MaxVisibleNotifications = 3
+	// NotificationMinWidth is the narrowest block worth reserving. Below it the
+	// dock is too tight to split, and the message takes what the screen has
+	// less a small margin instead.
+	NotificationMinWidth = 14
 
 	// AnimationMargin is the margin for culling animated windows
 	AnimationMargin = 20
@@ -203,6 +233,10 @@ func init() {
 	DockIconWorkspaceCount = fa.ThLarge.String()
 	WindowPillLeft = ple.LeftHalfCircleThick.String()
 	WindowPillRight = ple.RightHalfCircleThick.String()
+	NotificationGlyphError = fa.TimesCircle.String()
+	NotificationGlyphWarning = fa.ExclamationTriangle.String()
+	NotificationGlyphSuccess = fa.CheckCircle.String()
+	NotificationGlyphInfo = fa.InfoCircle.String()
 }
 
 // =============================================================================
@@ -272,6 +306,88 @@ const (
 	// NotificationIconInfo is the info notification icon
 	NotificationIconInfo = "[i]"
 )
+
+// Nerd Font severity marks, from the same FontAwesome block the dock already
+// draws its terminal and workspace counts from, so a terminal that renders the
+// dock at all renders these. They come from go-nf rather than being written out
+// as literals for the same reason the dock icons do: a private-use codepoint
+// pasted into source is invisible to review and is silently lost by any tool
+// that touches the file, which is exactly how the first version of this shipped
+// four empty strings and drew a message with no mark at all.
+var (
+	// NotificationGlyphError is the error mark (nf-fa-times_circle).
+	NotificationGlyphError string
+
+	// NotificationGlyphWarning is the warning mark (nf-fa-exclamation_triangle).
+	NotificationGlyphWarning string
+
+	// NotificationGlyphSuccess is the success mark (nf-fa-check_circle).
+	NotificationGlyphSuccess string
+
+	// NotificationGlyphInfo is the info mark (nf-fa-info_circle).
+	NotificationGlyphInfo string
+)
+
+// The message block's opening edge. It is the powerline cap and the severity
+// rail in one cell: a partial block drawn flush against the block's dark body,
+// opening it the way a cap does, inked two eighths for info and success, four
+// for a warning and six for an error.
+//
+// Two eighths apart rather than one because a single eighth is not a difference
+// you can see without the two of them side by side, and they never are. The
+// weight is what carries severity into a greyscale screenshot or a theme with
+// no contrast to spare.
+//
+// The body behind the cap is the dark surface, never a severity fill. A sliver
+// only reads as a weight against something that is not the same colour; against
+// a solid severity field all it changes is where the field starts, with nothing
+// to compare that against, and the severities become indistinguishable. That is
+// why this design carries less colour than a filled pill would.
+const (
+	// NotificationCapLight is the info and success cap (U+258E, two eighths).
+	NotificationCapLight = "▎"
+
+	// NotificationCapMedium is the warning cap (U+258C, four eighths).
+	NotificationCapMedium = "▌"
+
+	// NotificationCapHeavy is the error cap (U+258A, six eighths).
+	NotificationCapHeavy = "▊"
+
+	// NotificationCapASCII is the cap with Nerd Fonts off. Weight cannot be
+	// encoded in one ASCII cell, so severity falls back to the mark and the
+	// colour alone.
+	NotificationCapASCII = "|"
+)
+
+// The dock hairline's stroke while a message is burning down over it. A warning
+// or an error is drawn heavy, so an escalating message is a heavier line as
+// well as a different colour.
+const (
+	// NotificationRuleLight is the burn stroke for info and success (U+2500).
+	NotificationRuleLight = "─"
+
+	// NotificationRuleHeavy is the burn stroke for warnings and errors (U+2501).
+	NotificationRuleHeavy = "━"
+)
+
+// GetNotificationCap returns the weighted cap for a severity, or the ASCII
+// fallback when Nerd Fonts are off.
+func GetNotificationCap(cap string) string {
+	if UseASCIIOnly {
+		return NotificationCapASCII
+	}
+	return cap
+}
+
+// GetNotificationRule returns the burn stroke for the dock's hairline, matching
+// the separator character the rest of the row is drawn with when Nerd Fonts are
+// off so the lit run and the unlit run stay the same shape.
+func GetNotificationRule(stroke string) string {
+	if UseASCIIOnly {
+		return WindowSeparatorCharASCII
+	}
+	return stroke
+}
 
 // Dock Mode Colors
 const (

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Gaurav-Gosain/tuios/internal/theme"
 	"github.com/adrg/xdg"
@@ -15,13 +16,35 @@ import (
 
 // UserConfig represents the user's custom configuration
 type UserConfig struct {
-	Appearance  AppearanceConfig  `toml:"appearance"`
-	Keybindings KeybindingsConfig `toml:"keybindings"`
-	Daemon      DaemonConfig      `toml:"daemon"`
-	Startup     StartupConfig     `toml:"startup"`
-	Tape        TapeConfig        `toml:"tape"`
-	Hooks       HooksConfig       `toml:"hooks"`
-	Debug       DebugConfig       `toml:"debug"`
+	Appearance    AppearanceConfig    `toml:"appearance"`
+	Notifications NotificationsConfig `toml:"notifications"`
+	Keybindings   KeybindingsConfig   `toml:"keybindings"`
+	Daemon        DaemonConfig        `toml:"daemon"`
+	Startup       StartupConfig       `toml:"startup"`
+	Tape          TapeConfig          `toml:"tape"`
+	Hooks         HooksConfig         `toml:"hooks"`
+	Debug         DebugConfig         `toml:"debug"`
+}
+
+// NotificationsConfig holds how long a dock message stays up.
+//
+// Durations are in seconds and are a floor, not a cap: a caller that asks for
+// longer than the severity's default still gets what it asked for. Zero or
+// absent means "use the built-in default", which is the value documented on the
+// corresponding package var in constants.go.
+type NotificationsConfig struct {
+	// Duration is how long an info or success message stays up, in seconds.
+	Duration int `toml:"duration"`
+
+	// WarningDuration is how long a warning stays up, in seconds.
+	WarningDuration int `toml:"warning_duration"`
+
+	// ErrorDuration is how long an error stays up, in seconds, when
+	// error_sticky is false.
+	ErrorDuration int `toml:"error_duration"`
+
+	// ErrorSticky makes errors wait for esc instead of expiring (default true).
+	ErrorSticky *bool `toml:"error_sticky"`
 }
 
 // DebugConfig holds diagnostic settings. These are off by default so a normal
@@ -680,6 +703,33 @@ func ApplyAppearanceConfig(cfg *UserConfig) {
 	// clear any override and restore theme colors. This runs after the theme
 	// switch above, which resets the derived colors.
 	theme.SetBorderOverrides(cfg.Appearance.BorderFocusedColor, cfg.Appearance.BorderUnfocusedColor)
+
+	// [notifications] rides along here rather than in its own funnel because
+	// this is the one function every path that loads a config file already
+	// calls: the tape runner, the SSH server, the command palette's save, and
+	// the live reload. A second entry point is a second thing to forget.
+	ApplyNotificationConfig(cfg)
+}
+
+// ApplyNotificationConfig applies the [notifications] section to the package
+// globals the renderer reads. Absent or non-positive values leave the built-in
+// default in place rather than collapsing a message to zero seconds, which is
+// the failure mode the old 1500ms default was already close enough to.
+func ApplyNotificationConfig(cfg *UserConfig) {
+	if cfg.Notifications.Duration > 0 {
+		NotificationDuration = time.Duration(cfg.Notifications.Duration) * time.Second
+	}
+	if cfg.Notifications.WarningDuration > 0 {
+		NotificationWarningDuration = time.Duration(cfg.Notifications.WarningDuration) * time.Second
+	}
+	if cfg.Notifications.ErrorDuration > 0 {
+		NotificationErrorDuration = time.Duration(cfg.Notifications.ErrorDuration) * time.Second
+	}
+	// ErrorSticky defaults to true, so nil means "keep the default" and only an
+	// explicit false turns it off.
+	if cfg.Notifications.ErrorSticky != nil {
+		NotificationErrorSticky = *cfg.Notifications.ErrorSticky
+	}
 }
 
 // fillMissingTape fills in any missing tape settings with defaults. An unset or

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -101,6 +101,10 @@ func ValidateConfig(cfg *UserConfig) *ValidationResult {
 	// Validate the tape section (warn on an unknown autorun mode)
 	validateTapeConfig(cfg, result)
 
+	// Validate the notifications section (warn on a duration that would put a
+	// message back under the accessibility floor)
+	validateNotificationsConfig(cfg, result)
+
 	// Check for keybinding conflicts (same key bound to multiple actions)
 	conflicts := findConflicts(cfg, normalizer)
 	for key, actions := range conflicts {
@@ -178,6 +182,34 @@ func validateTapeConfig(cfg *UserConfig, result *ValidationResult) {
 		Key:     "autorun",
 		Message: fmt.Sprintf("'%s' is not a valid value (allowed: %s); falling back to default", value, strings.Join(TapeAutorunModes, ", ")),
 	})
+}
+
+// minReadableNotification is the shortest message lifetime this config will
+// accept without complaint. Below about four seconds a status line is a time
+// limit on reading content with no way to extend it, which is the WCAG 2.2.1
+// failure the old 1500ms default was. The value is not enforced, because a user
+// who has read the warning and wants a faster bar is entitled to one; it is
+// reported so the choice is a choice.
+const minReadableNotification = 4
+
+// validateNotificationsConfig warns when a configured message lifetime is short
+// enough to be unreadable. Negative and zero values are not warned about: they
+// mean "unset" and leave the default in place.
+func validateNotificationsConfig(cfg *UserConfig, result *ValidationResult) {
+	check := func(key string, seconds int) {
+		if seconds <= 0 || seconds >= minReadableNotification {
+			return
+		}
+		result.Warnings = append(result.Warnings, ValidationError{
+			Field: "notifications",
+			Key:   key,
+			Message: fmt.Sprintf("%ds is shorter than the %ds needed to read a message; it is applied as written but is an accessibility (WCAG 2.2.1) failure",
+				seconds, minReadableNotification),
+		})
+	}
+	check("duration", cfg.Notifications.Duration)
+	check("warning_duration", cfg.Notifications.WarningDuration)
+	check("error_duration", cfg.Notifications.ErrorDuration)
 }
 
 // validateAppearanceEnums warns when an enum appearance option holds a value

--- a/internal/input/copymode_lock_test.go
+++ b/internal/input/copymode_lock_test.go
@@ -187,8 +187,14 @@ func TestCopyModeEffectsPreserveHandlerBehaviour(t *testing.T) {
 		if win.CopyMode.PendingCount != 5 {
 			t.Fatalf("PendingCount = %d, want 5", win.CopyMode.PendingCount)
 		}
-		if !hasNotification(o, "5") {
-			t.Fatalf("expected the count notification, got %v", notificationMessages(o))
+		// The count indicator is pushed with a zero duration, which now means
+		// "not a notification" rather than "a notification that expires
+		// immediately". It never reached the screen either way: the old renderer
+		// computed a non-positive opacity for it and skipped it. What this
+		// subtest is really guarding is that the handler runs its effects after
+		// the I/O lock is dropped, and PendingCount is the trace of that.
+		if len(o.Notifications) != 0 {
+			t.Fatalf("a zero-duration count indicator should not become a dock message, got %v", notificationMessages(o))
 		}
 
 		HandleCopyModeKey(key("j"), o, win)
@@ -205,8 +211,10 @@ func TestCopyModeEffectsPreserveHandlerBehaviour(t *testing.T) {
 		if win.CopyMode.State != terminal.CopyModeSearch {
 			t.Fatal("/ did not enter search state")
 		}
-		if !hasNotification(o, "/") {
-			t.Fatalf("expected the search prompt notification, got %v", notificationMessages(o))
+		// As above: the search prompt is a zero-duration push and is not a dock
+		// message. The state transition is what the effects path has to deliver.
+		if len(o.Notifications) != 0 {
+			t.Fatalf("a zero-duration search prompt should not become a dock message, got %v", notificationMessages(o))
 		}
 	})
 }

--- a/internal/input/handler.go
+++ b/internal/input/handler.go
@@ -154,6 +154,23 @@ func HandleKeyPress(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		o.CaptureKeyEvent(msg)
 	}
 
+	// esc takes a message off the dock, in every mode, without consuming the key.
+	//
+	// Not consuming it is the whole design. esc means something to the shell,
+	// to vim, to copy mode and to every overlay below, and a message is not
+	// worth stealing it from any of them; dismissing is non-destructive, so
+	// doing it as a side effect of an esc the user pressed for another reason
+	// costs them nothing. What it buys is an exit for a sticky error, which
+	// otherwise waits forever, and a way out of any message the user has read
+	// and does not want to sit through.
+	//
+	// It runs before the overlay routing below so it works while help, the
+	// palette or the quit dialog is up, since those are exactly the moments a
+	// message is in the way.
+	if msg.String() == "esc" {
+		o.DismissNotifications()
+	}
+
 	// Handle quit confirmation dialog (highest priority - works in any mode)
 	if o.ShowQuitConfirm {
 		key := msg.String()

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -300,10 +300,15 @@ func LogViewerBg() color.Color {
 }
 
 // NotificationError returns the color for error notifications.
+//
+// The no-theme fallbacks for the four severities are ink colors, not the raw
+// ANSI primaries they used to be: these are drawn as a one-cell mark and a
+// sliver of cap on a dark bar, and #0000ee blue on #1a1a2e was a smudge. A
+// theme, when one is active, still wins outright.
 func NotificationError() color.Color {
 	t := Current()
 	if t == nil {
-		return lipgloss.Color("#cd0000")
+		return lipgloss.Color("#dc2626")
 	}
 	return t.Red
 }
@@ -312,7 +317,7 @@ func NotificationError() color.Color {
 func NotificationWarning() color.Color {
 	t := Current()
 	if t == nil {
-		return lipgloss.Color("#cdcd00")
+		return lipgloss.Color("#d97706")
 	}
 	return t.Yellow
 }
@@ -321,7 +326,7 @@ func NotificationWarning() color.Color {
 func NotificationSuccess() color.Color {
 	t := Current()
 	if t == nil {
-		return lipgloss.Color("#00cd00")
+		return lipgloss.Color("#16a34a")
 	}
 	return t.Green
 }
@@ -330,27 +335,57 @@ func NotificationSuccess() color.Color {
 func NotificationInfo() color.Color {
 	t := Current()
 	if t == nil {
-		return lipgloss.Color("#0000ee")
+		return lipgloss.Color("#2563eb")
 	}
 	return t.Blue
 }
 
-// NotificationBg returns the background color for notifications.
+// NotificationBg returns the background color for the message block: the dark
+// body the weighted severity cap opens.
+//
+// With theming off this is the dock's own help background rather than black, so
+// a message sitting in the dock's right-hand block is made of the same material
+// as the copy-mode help line that shares the row. Black would read as a hole
+// punched in the bar.
 func NotificationBg() color.Color {
 	t := Current()
 	if t == nil {
-		return lipgloss.Color("#000000")
+		return lipgloss.Color("#1a1a2e")
 	}
 	return t.Bg
 }
 
-// NotificationFg returns the foreground color for notifications.
+// NotificationFg returns the foreground color for notification message text.
 func NotificationFg() color.Color {
 	t := Current()
 	if t == nil {
 		return lipgloss.Color("#e5e5e5")
 	}
 	return t.Fg
+}
+
+// NotificationRule returns the color of the dock hairline that a message has
+// not lit: the unburnt remainder of the rule, and the whole rule when nothing
+// is on screen. It matches the separator the dock already draws.
+func NotificationRule() color.Color {
+	return lipgloss.Color("#303040")
+}
+
+// NotificationSeverity maps a notification type string to its color. The type
+// strings are the ones every ShowNotification call site already passes, so this
+// is the single place the renderer turns one into a color and the only place
+// that has to know "warning" and "warn" are the same thing.
+func NotificationSeverity(notifType string) color.Color {
+	switch notifType {
+	case "error":
+		return NotificationError()
+	case "warning", "warn":
+		return NotificationWarning()
+	case "success":
+		return NotificationSuccess()
+	default:
+		return NotificationInfo()
+	}
 }
 
 // DockBg returns the background color for the dock.


### PR DESCRIPTION
Toasts overlaid pane content, expired only from inside the render loop, ignored the theme, and had a configuration surface that did nothing. This replaces them with the design chosen from an interactive prototype after comparing four placements and then four treatments of the winning one.

## The design

The message occupies the dock's right-hand block and **never covers a pane**. Its left edge is a single weighted bar acting as both the powerline cap and the severity rail (`▎` `▌` `▊` at 2/4/6 eighths), so severity survives greyscale, colourblindness and a low-contrast theme. A Nerd Font severity mark sits beside it. The message itself is never on a coloured ground.

The dock's own hairline above lights in the severity colour across exactly the block's span and burns down from the right as the message ages. A sticky error lights it end to end and it does not move, so "not moving" is the affordance that this one is waiting for you. Overflow behind the newest message is a counter coloured by the worst severity queued, so a buried error still announces itself.

One detail that cost the prototype a rebuild: the weighted bar sits against the block's **dark body**, not a solid severity field. Against a solid field the weight only shifts where the field starts, with nothing to compare against, and the severities become indistinguishable. That is why this carries less colour than a filled pill.

Width is a hard contract: `renderNotificationBlock` returns the block, its rule, and one width that is simultaneously what the dock reserves, what the rule spans, and what the block measures.

## A real bug this uncovered

`CleanupNotifications` kept a message while `now.Sub(StartTime) < Duration`. With `Duration = 0` that is false on the very first pass, so a duration of zero never meant "no timeout", it meant **"never displayed"**.

`os_selection.go:18` calls `ShowNotification("Capture failed: "+err.Error(), "error", 0)`. A failed capture has been showing the user nothing at all.

Errors and warnings are now shown whatever duration they were handed. Info and success with a non-positive duration stay unshown, which is what keeps copy mode's dead `"VISUAL"` and `"f"` indicators out of the dock.

## The rest of what was wrong

- **1500 ms was a WCAG 2.2.1 Level A failure**, a content-set time limit with none of the six exemptions. Lifetimes are now severity-tiered and configurable, in the range the field converges on: tmux-sensible overrides tmux's own 750 ms to 4 s, VS Code purges info at 10 s, warnings at 12 s, errors at 15 s. Errors do not expire by default, which is only defensible because `esc` now dismisses.
- **`esc` dismissal did not exist.** It does now, and it does **not consume the key**: it dismisses and still reaches the shell, copy mode, or whatever overlay is open, so it never costs you the keypress you meant.
- **The layout constants were fiction.** `MaxVisibleNotifications`, `NotificationMargin`, `NotificationSpacing`, `MinNotificationWidth` and `MaxNotificationWidth` were referenced nowhere outside `constants.go` while the renderer hardcoded everything. (`ZIndexNotifications` was **not** dead, the script indicator and showkeys overlay both use it, so it stayed.)
- **Toasts ignored the theme**, using hardcoded Tailwind hex while `theme.NotificationError/Warning/Success/Info/Bg/Fg` existed unused and `NotificationBg()`/`NotificationFg()` had zero callers. Verified against Nord.
- **A message arriving while copy mode held the dock's right block was silently dropped.** A live message now outranks the help line.

## Verified by looking

Drove the real binary under tmux at 50, 80, 100 and 120 columns, capturing ANSI and rendering it to PNG: each severity, short and over-long messages, a sticky error, a queue with a buried error, the burn-down over time, `esc` dismissal, a message arriving during copy mode, a dock crowded with minimized windows, and Nord.

Two fixes came out of looking rather than reasoning:

1. **The severity marks were four empty strings.** The private-use codepoints did not survive being written into source, so the first build drew a cap, a gap, and no mark. They now come from `go-nf` like every other glyph in the dock, which is also why it cannot silently recur.
2. At 80 columns with two minimized windows, the opening cap butted straight against the dock items' `...` and read as one run-on shape. The block now leaves a column of bar in front of itself.

## One existing test changed, and why

`TestFocusCycleWithRapidKeyRepeat` ended by sending alt+esc while already in window-management mode, where it pushes no message. It passed because the old renderer stacked three toasts and a **stale** one from an earlier step was still visible underneath a newer one, satisfying the wait. With the newest message shown and the rest counted there is no stale message to lean on, so the assertion now toggles tiling and waits for the message that keystroke actually causes. That is a stronger test of "the UI still takes input" than the original. Confirmed against a stashed tree that base tuios behaves identically for that keypress, so this is the test's assumption changing, not behaviour.

## Tests

`render_dock_notification_test.go` pins the block never exceeding its budget (six widths x four severities x three message lengths), the rule matching the block's span, the burn shortening while a sticky one does not move, truncation cutting the message and never the cap or mark, the three cap weights being distinct, a buried error still being indicated, the dock staying one screen wide, the duration floors, and no overlay layer carrying a message.

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module all pass.