### PR TITLE
Make the mouse behave like a terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ docker run -it --rm ghcr.io/gaurav-gosain/tuios:latest
 - **Showkeys Overlay** - Display pressed keys for presentations
 - **Customizable Keybindings** - TOML configuration with Kitty protocol support
 - **Hooks** - Run shell commands on window create, close and focus events ([docs](docs/HOOKS.md))
-- **Mouse Support** - Click, drag, resize, scrollbar interaction
+- **Mouse Support** - Wheel scrollback, drag-to-select with copy on release, double-click word and triple-click line, window drag, resize, scrollbar
 - **SSH Server Mode** - Remote terminal multiplexing
 - **Web Terminal Mode** - Browser-based access (separate `tuios-web` binary)
 - **Themes** - Bundled themes plus custom themes from JSON ([docs](docs/THEMES.md))
@@ -227,7 +227,7 @@ See [Configuration Guide](docs/CONFIGURATION.md) for all options including `show
 - **Shared borders** (`--shared-borders`) - tmux-style thin separator lines between tiled panes.
 - **Smart auto-split** - Aspect-ratio-aware BSP splitting (opt-in via command palette).
 - **Interactive scrollbar** - Click/drag the right border to scroll, theme-aware colors.
-- **Mouse wheel scrollback** - Scroll wheel enters copy mode directly with full vim/selection support.
+- **Mouse wheel scrollback** - The wheel scrolls, with no mode entered and nothing announced. Typing or reaching the bottom returns to live output.
 - **Selection auto-scroll** - Drag selection above/below pane to scroll during visual mode.
 - **Dock stats opt-in** - Clock, CPU, RAM hidden by default (`--show-clock`, `--show-cpu`, `--show-ram`).
 
@@ -258,7 +258,7 @@ TUIOS follows the Model-View-Update pattern on Bubble Tea v2. For details, see [
 - **Event-driven rendering** - PTY reader goroutines signal bubbletea via a buffered channel. No fixed-rate ticking for terminal content.
 - **Kitty graphics passthrough** - Image IDs are reused across frames for flicker-free video. Output is batched with the render cycle and wrapped in mode 2026 sync.
 - **BSP tiling** - Binary space partitioning tree with configurable schemes (spiral, smart split). Shared borders mode overlaps window rects and draws separator lines as a separate layer.
-- **Copy mode** - Full vim navigation over scrollback with mouse wheel entry, scrollbar interaction, and selection auto-scroll (timer-based continuous drag scrolling).
+- **Copy mode** - Full vim navigation over scrollback. Wheel scrolling and mouse selection borrow the same machinery through an implicit session that presents as nothing at all, plus scrollbar interaction and selection auto-scroll (timer-based continuous drag scrolling).
 
 **Core Components:**
 - **Window Manager** ([`internal/app/os.go`](./internal/app/os.go)) - Central state, workspaces, overlays

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -293,6 +293,30 @@ Controls how many lines a single mouse wheel notch scrolls in scrollback, copy m
 
 **Note:** Values outside the valid range are automatically clamped. Also settable from the in-app settings page (Advanced, "Scroll lines").
 
+### copy_on_select
+
+Controls whether releasing a mouse selection puts the text on the clipboard straight away, the way X11's primary selection and kitty's `copy_on_select` do. With it off, a selection stays highlighted and is copied only by pressing `y` in copy mode.
+
+A click that never moved is not a selection and never writes to the clipboard, whatever this is set to.
+
+**Valid values:** `true`, `false`
+
+**Default:** `true`
+
+**Note:** The clipboard is written with OSC 52, the same path copy mode's `y` uses, so it reaches whatever the host terminal supports (including over SSH). Also settable from the in-app settings page (Advanced, "Copy on select").
+
+### word_characters
+
+The punctuation that counts as part of a word when a double-click selects one. Letters and digits always count and do not need listing.
+
+The default is chosen for what terminal output looks like: a path, a query string, a version number or a flag such as `--no-vm` selects as one word instead of breaking at every punctuation mark. A colon is deliberately absent, so `host:port` and `file:line` select as their parts; add `:` if you would rather have them whole.
+
+**Valid values:** Any string of characters. An empty string means only letters and digits are word characters.
+
+**Default:** `"@-./_~?&=%+#"`
+
+**Note:** Triple-click selects the whole line and is not affected by this. Also settable from the in-app settings page (Advanced, "Word characters").
+
 ### window_title_position
 
 Controls where window titles are displayed. Titles show the custom name if set by the user, otherwise the terminal's title (e.g., from shell prompt).

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -316,17 +316,22 @@ Access debug and development tools:
 
 ## Mouse Controls
 
+- **Mouse Wheel**: Scroll the pane's scrollback (when no mouse tracking, not alt screen). No mode is entered and nothing is announced; scrolling back to the bottom returns to live output, and so does typing.
+- **Left Drag in a pane**: Select text. Releasing copies it (`copy_on_select`, on by default)
+- **Double Click**: Select the word under the pointer (`word_characters` decides what a word is)
+- **Triple Click**: Select the whole line
+- **Left Drag Above/Below a pane**: Continues the selection and scrolls
 - **Left Click**: Focus window
-- **Left Drag**: Move window (non-tiling) or swap windows (tiling)
+- **Left Drag on the title bar**: Move window (non-tiling) or swap windows (tiling). In window management mode the whole window is a drag handle
 - **Right Drag**: Resize window (non-tiling only)
 - **Title Bar Buttons**: Minimize, maximize, or close window
 - **Click Dock Item**: Restore minimized window
 - **Copy Mode Click**: Move cursor to position
-- **Copy Mode Drag**: Select text (enters visual mode)
-- **Mouse Wheel**: Enter copy mode and scroll (when no mouse tracking, not alt screen)
-- **Copy Mode Drag Auto-Scroll**: Dragging a selection above/below the pane continuously scrolls via a timer
 - **Right Border Click**: Scrollbar jump
 - **Right Border Drag**: Scrollbar scroll
+
+Panes running an application that asked for the mouse (vim, less, htop) receive
+every one of these events themselves; tuios does not interpret them.
 
 ## Customization
 

--- a/e2e/tui/NEGATIVE_CONTROLS.md
+++ b/e2e/tui/NEGATIVE_CONTROLS.md
@@ -3,9 +3,9 @@
 A regression test that has never been observed to fail on broken code is not
 evidence. Every test in this package that claims to cover a specific bug was run
 against a binary built with that bug's fix removed, and the result is recorded
-below. Two of the four bugs are **not** caught here; that is written down rather
-than papered over, because a suite whose real coverage is unknown is worse than
-no suite.
+below. Two of them are **not** caught here; that is written down rather than
+papered over, because a suite whose real coverage is unknown is worse than no
+suite.
 
 ## How to rebuild a control
 
@@ -42,8 +42,28 @@ a working negative control look like a broken one for half an hour.
 | Blank pane: `clipWindowContent` measured width from `lines[0]` | `b9f770b` | revert `internal/app/render_helpers.go` hunk | `TestAltScreenPaneSurvivesFocusSwitch`, `TestLeftmostTileWithBlankFirstLineIsNotDiscarded` | **caught** |
 | Blank pane: a transient blank frame became the render cache | `11a0023` | neuter the `isBlankRender` guard in `cacheRender` | none | **not caught** |
 | Torn cell buffer: emulator resized without the window I/O lock | `fd1463e` | drop both `LockIO`/`UnlockIO` pairs around `Terminal.Resize` in `internal/app/session.go` | none (2 full runs) | **not caught** |
+| Mouse: the wheel announced a mode, stranded the user in it, and a drag moved the window instead of selecting | whole change | build the merge-base (`2005b01`) and point `TUIOS_E2E_BIN` at it | `TestWheelScrollShowsScrollbackWithoutAnnouncingAMode`, `TestWheelDownToBottomReturnsToLiveOutput`, `TestTypingWhileScrolledSnapsBackToLiveOutput`, `TestDragSelectionCopiesOnRelease`, `TestDoubleClickCopiesAWordAndTripleClickTheLine` | **caught** |
+| Mouse: the wheel over a pane that asked for the mouse | n/a, never broken | same binary | none, and that is correct: `TestMouseTrackingAppKeepsItsOwnWheel` passes on both, because it guards behaviour that already worked | **guard, not a control** |
 
-### Why the last two are not caught, and what does cover them
+### The mouse row is a whole-change control, not a single-hunk one
+
+The mouse tests were written against a change whose whole point is a different
+interaction, not against a bug with one faulty line, so the control is the
+merge-base binary rather than a hunk revert:
+
+```sh
+git worktree add --detach /tmp/negctl origin/main
+(cd /tmp/negctl && go build -o /tmp/tuios-main ./cmd/tuios)
+cd e2e/tui && TUIOS_E2E=1 TUIOS_E2E_BIN=/tmp/tuios-main go test -count=1 \
+  -run 'TestWheel|TestTypingWhileScrolled|TestMouseTracking|TestDragSelection|TestDoubleClick' -timeout 900s .
+```
+
+Each failure names the old behaviour: "COPY MODE" on the dock during a scroll,
+`echo` never producing its marker because the keystrokes were eaten as vim
+motions, and an empty list of clipboard writes because a drag moved the window
+instead of selecting.
+
+### Why the two blank-pane and torn-buffer entries are not caught, and what does cover them
 
 **The blank-frame cache (`11a0023`)** needs a render to land in the gap between
 a full-screen application clearing the alternate screen and painting it. Once

--- a/e2e/tui/harness_test.go
+++ b/e2e/tui/harness_test.go
@@ -65,6 +65,7 @@ package tuie2e
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -155,6 +156,12 @@ type startOpts struct {
 	args []string
 	// env are extra KEY=VALUE entries layered over the isolated defaults.
 	env []string
+	// out receives a copy of the PTY traffic, so a test can assert on output
+	// that never reaches the grid. OSC 52 clipboard writes are the reason it
+	// exists: a copy is invisible on screen but unmistakable on the wire. The
+	// stream carries both directions, which is harmless for that purpose since
+	// nothing the tests send contains an OSC 52.
+	out io.Writer
 }
 
 // start spawns tuios in a hermetic environment and returns the terminal plus
@@ -218,13 +225,16 @@ func startIn(t *testing.T, base string, o startOpts) *tuitest.Terminal {
 	}
 	t.Cleanup(func() { _ = logFile.Close() })
 
-	term := tuitest.StartT(t, argv,
+	var mirror io.Writer = logFile
+	if o.out != nil {
+		mirror = io.MultiWriter(logFile, o.out)
+	}
+	return tuitest.StartT(t, argv,
 		tuitest.WithSize(cols, rows),
 		tuitest.WithTerm("xterm-256color"),
 		tuitest.WithEnv(env...),
-		tuitest.WithLog(logFile),
+		tuitest.WithLog(mirror),
 	)
-	return term
 }
 
 // waitBoot blocks until the welcome screen is up.

--- a/e2e/tui/mouse_test.go
+++ b/e2e/tui/mouse_test.go
@@ -1,0 +1,435 @@
+package tuie2e
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// The screen assertions below are what makes this suite evidence rather than
+// decoration: every claim about the wheel and about selection is checked
+// against a real tuios binary painting a real PTY, driven by real SGR mouse
+// reports.
+
+// wheelAt turns the wheel n notches over a screen cell.
+func wheelAt(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, n int) {
+	t.Helper()
+	for range n {
+		if err := term.SendMouse(tuitest.MouseEvent{
+			Col: col, Row: row, Button: button, Action: tuitest.MousePress,
+		}); err != nil {
+			t.Fatalf("wheel: %v", err)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+}
+
+// dragSelect presses at one cell, drags across the row, and releases.
+func dragSelect(t *testing.T, term *tuitest.Terminal, fromCol, toCol, row int) {
+	t.Helper()
+	send := func(ev tuitest.MouseEvent) {
+		t.Helper()
+		if err := term.SendMouse(ev); err != nil {
+			t.Fatalf("mouse %+v: %v", ev, err)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+	send(tuitest.MouseEvent{Col: fromCol, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MousePress})
+	// MouseMove with a button set is a drag on the wire: the motion bit plus
+	// the button code, which is what SGR mode 1002 reports while dragging.
+	step := 1
+	if toCol < fromCol {
+		step = -1
+	}
+	for c := fromCol + step; c != toCol+step; c += step {
+		send(tuitest.MouseEvent{Col: c, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseMove})
+	}
+	send(tuitest.MouseEvent{Col: toCol, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseRelease})
+}
+
+// clickAt sends n presses and a release at one cell, fast enough to count as a
+// single multi-click gesture.
+func clickAt(t *testing.T, term *tuitest.Terminal, col, row, n int) {
+	t.Helper()
+	for range n {
+		if err := term.SendMouse(tuitest.MouseEvent{
+			Col: col, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MousePress,
+		}); err != nil {
+			t.Fatalf("click: %v", err)
+		}
+		time.Sleep(40 * time.Millisecond)
+	}
+	if err := term.SendMouse(tuitest.MouseEvent{
+		Col: col, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseRelease,
+	}); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+}
+
+// findText locates a substring on screen and returns its row and starting
+// column. Tests use it so they click on real content rather than on coordinates
+// guessed from the layout.
+//
+// The column is counted in runes, not bytes. A pane's own border is U+2502,
+// three bytes wide and one cell wide, so a byte index puts every click two
+// cells to the right of where the test meant it.
+func findText(t *testing.T, term *tuitest.Terminal, want string) (row, col int) {
+	t.Helper()
+	if err := term.WaitForText(want, shellTimeout); err != nil {
+		t.Fatalf("%q never appeared: %v\n%s", want, err, term.Snapshot())
+	}
+	s := term.Screen()
+	_, rows := s.Size()
+	for r := range rows {
+		line := s.Line(r)
+		if b := strings.Index(line, want); b >= 0 {
+			return r, len([]rune(line[:b]))
+		}
+	}
+	t.Fatalf("%q is in the screen text but on no single row\n%s", want, term.Snapshot())
+	return 0, 0
+}
+
+// fillScrollback prints n tagged lines into the focused pane so there is
+// history to scroll through, and returns the tag of the last one.
+func fillScrollback(t *testing.T, term *tuitest.Terminal, prefix string, n int) string {
+	t.Helper()
+	last := fmt.Sprintf("%s-%d-END", prefix, n)
+	runInShell(t, term,
+		fmt.Sprintf("for i in $(seq 1 %d); do echo \"%s-$i-END\"; done", n, prefix),
+		last, bulkTimeout)
+	return last
+}
+
+// paneCell picks a cell inside the focused pane: the middle of the screen is
+// always pane content with one window open.
+func paneCell(t *testing.T, term *tuitest.Terminal) (col, row int) {
+	t.Helper()
+	cols, rows := term.Screen().Size()
+	return cols / 2, rows / 2
+}
+
+// watchForBanner samples the screen until the returned stop function is called,
+// and reports the first of the given strings it ever saw. Sampling throughout
+// is what makes an absence assertion meaningful: a banner that has already
+// expired by the time of a single check would otherwise pass.
+func watchForBanner(term *tuitest.Terminal, banners ...string) (stop func() string) {
+	done := make(chan struct{})
+	result := make(chan string, 1)
+	go func() {
+		seen := ""
+		for seen == "" {
+			select {
+			case <-done:
+				result <- seen
+				return
+			default:
+			}
+			text := term.Screen().Text()
+			for _, b := range banners {
+				if strings.Contains(text, b) {
+					seen = b
+					break
+				}
+			}
+			time.Sleep(40 * time.Millisecond)
+		}
+		<-done
+		result <- seen
+	}()
+	return func() string {
+		close(done)
+		return <-result
+	}
+}
+
+// newestVisible returns the highest numbered PREFIX-n-END marker on screen, or
+// -1 when none is there.
+//
+// Assertions go through this rather than waiting for one specific line number.
+// Waiting for a line by name races the gesture: the notches are sent back to
+// back, and by the time the wait starts the view has already moved past the
+// line the test named. Asking where the viewport ended up instead is both
+// stable and a more direct statement of what scrolling means.
+func newestVisible(s tuitest.Screen, prefix string) int {
+	re := regexp.MustCompile(regexp.QuoteMeta(prefix) + `-(\d+)-END`)
+	newest := -1
+	for _, m := range re.FindAllStringSubmatch(s.Text(), -1) {
+		if n, err := strconv.Atoi(m[1]); err == nil && n > newest {
+			newest = n
+		}
+	}
+	return newest
+}
+
+// waitScrolledTo blocks until the newest marker on screen satisfies want, and
+// reports where the viewport actually settled if it never does.
+func waitScrolledTo(t *testing.T, term *tuitest.Terminal, prefix, what string, want func(int) bool) {
+	t.Helper()
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return want(newestVisible(s, prefix))
+	}, uiTimeout); err != nil {
+		t.Fatalf("%s: the newest line on screen is %s-%d-END: %v\n%s",
+			what, prefix, newestVisible(term.Screen(), prefix), err, term.Snapshot())
+	}
+}
+
+// TestWheelScrollShowsScrollbackWithoutAnnouncingAMode is the centre of the
+// change. Turning the wheel over a pane used to drop the user into copy mode
+// and put "COPY MODE (hjkl/q)" on the dock along with a line of vim keybindings,
+// which is tmux's behaviour. In kitty, WezTerm, iTerm2 or GNOME Terminal the
+// view just scrolls.
+//
+// Two things are asserted, and both matter. Older output must appear, so this
+// is really testing scrolling. And no mode may be announced at any point during
+// the gesture, which is sampled continuously rather than once, because a
+// notification that has already expired by the time of a single sample would
+// let the old behaviour through.
+func TestWheelScrollShowsScrollbackWithoutAnnouncingAMode(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	const total = 300
+	last := fillScrollback(t, term, "WHEEL", total)
+
+	col, row := paneCell(t, term)
+
+	// Watch for any announcement for the whole gesture, not just after it: a
+	// notification that expired before a single sample would slip through.
+	stop := watchForBanner(term, "COPY MODE", "hjkl:move", "y:yank")
+
+	wheelAt(t, term, col, row, tuitest.MouseWheelUp, 20)
+
+	// The viewport must have moved back by roughly what was asked for: sixty
+	// lines of history, minus the pane's own height.
+	waitScrolledTo(t, term, "WHEEL", "the wheel did not scroll back through the history",
+		func(n int) bool { return n > 0 && n <= total-40 })
+	time.Sleep(500 * time.Millisecond)
+	if seen := stop(); seen != "" {
+		t.Fatalf("scrolling announced a mode: %q was on screen. Turning the wheel must not "+
+			"put the user in a mode or teach them keybindings.\n%s", seen, term.Snapshot())
+	}
+	if strings.Contains(term.Screen().Text(), last) {
+		t.Errorf("the newest line %q is still on screen; the viewport did not really move\n%s",
+			last, term.Snapshot())
+	}
+	alive(t, term, "after wheel scrolling")
+}
+
+// TestWheelDownToBottomReturnsToLiveOutput drives the whole round trip: scroll
+// up, scroll back down, then type. The typing is the assertion. tuios used to
+// leave the pane in copy mode after the wheel came back to the bottom, with the
+// scroll offset at zero so it looked like live output, and every subsequent
+// keystroke was eaten as a vim motion. Nothing the user typed reached the shell
+// and nothing said why.
+func TestWheelDownToBottomReturnsToLiveOutput(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	fillScrollback(t, term, "ROUND", 200)
+	col, row := paneCell(t, term)
+
+	wheelAt(t, term, col, row, tuitest.MouseWheelUp, 10)
+	waitScrolledTo(t, term, "ROUND", "the wheel did not scroll up",
+		func(n int) bool { return n > 0 && n <= 190 })
+	wheelAt(t, term, col, row, tuitest.MouseWheelDown, 10)
+	waitScrolledTo(t, term, "ROUND", "the wheel did not scroll back to live output",
+		func(n int) bool { return n == 200 })
+
+	// The shell must have the keyboard again. The marker is computed by the
+	// shell, so an echo of the keystrokes cannot satisfy it.
+	runInShell(t, term, "echo WHEELBACK-$((6*7))", "WHEELBACK-42", shellTimeout)
+	alive(t, term, "after a wheel round trip")
+}
+
+// TestTypingWhileScrolledSnapsBackToLiveOutput covers the other half: the user
+// scrolls up, reads, and then starts typing without scrolling back. A terminal
+// with no modes jumps to the bottom and types the character. tuios used to feed
+// the keystrokes to copy mode's motions instead.
+func TestTypingWhileScrolledSnapsBackToLiveOutput(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	fillScrollback(t, term, "TYPED", 200)
+	col, row := paneCell(t, term)
+
+	wheelAt(t, term, col, row, tuitest.MouseWheelUp, 10)
+	waitScrolledTo(t, term, "TYPED", "the wheel did not scroll",
+		func(n int) bool { return n > 0 && n <= 190 })
+
+	runInShell(t, term, "echo TYPEBACK-$((6*7))", "TYPEBACK-42", shellTimeout)
+
+	// And the pane is back at the bottom, not left hanging in the scrollback.
+	waitScrolledTo(t, term, "TYPED", "typing did not return the pane to live output",
+		func(n int) bool { return n == 200 })
+	alive(t, term, "after typing while scrolled")
+}
+
+// TestMouseTrackingAppKeepsItsOwnWheel is the regression guard on the thing
+// that already worked and must keep working: vim, less and htop ask for the
+// mouse, and the wheel belongs to them.
+//
+// The fixture is the terminal line discipline itself. With echo on, whatever
+// tuios writes into the pane's PTY is echoed straight back, so a forwarded SGR
+// wheel report appears in the pane as its own text. Nothing has to be running
+// but the shell.
+func TestMouseTrackingAppKeepsItsOwnWheel(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	last := fillScrollback(t, term, "OWNED", 200)
+
+	// Ask for mouse tracking the way an application does, in SGR encoding.
+	runInShell(t, term, `printf '\033[?1000h\033[?1006h'; echo MOUSEON`, "MOUSEON", shellTimeout)
+
+	col, row := paneCell(t, term)
+	wheelAt(t, term, col, row, tuitest.MouseWheelUp, 2)
+
+	// The report reaches the pane and the tty echoes it back. The ESC and the
+	// CSI introducer are swallowed on the way through the emulator, so what
+	// lands on screen is the tail of the SGR report: button 64 (wheel up) and
+	// the cell it happened over, in terminal-relative coordinates.
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return sgrWheelReport.MatchString(s.Text())
+	}, uiTimeout); err != nil {
+		t.Fatalf("the wheel was not forwarded to the pane that asked for the mouse: %v\n%s",
+			err, term.Snapshot())
+	}
+	// And tuios did not scroll its own scrollback underneath it: the newest
+	// line is still there.
+	if !strings.Contains(term.Screen().Text(), last) {
+		t.Fatalf("tuios scrolled a mouse-tracking pane's scrollback; %q left the screen\n%s",
+			last, term.Snapshot())
+	}
+	alive(t, term, "after wheeling over a mouse-tracking pane")
+}
+
+// sgrWheelReport matches a forwarded wheel-up report as it comes back out of
+// the pane's own tty echo: button 64, a column, a row, and the press marker.
+var sgrWheelReport = regexp.MustCompile(`64;\d+;\d+M`)
+
+// osc52 matches a clipboard write on the wire. tuios's copy path is
+// tea.SetClipboard, which is OSC 52, so this is what a copy looks like to the
+// terminal the user is actually sitting in front of.
+var osc52 = regexp.MustCompile(`\x1b\]52;[^;]*;([A-Za-z0-9+/=]*)(?:\x07|\x1b\\)`)
+
+// clipboardWrites decodes every OSC 52 payload tuios has written so far.
+func clipboardWrites(out *lockedBuffer) []string {
+	var got []string
+	for _, m := range osc52.FindAllStringSubmatch(out.String(), -1) {
+		if data, err := base64.StdEncoding.DecodeString(m[1]); err == nil {
+			got = append(got, string(data))
+		}
+	}
+	return got
+}
+
+// lockedBuffer is a bytes.Buffer the output pump can write while the test reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForClipboard blocks until tuios has written the wanted text to the
+// clipboard, and reports what it did write if it never does.
+func waitForClipboard(t *testing.T, term *tuitest.Terminal, out *lockedBuffer, want string) {
+	t.Helper()
+	deadline := time.Now().Add(uiTimeout)
+	for time.Now().Before(deadline) {
+		for _, got := range clipboardWrites(out) {
+			if strings.TrimSpace(got) == want {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("no clipboard write of %q. tuios wrote %q\n%s",
+		want, clipboardWrites(out), term.Snapshot())
+}
+
+// TestDragSelectionCopiesOnRelease drives a real click-drag across a line of
+// output and asserts the text left the process on the clipboard.
+//
+// Before this change a left drag inside a pane in terminal mode did not select
+// at all: it grabbed the window, moved it, and dropped the user into window
+// management mode.
+func TestDragSelectionCopiesOnRelease(t *testing.T) {
+	out := &lockedBuffer{}
+	term, _ := start(t, startOpts{out: out})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	const marker = "DRAGME-alpha-bravo"
+	runInShell(t, term, "echo "+marker, marker, shellTimeout)
+	row, col := findText(t, term, marker)
+
+	dragSelect(t, term, col, col+len(marker)-1, row)
+
+	waitForClipboard(t, term, out, marker)
+	if err := term.WaitForText("Copied", uiTimeout); err != nil {
+		t.Errorf("no copy confirmation in the dock: %v\n%s", err, term.Snapshot())
+	}
+	alive(t, term, "after a drag selection")
+}
+
+// TestDoubleClickCopiesAWordAndTripleClickTheLine covers the two gestures every
+// terminal has had since the nineties and tuios had neither of.
+//
+// The word is a path so the assertion also pins the word-character set: a
+// double-click that stopped at every punctuation mark would select "usr" and
+// the test would say so.
+func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
+	out := &lockedBuffer{}
+	term, _ := start(t, startOpts{out: out})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	const word = "/opt/dblclick/word.txt"
+	const line = "PREFIX " + word + " SUFFIX"
+	// The word is assembled from a variable so the shell's echo of the command
+	// does not itself contain it: otherwise findText lands on the command line
+	// rather than on the output, and the test asserts about the wrong row.
+	runInShell(t, term, `P=/opt; echo "PREFIX $P/dblclick/word.txt SUFFIX"`, word, shellTimeout)
+	row, col := findText(t, term, word)
+
+	clickAt(t, term, col+6, row, 2)
+	waitForClipboard(t, term, out, word)
+
+	// Let the multi-click window lapse, or the first press of the triple
+	// continues the double and the counts come out shifted.
+	time.Sleep(800 * time.Millisecond)
+
+	clickAt(t, term, col+6, row, 3)
+	waitForClipboard(t, term, out, line)
+	alive(t, term, "after multi-click selection")
+}

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -27,8 +27,10 @@ func (m *OS) getRealCursor() *tea.Cursor {
 	// IsCursorHidden and CursorPosition read emulator state that the PTY and
 	// daemon output goroutines mutate under the window's I/O lock, so both
 	// reads take the read side of it.
-	if (window.CopyMode != nil && window.CopyMode.Active) ||
-		window.ScrollbackOffset > 0 {
+	// An implicit copy-mode session that is sitting at the bottom (a
+	// drag-selection over live output) is not a reason to hide the shell's
+	// cursor; being scrolled back still is, and that is the second condition.
+	if window.CopyModeVisible() || window.ScrollbackOffset > 0 {
 		return nil
 	}
 

--- a/internal/app/dock_helpers.go
+++ b/internal/app/dock_helpers.go
@@ -94,7 +94,7 @@ func (m *OS) buildDockLeftText() (string, int, ModeInfo) {
 	var modeLabel string
 
 	if m.Mode == TerminalMode {
-		if focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
+		if focusedWindow.CopyModeVisible() {
 			// Copy mode
 			modeInfo.Color = theme.ColorToString(theme.DockColorCopy())
 			modeInfo.CursorPos = fmt.Sprintf("%d:%d", focusedWindow.CopyMode.CursorY, focusedWindow.CopyMode.CursorX)
@@ -223,9 +223,8 @@ func (m *OS) calculateDockRightWidth() int {
 	}
 
 	focusedWindow := m.GetFocusedWindow()
-	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
 
-	if inCopyMode {
+	if focusedWindow.CopyModeVisible() {
 		// In copy mode the help line is the right-hand block. Measure the
 		// longest variant rather than guessing at it, so a terminal with room
 		// for it reserves exactly enough and one without falls to a shorter

--- a/internal/app/render_dock.go
+++ b/internal/app/render_dock.go
@@ -182,7 +182,7 @@ func (m *OS) renderDockString() (string, int) {
 	// closing cap: the block would lose the shape that makes it part of the bar.
 	notif, hasNotif := m.renderNotificationBlock(renderWidth, max(renderWidth-actualLeftWidth-centerWidth, 0))
 
-	inCopyMode := focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active
+	inCopyMode := focusedWindow.CopyModeVisible()
 	switch {
 	case hasNotif:
 		// The message outranks the help line for its duration. Copy mode is a

--- a/internal/app/render_terminal.go
+++ b/internal/app/render_terminal.go
@@ -205,9 +205,15 @@ func (m *OS) renderTerminal(window *terminal.Window, isFocused bool, inTerminalM
 	scrollbackLen := window.ScrollbackLen()
 	inScrollbackMode := window.ScrollbackOffset > 0
 
-	inCopyMode := window.CopyMode != nil && window.CopyMode.Active
-	var copyModeCursorX, copyModeCursorY int
-	if inCopyMode {
+	inCopyMode := window.InCopyMode()
+	// The block cursor is copy mode showing itself. A pane that is merely
+	// scrolled back under the wheel draws none: a cursor parked mid-pane over
+	// output the user is only reading is the clearest tell that they have been
+	// put in a mode. Selection highlights and search matches still render,
+	// because a drag-selection runs in an implicit session.
+	showCopyCursor := window.CopyModeVisible()
+	copyModeCursorX, copyModeCursorY := -1, -1
+	if showCopyCursor {
 		copyModeCursorX = window.CopyMode.CursorX
 		copyModeCursorY = window.CopyMode.CursorY
 	}
@@ -426,7 +432,7 @@ func (m *OS) renderTerminal(window *terminal.Window, isFocused bool, inTerminalM
 		for x := 0; x < maxX; {
 			var cell *uv.Cell
 
-			if inCopyMode && x == copyModeCursorX && y == copyModeCursorY {
+			if showCopyCursor && x == copyModeCursorX && y == copyModeCursorY {
 				char := " "
 				var cursorCell *uv.Cell
 				charWidth := 1

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -469,6 +469,18 @@ func (m *OS) settingsCategories() []settingsCategory {
 					config.ScrollLines = v
 					m.setAppearance(func(a *config.AppearanceConfig) { a.ScrollLines = v })
 				}),
+			boolItem("Copy on select", "Put a mouse selection on the clipboard as soon as it is released",
+				func() bool { return config.CopyOnSelect },
+				func(m *OS, v bool) {
+					config.CopyOnSelect = v
+					m.setAppearance(func(a *config.AppearanceConfig) { a.CopyOnSelect = &v })
+				}),
+			stringItem("Word characters", "Punctuation double-click keeps inside a word (letters and digits always count)", "@-./_~?&=%+#",
+				func(m *OS) string { return config.WordCharacters },
+				func(m *OS, v string) {
+					config.WordCharacters = v
+					m.setAppearance(func(a *config.AppearanceConfig) { a.WordCharacters = &v })
+				}),
 			intItem("Zoom width", "Max columns in zoom mode (0 = fullscreen)", 0, 400, 10,
 				func() int { return config.ZoomMaxWidth },
 				func(m *OS, v int) {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -534,6 +534,23 @@ var ScrollbackLines = 10000
 // Set via appearance.scroll_lines config
 var ScrollLines = 3
 
+// CopyOnSelect puts the text on the clipboard as soon as a mouse selection is
+// released, the way X11's primary selection and kitty's copy_on_select do.
+// Turn it off to keep the clipboard until an explicit yank.
+// Set via appearance.copy_on_select config.
+var CopyOnSelect = true
+
+// WordCharacters lists the punctuation that counts as part of a word when a
+// double-click selects one, on top of letters and digits, which always do.
+//
+// The default is kitty's select_by_word_characters, and it is chosen for what
+// terminal content actually looks like: it takes a path, a URL, a version
+// number, or a flag such as --no-vm as a single word instead of stopping at
+// every punctuation mark. A colon is deliberately absent, so host:port and
+// file:line select as their parts.
+// Set via appearance.word_characters config.
+var WordCharacters = `@-./_~?&=%+#`
+
 // NiriReverseScroll reverses mouse scroll direction in niri scrolling mode.
 // When true, scroll-up moves viewport right and scroll-down moves left.
 // Set via appearance.niri_reverse_scroll config

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -106,24 +106,26 @@ type DaemonConfig struct {
 
 // AppearanceConfig holds appearance-related settings
 type AppearanceConfig struct {
-	BorderStyle         string `toml:"border_style"`          // Border style: rounded, normal, thick, double, hidden, block, ascii, outer-half-block, inner-half-block (borderless mode not yet implemented)
-	HideWindowButtons   bool   `toml:"hide_window_buttons"`   // Hide window control buttons (minimize, maximize, close)
-	HideScrollbar       bool   `toml:"hide_scrollbar"`        // Hide the window scrollbar thumb on the border
-	ScrollbackLines     int    `toml:"scrollback_lines"`      // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
-	ScrollLines         int    `toml:"scroll_lines"`          // Lines scrolled per mouse wheel notch (default: 3, min: 1, max: 50)
-	DockbarPosition     string `toml:"dockbar_position"`      // Dockbar position: bottom, top, hidden
-	PreferredShell      string `toml:"preferred_shell"`       // Preferred shell: if empty, auto-detect based on platform.
-	AnimationsEnabled   *bool  `toml:"animations_enabled"`    // Enable UI animations (default: true). Set to false for instant transitions.
-	ConfirmQuit         *bool  `toml:"confirm_quit"`          // Always show quit confirmation dialog (default: false). When false, only shown if foreground processes are running.
-	WhichKeyEnabled     *bool  `toml:"whichkey_enabled"`      // Show which-key popup after pressing leader key (default: true)
-	WhichKeyPosition    string `toml:"whichkey_position"`     // Which-key popup position: bottom-right, bottom-left, top-right, top-left, center (default: bottom-right)
-	WindowTitlePosition string `toml:"window_title_position"` // Window title position: bottom, top, hidden (default: bottom). Shows CustomName if set, else terminal title.
-	HideClock           bool   `toml:"hide_clock"`            // Hide the clock overlay (deprecated, use show_clock)
-	ShowClock           bool   `toml:"show_clock"`            // Show the clock overlay (default: false)
-	ShowCPU             bool   `toml:"show_cpu"`              // Show CPU graph in dock (default: false)
-	ShowRAM             bool   `toml:"show_ram"`              // Show RAM usage in dock (default: false)
-	Theme               string `toml:"theme"`                 // Color theme name (e.g., dracula, nord, my-custom-theme)
-	SharedBorders       *bool  `toml:"shared_borders"`        // Share borders between adjacent tiled windows (default: false)
+	BorderStyle         string  `toml:"border_style"`          // Border style: rounded, normal, thick, double, hidden, block, ascii, outer-half-block, inner-half-block (borderless mode not yet implemented)
+	HideWindowButtons   bool    `toml:"hide_window_buttons"`   // Hide window control buttons (minimize, maximize, close)
+	HideScrollbar       bool    `toml:"hide_scrollbar"`        // Hide the window scrollbar thumb on the border
+	ScrollbackLines     int     `toml:"scrollback_lines"`      // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
+	ScrollLines         int     `toml:"scroll_lines"`          // Lines scrolled per mouse wheel notch (default: 3, min: 1, max: 50)
+	CopyOnSelect        *bool   `toml:"copy_on_select"`        // Copy a mouse selection to the clipboard on release (default: true)
+	WordCharacters      *string `toml:"word_characters"`       // Punctuation that counts as part of a word for double-click selection (default: "@-./_~?&=%+#")
+	DockbarPosition     string  `toml:"dockbar_position"`      // Dockbar position: bottom, top, hidden
+	PreferredShell      string  `toml:"preferred_shell"`       // Preferred shell: if empty, auto-detect based on platform.
+	AnimationsEnabled   *bool   `toml:"animations_enabled"`    // Enable UI animations (default: true). Set to false for instant transitions.
+	ConfirmQuit         *bool   `toml:"confirm_quit"`          // Always show quit confirmation dialog (default: false). When false, only shown if foreground processes are running.
+	WhichKeyEnabled     *bool   `toml:"whichkey_enabled"`      // Show which-key popup after pressing leader key (default: true)
+	WhichKeyPosition    string  `toml:"whichkey_position"`     // Which-key popup position: bottom-right, bottom-left, top-right, top-left, center (default: bottom-right)
+	WindowTitlePosition string  `toml:"window_title_position"` // Window title position: bottom, top, hidden (default: bottom). Shows CustomName if set, else terminal title.
+	HideClock           bool    `toml:"hide_clock"`            // Hide the clock overlay (deprecated, use show_clock)
+	ShowClock           bool    `toml:"show_clock"`            // Show the clock overlay (default: false)
+	ShowCPU             bool    `toml:"show_cpu"`              // Show CPU graph in dock (default: false)
+	ShowRAM             bool    `toml:"show_ram"`              // Show RAM usage in dock (default: false)
+	Theme               string  `toml:"theme"`                 // Color theme name (e.g., dracula, nord, my-custom-theme)
+	SharedBorders       *bool   `toml:"shared_borders"`        // Share borders between adjacent tiled windows (default: false)
 	// Customization
 	BorderFocusedColor   string `toml:"border_focused_color"`   // Hex color for focused pane border (e.g., "#89b4fa")
 	BorderUnfocusedColor string `toml:"border_unfocused_color"` // Hex color for unfocused pane border (e.g., "#585b70")
@@ -682,6 +684,17 @@ func ApplyAppearanceConfig(cfg *UserConfig) {
 	// ScrollLines (lines per wheel notch)
 	if cfg.Appearance.ScrollLines > 0 {
 		ScrollLines = cfg.Appearance.ScrollLines
+	}
+
+	// CopyOnSelect defaults to true (nil means use default)
+	if cfg.Appearance.CopyOnSelect != nil {
+		CopyOnSelect = *cfg.Appearance.CopyOnSelect
+	}
+
+	// WordCharacters is a pointer so an explicitly empty string can mean "no
+	// punctuation is part of a word", which is different from "unset".
+	if cfg.Appearance.WordCharacters != nil {
+		WordCharacters = *cfg.Appearance.WordCharacters
 	}
 
 	// ZoomMaxWidth (0 = fullscreen)

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -170,36 +170,43 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return o, nil
 	}
 
-	// Shift+Up/Shift+Down: enter copy mode (if not active) and scroll scrollback.
-	// Handled BEFORE the copy mode check so subsequent presses also scroll
-	// instead of being consumed by the copy mode key handler.
+	// Shift+Up/Shift+Down: scroll the scrollback, the keyboard spelling of the
+	// wheel. Handled BEFORE the copy mode check so subsequent presses also
+	// scroll instead of being consumed by the copy mode key handler, and it
+	// enters copy mode the same silent way the wheel does.
 	if focusedWindow != nil {
 		shiftScroll := msg.String()
 		if shiftScroll == "shift+up" || shiftScroll == "shift+down" {
-			if focusedWindow.CopyMode == nil || !focusedWindow.CopyMode.Active {
-				focusedWindow.EnterCopyMode()
-			}
-			if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
-				cm := focusedWindow.CopyMode
-				if shiftScroll == "shift+up" {
-					if cm.ScrollOffset < focusedWindow.ScrollbackLen() {
-						cm.ScrollOffset++
-						focusedWindow.ScrollbackOffset = cm.ScrollOffset
-					}
-				} else {
-					if cm.ScrollOffset > 0 {
-						cm.ScrollOffset--
-						focusedWindow.ScrollbackOffset = cm.ScrollOffset
-					}
+			// One line per press, the way it has always been, but through the
+			// same viewport helpers the wheel uses.
+			if shiftScroll == "shift+up" {
+				if !focusedWindow.InCopyMode() && focusedWindow.ScrollbackLen() > 0 {
+					focusedWindow.EnterCopyModeImplicit()
 				}
-				focusedWindow.InvalidateCache()
+				scrollCopyModeUpBy(focusedWindow, 1)
+			} else if focusedWindow.InCopyMode() {
+				scrollCopyModeDownBy(focusedWindow, 1)
+				leaveCopyModeAtBottom(focusedWindow)
 			}
 			return o, nil
 		}
 	}
 
+	// A scroll gesture leaves the pane in an implicit copy mode, because that is
+	// the only thing that renders scrollback. Typing means the reading is over:
+	// snap back to live output and let the key through to the shell, which is
+	// what a terminal with no modes does. Esc is the one key not forwarded; it
+	// is the reflex for "get me out of this", and a bare Esc into a shell in vi
+	// mode or a readline meta prefix is not a no-op.
+	if focusedWindow != nil && focusedWindow.InImplicitCopyMode() {
+		focusedWindow.ExitCopyMode()
+		if msg.String() == "esc" {
+			return o, nil
+		}
+	}
+
 	// Handle copy mode (vim-style scrollback/selection)
-	if focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
+	if focusedWindow.InCopyMode() {
 		return HandleCopyModeKey(msg, o, focusedWindow)
 	}
 

--- a/internal/input/keyboard_wm.go
+++ b/internal/input/keyboard_wm.go
@@ -11,8 +11,15 @@ import (
 func HandleWindowManagementModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	focusedWindow := o.GetFocusedWindow()
 
+	// A wheel scroll here leaves the pane in an implicit copy mode too, and a
+	// window-manager binding must not be swallowed by it. Any key ends the
+	// scrolled view and is then handled as the window-manager command it is.
+	if focusedWindow != nil && focusedWindow.InImplicitCopyMode() {
+		focusedWindow.ExitCopyMode()
+	}
+
 	// Handle copy mode (vim-style scrollback/selection) - takes priority
-	if focusedWindow != nil && focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
+	if focusedWindow.InCopyMode() {
 		return HandleCopyModeKey(msg, o, focusedWindow)
 	}
 

--- a/internal/input/mouse.go
+++ b/internal/input/mouse.go
@@ -129,9 +129,11 @@ func scrollToPosition(win *terminal.Window, mouseY int) {
 		return
 	}
 
-	// Enter copy mode if not already
-	if win.CopyMode == nil || !win.CopyMode.Active {
-		win.EnterCopyMode()
+	// Dragging the scrollbar is a scroll gesture like the wheel, so it enters
+	// copy mode the same silent way: the scrollback has to be rendered by
+	// something, but the user did not ask to be put in a mode.
+	if !win.InCopyMode() {
+		win.EnterCopyModeImplicit()
 	}
 	if win.CopyMode == nil {
 		return
@@ -149,4 +151,8 @@ func scrollToPosition(win *terminal.Window, mouseY int) {
 	win.CopyMode.ScrollOffset = scrollOffset
 	win.ScrollbackOffset = scrollOffset // Sync for rendering
 	win.InvalidateCache()
+
+	// Dragged all the way to the bottom is the same as scrolling there with the
+	// wheel: back to live output, with nothing left over.
+	leaveCopyModeAtBottom(win)
 }

--- a/internal/input/mouse_click.go
+++ b/internal/input/mouse_click.go
@@ -183,22 +183,37 @@ func handleMouseClick(msg tea.MouseClickMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		}
 	}
 
-	// Handle copy mode mouse clicks AFTER button checks
-	if clickedWindow.CopyMode != nil && clickedWindow.CopyMode.Active {
-		// In copy mode, handle mouse clicks for cursor movement and selection
-		if mouse.Button == tea.MouseLeft {
-			// Check if clicking in terminal content area (not on title bar or buttons)
-			_, _, inContent := clickedWindow.ScreenToTerminal(X, Y)
-			if inContent {
-				// Start drag for visual selection
-				HandleCopyModeMouseDrag(clickedWindow.CopyMode, clickedWindow, X, Y)
-				o.Dragging = true
-				o.DraggedWindowIndex = clickedWindowIndex
-				o.InteractionMode = true
-				return o, nil
+	// Text selection with the mouse, AFTER the button checks.
+	//
+	// A left press inside a pane's content selects text, in terminal mode as
+	// well as in copy mode. It used to only select in copy mode: in terminal
+	// mode the same press grabbed the window, dragged it, and dropped the user
+	// into window management mode, so click-dragging over output moved the pane
+	// instead of selecting the line. The title bar and the borders are still
+	// the window's drag handle, and window management mode still drags from
+	// anywhere, so nothing lost a way to move a window.
+	//
+	// Panes running an application with mouse tracking never reach here; their
+	// press was forwarded to the application further up, exactly as the wheel is.
+	if mouse.Button == tea.MouseLeft && (clickedWindow.InCopyMode() || o.Mode == app.TerminalMode) {
+		terminalX, terminalY, inContent := clickedWindow.ScreenToTerminal(X, Y)
+		if inContent {
+			o.FocusWindow(clickedWindowIndex)
+			if !clickedWindow.InCopyMode() {
+				// Selection reads through copy mode's machinery, so a
+				// selection in terminal mode has to turn it on. Implicitly:
+				// nothing is announced and the dock does not change.
+				clickedWindow.EnterCopyModeImplicit()
 			}
+			beginMouseSelection(clickedWindow.CopyMode, clickedWindow, X, Y,
+				registerClick(clickedWindow, terminalX, terminalY))
+			o.Dragging = true
+			o.DraggedWindowIndex = clickedWindowIndex
+			o.InteractionMode = true
+			return o, nil
 		}
-		// If click is outside content area, fall through to normal window interaction
+		// A press outside the content area falls through to normal window
+		// interaction: that is the title bar, and it should still drag.
 	}
 
 	// Focus the clicked window and bring to front Z-index

--- a/internal/input/mouse_motion.go
+++ b/internal/input/mouse_motion.go
@@ -98,8 +98,8 @@ func handleMouseMotion(msg tea.MouseMotionMsg, o *app.OS) (*app.OS, tea.Cmd) {
 
 				if mouse.Y < contentTop {
 					// Dragging above  - enter copy mode and scroll up
-					if focusedWindow.CopyMode == nil || !focusedWindow.CopyMode.Active {
-						focusedWindow.EnterCopyMode()
+					if !focusedWindow.InCopyMode() {
+						focusedWindow.EnterCopyModeImplicit()
 					}
 					if focusedWindow.CopyMode != nil {
 						for range 3 {

--- a/internal/input/mouse_release.go
+++ b/internal/input/mouse_release.go
@@ -54,14 +54,17 @@ func handleMouseRelease(msg tea.MouseReleaseMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	// Handle copy mode mouse release
 	if o.Dragging && o.DraggedWindowIndex >= 0 && o.DraggedWindowIndex < len(o.Windows) {
 		draggedWindow := o.Windows[o.DraggedWindowIndex]
-		if draggedWindow.CopyMode != nil && draggedWindow.CopyMode.Active {
-			// Selection is complete, clean up drag state and stop auto-scroll
+		if draggedWindow.InCopyMode() {
+			// Selection is complete: copy it if the user wants that, then clean
+			// up drag state and stop auto-scroll.
+			cmd := finishMouseSelection(o, draggedWindow)
+			draggedWindow.InvalidateCache()
 			o.Dragging = false
 			o.DraggedWindowIndex = -1
 			o.InteractionMode = false
 			o.AutoScrollActive = false
 			o.AutoScrollDir = 0
-			return o, nil
+			return o, cmd
 		}
 	}
 

--- a/internal/input/mouse_scroll.go
+++ b/internal/input/mouse_scroll.go
@@ -1,0 +1,108 @@
+package input
+
+import (
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// A wheel click is a viewport gesture, not a cursor motion.
+//
+// These helpers move CopyMode.ScrollOffset directly, the way Shift+Up/Down
+// already did. The wheel used to drive the k/j motions instead, and those keep
+// the cursor near the middle of the pane and only scroll once it gets there:
+// deliberate for keyboard navigation, and wrong for a wheel. With the cursor
+// down at the shell prompt, where it lands after the previous gesture scrolled
+// back to the bottom or after a click, every iteration only decremented CursorY
+// and the view did not move at all. On a 40-row pane that is around twenty dead
+// iterations, several whole wheel clicks of nothing happening before the first
+// line moved. moveUp/moveDown are untouched, so k and j still behave as before.
+//
+// The cursor follows the text under it rather than the screen row it sits on:
+// CursorY is viewport-relative and absolute position is
+// scrollbackLen-ScrollOffset+CursorY, so a scroll that did not move the cursor
+// would silently slide it onto different content. Following keeps a v pressed
+// after a scroll selecting from the line the user was looking at, and keeps an
+// in-progress visual selection anchored to its text. It is clamped to the
+// visible rows on every step, so the cursor can never end up outside the region
+// being drawn: once the line it was on scrolls past an edge, the cursor rides
+// that edge.
+
+// scrollCopyModeUp scrolls the pane's viewport back by one wheel step.
+func scrollCopyModeUp(win *terminal.Window) { scrollCopyModeUpBy(win, scrollStep()) }
+
+// scrollCopyModeDown scrolls the pane's viewport forward by one wheel step.
+func scrollCopyModeDown(win *terminal.Window) { scrollCopyModeDownBy(win, scrollStep()) }
+
+// scrollCopyModeUpBy scrolls the viewport back by lines, stopping at the oldest
+// line in the scrollback.
+func scrollCopyModeUpBy(win *terminal.Window, lines int) {
+	cm := win.CopyMode
+	if cm == nil || !cm.Active {
+		return
+	}
+	limit := win.ScrollbackLen()
+	moved := min(cm.ScrollOffset+lines, limit) - cm.ScrollOffset
+	if moved <= 0 {
+		return
+	}
+	cm.ScrollOffset += moved
+	win.ScrollbackOffset = cm.ScrollOffset
+	setCopyCursorRow(cm, win, cm.CursorY+moved)
+	win.InvalidateCache()
+}
+
+// scrollCopyModeDownBy scrolls the viewport forward by lines, stopping at the
+// live screen.
+func scrollCopyModeDownBy(win *terminal.Window, lines int) {
+	cm := win.CopyMode
+	if cm == nil || !cm.Active {
+		return
+	}
+	moved := cm.ScrollOffset - max(cm.ScrollOffset-lines, 0)
+	if moved <= 0 {
+		return
+	}
+	cm.ScrollOffset -= moved
+	win.ScrollbackOffset = cm.ScrollOffset
+	setCopyCursorRow(cm, win, cm.CursorY-moved)
+	win.InvalidateCache()
+}
+
+// setCopyCursorRow puts the copy-mode cursor on a viewport row, clamped to the
+// rows that are actually drawn.
+func setCopyCursorRow(cm *terminal.CopyMode, win *terminal.Window, row int) {
+	cm.CursorY = max(min(row, win.ContentHeight()-1), 0)
+}
+
+// scrollStep is the number of lines one wheel click moves, from
+// appearance.scroll_lines, floored at one so a misconfigured zero cannot make
+// the wheel inert.
+func scrollStep() int {
+	return max(config.ScrollLines, 1)
+}
+
+// leaveCopyModeAtBottom ends an implicit copy-mode session that has scrolled
+// back to the live screen.
+//
+// Reaching the bottom and being done are the same event: a wheel gesture that
+// walks the view back down to live output has nothing left to render from
+// scrollback, so the session that existed only to render it goes away. It goes
+// quietly, because there was nothing to announce on the way in either.
+//
+// An explicit session is left alone. The wheel used to throw the user out of
+// copy mode they had asked for, once the cursor happened to reach the last row,
+// which is a surprise in the other direction; q and Esc still exit, and both
+// already return the pane to the bottom.
+//
+// A selection in progress holds the session open: dragging past the bottom edge
+// auto-scrolls, and exiting at zero would drop the drag mid-gesture.
+func leaveCopyModeAtBottom(win *terminal.Window) {
+	cm := win.CopyMode
+	if cm == nil || !cm.Active || !cm.Implicit {
+		return
+	}
+	if cm.ScrollOffset != 0 || cm.State != terminal.CopyModeNormal {
+		return
+	}
+	win.ExitCopyMode()
+}

--- a/internal/input/mouse_scroll_test.go
+++ b/internal/input/mouse_scroll_test.go
@@ -1,0 +1,293 @@
+package input
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// scrollPane builds a pane whose emulator has far more history than fits on
+// screen, sized like a real window rather than the minimum, so the midpoint the
+// old wheel path walked the cursor to is many rows away from the bottom.
+func scrollPane(t *testing.T) (*app.OS, *terminal.Window) {
+	t.Helper()
+	em := vt.NewEmulator(40, 20)
+	t.Cleanup(func() { _ = em.Close() })
+	for i := range 200 {
+		_, _ = em.Write([]byte(fmt.Sprintf("line %d\r\n", i)))
+	}
+	if em.ScrollbackLen() < 50 {
+		t.Fatalf("emulator produced %d scrollback lines; the test needs more", em.ScrollbackLen())
+	}
+	win := &terminal.Window{Terminal: em, Width: 42, Height: 22}
+	o := &app.OS{
+		Mode:          app.TerminalMode,
+		FocusedWindow: 0,
+		Windows:       []*terminal.Window{win},
+	}
+	return o, win
+}
+
+func wheel(o *app.OS, button tea.MouseButton, times int) {
+	for range times {
+		handleMouseWheel(tea.MouseWheelMsg{Button: button}, o)
+	}
+}
+
+// The wheel used to drive the k/j cursor motions, which keep the cursor near
+// the middle of the pane and only scroll once it gets there. With the cursor
+// down by the shell prompt, every early click moved the cursor and nothing
+// else: on a tall pane that is several whole clicks of the view not moving.
+//
+// One click, one scroll, from wherever the cursor happens to be.
+func TestWheelUpScrollsOnTheFirstClickWhateverTheCursorRow(t *testing.T) {
+	for _, cursorRow := range []int{0, 10, 19} {
+		t.Run(fmt.Sprintf("cursor row %d", cursorRow), func(t *testing.T) {
+			o, win := scrollPane(t)
+			win.EnterCopyMode()
+			win.CopyMode.CursorY = cursorRow
+
+			wheel(o, tea.MouseWheelUp, 1)
+
+			if win.CopyMode.ScrollOffset != config.ScrollLines {
+				t.Fatalf("one wheel click from cursor row %d scrolled %d lines, want %d. "+
+					"The wheel is walking the cursor instead of moving the viewport.",
+					cursorRow, win.CopyMode.ScrollOffset, config.ScrollLines)
+			}
+			if win.ScrollbackOffset != win.CopyMode.ScrollOffset {
+				t.Errorf("ScrollbackOffset = %d, want it in step with the copy-mode offset %d",
+					win.ScrollbackOffset, win.CopyMode.ScrollOffset)
+			}
+		})
+	}
+}
+
+// Entering copy mode is a mechanism for rendering scrollback, not a mode the
+// user asked for, so the wheel says nothing and the dock does not change.
+func TestWheelDoesNotAnnounceCopyMode(t *testing.T) {
+	o, win := scrollPane(t)
+
+	wheel(o, tea.MouseWheelUp, 2)
+
+	if len(o.Notifications) != 0 {
+		t.Fatalf("scrolling raised %d notification(s), first %q; turning the wheel must not "+
+			"announce a mode or teach keybindings", len(o.Notifications), o.Notifications[0].Message)
+	}
+	if !win.InCopyMode() {
+		t.Fatal("the wheel did not scroll at all")
+	}
+	if win.CopyModeVisible() {
+		t.Error("a wheel scroll presented itself as copy mode; the dock would show the copy-mode key hints")
+	}
+}
+
+// Scrolling back to the bottom is the same event as being done: the session
+// that existed only to render scrollback goes away, silently, and the pane is
+// on live output again.
+func TestWheelDownToBottomReturnsToLiveOutput(t *testing.T) {
+	o, win := scrollPane(t)
+
+	wheel(o, tea.MouseWheelUp, 4)
+	if win.CopyMode.ScrollOffset == 0 {
+		t.Fatal("wheel up did not scroll")
+	}
+
+	wheel(o, tea.MouseWheelDown, 4)
+
+	if win.InCopyMode() {
+		t.Fatalf("still in copy mode after scrolling back to the bottom "+
+			"(offset %d, cursor row %d); the user is stranded in a mode with no way "+
+			"back that they were told about", win.CopyMode.ScrollOffset, win.CopyMode.CursorY)
+	}
+	if win.ScrollbackOffset != 0 {
+		t.Errorf("ScrollbackOffset = %d, want 0 (live output)", win.ScrollbackOffset)
+	}
+	if len(o.Notifications) != 0 {
+		t.Errorf("leaving raised %d notification(s), first %q; a silent entry deserves a silent exit",
+			len(o.Notifications), o.Notifications[0].Message)
+	}
+}
+
+// Typing is how a user says they are done reading. A terminal with no modes
+// snaps to the bottom and types the character; so does this.
+func TestTypingAfterAWheelScrollReturnsToLiveOutput(t *testing.T) {
+	o, win := scrollPane(t)
+	wheel(o, tea.MouseWheelUp, 3)
+	if win.ScrollbackOffset == 0 {
+		t.Fatal("wheel up did not scroll")
+	}
+
+	// "e" is a copy-mode motion (word end). Under the old behaviour it moved
+	// the cursor and never reached the shell.
+	HandleTerminalModeKey(tea.KeyPressMsg{Code: 'e', Text: "e"}, o)
+
+	if win.InCopyMode() {
+		t.Fatal("typing left the pane in copy mode; the keystroke was eaten as a motion " +
+			"instead of reaching the shell")
+	}
+	if win.ScrollbackOffset != 0 {
+		t.Errorf("ScrollbackOffset = %d after typing, want 0: typing must snap back to live output",
+			win.ScrollbackOffset)
+	}
+}
+
+// Esc is the reflex for "get me out of this", and a bare Esc into a shell in vi
+// mode or a readline meta prefix is not a no-op, so it is the one key that
+// leaves the scrolled view without also being typed.
+func TestEscapeAfterAWheelScrollIsNotForwarded(t *testing.T) {
+	o, win := scrollPane(t)
+	wheel(o, tea.MouseWheelUp, 3)
+
+	HandleTerminalModeKey(tea.KeyPressMsg{Code: tea.KeyEscape}, o)
+
+	if win.InCopyMode() {
+		t.Error("esc did not leave the scrolled view")
+	}
+	if o.Mode != app.TerminalMode {
+		t.Errorf("Mode = %v after esc, want terminal mode", o.Mode)
+	}
+}
+
+// Copy mode the user asked for is a mode they are holding. The wheel scrolls it
+// and leaves it alone: it announces itself in the dock, and q and Esc exit.
+func TestWheelDoesNotDropAnExplicitCopyModeSession(t *testing.T) {
+	o, win := scrollPane(t)
+	win.EnterCopyMode() // explicit: what the prefix binding and the palette do
+
+	wheel(o, tea.MouseWheelUp, 3)
+	wheel(o, tea.MouseWheelDown, 10)
+
+	if !win.InCopyMode() {
+		t.Fatal("the wheel threw the user out of a copy mode session they asked for")
+	}
+	if !win.CopyModeVisible() {
+		t.Error("an explicit session stopped presenting itself as a mode")
+	}
+	if win.CopyMode.ScrollOffset != 0 {
+		t.Errorf("ScrollOffset = %d, want 0: scrolling down must still reach the bottom", win.CopyMode.ScrollOffset)
+	}
+}
+
+// A pane with nothing behind it has nothing to scroll to. Turning the wheel
+// over a fresh shell used to drop it into copy mode showing the same screen.
+func TestWheelOverAPaneWithNoScrollbackDoesNothing(t *testing.T) {
+	em := vt.NewEmulator(40, 20)
+	t.Cleanup(func() { _ = em.Close() })
+	win := &terminal.Window{Terminal: em, Width: 42, Height: 22}
+	o := &app.OS{Mode: app.TerminalMode, FocusedWindow: 0, Windows: []*terminal.Window{win}}
+
+	wheel(o, tea.MouseWheelUp, 3)
+
+	if win.InCopyMode() {
+		t.Error("the wheel entered copy mode over a pane with no scrollback")
+	}
+	if len(o.Notifications) != 0 {
+		t.Errorf("the wheel raised %q over a pane with nothing to scroll", o.Notifications[0].Message)
+	}
+}
+
+// vim, less and htop ask for the mouse and must keep getting the wheel
+// themselves. tuios must not scroll its own scrollback underneath them.
+func TestWheelOverAMouseTrackingAppIsNotConsumedByScrollback(t *testing.T) {
+	o, win := scrollPane(t)
+	if _, err := win.Terminal.Write([]byte("\x1b[?1000h")); err != nil {
+		t.Fatalf("enable mouse tracking: %v", err)
+	}
+	if !win.Terminal.HasMouseMode() {
+		t.Fatal("fixture did not enable mouse tracking")
+	}
+
+	wheel(o, tea.MouseWheelUp, 3)
+
+	if win.InCopyMode() {
+		t.Error("tuios scrolled its own scrollback for a pane whose application owns the mouse")
+	}
+	if win.ScrollbackOffset != 0 {
+		t.Errorf("ScrollbackOffset = %d, want 0", win.ScrollbackOffset)
+	}
+}
+
+// The alternate screen has no scrollback worth showing, and an application
+// sitting on it redraws the whole screen anyway.
+func TestWheelOverAnAltScreenPaneDoesNotScroll(t *testing.T) {
+	o, win := scrollPane(t)
+	win.SetAltScreen(true)
+
+	wheel(o, tea.MouseWheelUp, 3)
+
+	if win.InCopyMode() {
+		t.Error("the wheel scrolled scrollback for an alt-screen pane")
+	}
+}
+
+// The cursor rides the viewport rather than staying on a screen row, so a v
+// pressed after a scroll starts from the line the user is looking at. Whatever
+// it does, it may never leave the rows being drawn.
+func TestWheelKeepsTheCopyCursorOnScreen(t *testing.T) {
+	o, win := scrollPane(t)
+	win.EnterCopyMode()
+
+	for range 30 {
+		wheel(o, tea.MouseWheelUp, 1)
+		if win.CopyMode.CursorY < 0 || win.CopyMode.CursorY >= win.ContentHeight() {
+			t.Fatalf("cursor row %d is outside the %d drawn rows after scrolling up",
+				win.CopyMode.CursorY, win.ContentHeight())
+		}
+	}
+	for range 60 {
+		wheel(o, tea.MouseWheelDown, 1)
+		if win.CopyMode.CursorY < 0 || win.CopyMode.CursorY >= win.ContentHeight() {
+			t.Fatalf("cursor row %d is outside the %d drawn rows after scrolling down",
+				win.CopyMode.CursorY, win.ContentHeight())
+		}
+	}
+}
+
+// Shift+Up is the keyboard spelling of the wheel and shares its entry and exit:
+// one line per press, silent, and back to live output at the bottom.
+func TestShiftArrowScrollIsSilentAndReturnsToLiveOutput(t *testing.T) {
+	o, win := scrollPane(t)
+
+	for range 5 {
+		HandleTerminalModeKey(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift}, o)
+	}
+	if win.CopyMode.ScrollOffset != 5 {
+		t.Fatalf("five shift+up presses scrolled %d lines, want 5", win.CopyMode.ScrollOffset)
+	}
+	if len(o.Notifications) != 0 {
+		t.Errorf("shift+up raised %q", o.Notifications[0].Message)
+	}
+
+	for range 5 {
+		HandleTerminalModeKey(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift}, o)
+	}
+	if win.InCopyMode() {
+		t.Error("shift+down to the bottom left the pane in copy mode")
+	}
+}
+
+// Scrolling in window management mode is the same gesture and gets the same
+// treatment, and a window-manager binding pressed afterwards must not be eaten.
+func TestWindowModeWheelIsSilentAndYieldsToBindings(t *testing.T) {
+	o, win := scrollPane(t)
+	o.Mode = app.WindowManagementMode
+
+	wheel(o, tea.MouseWheelUp, 2)
+	if win.CopyMode.ScrollOffset != 2*config.ScrollLines {
+		t.Fatalf("ScrollOffset = %d, want %d", win.CopyMode.ScrollOffset, 2*config.ScrollLines)
+	}
+	if len(o.Notifications) != 0 {
+		t.Fatalf("the wheel raised %q in window management mode", o.Notifications[0].Message)
+	}
+
+	HandleWindowManagementModeKey(tea.KeyPressMsg{Code: 'n', Text: "n"}, o)
+	if win.InCopyMode() {
+		t.Error("a window-manager binding was swallowed by the scrolled view")
+	}
+}

--- a/internal/input/mouse_select.go
+++ b/internal/input/mouse_select.go
@@ -1,0 +1,212 @@
+package input
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// multiClickInterval is how long after a click a second one still counts as
+// part of the same gesture. 500ms is the top of the usual 250-500ms range and
+// what Windows and macOS default to; it is generous on purpose, because the
+// cost of guessing low is a double-click that silently behaves as two singles.
+const multiClickInterval = 500 * time.Millisecond
+
+// multiClickSlop is how far the pointer may drift between clicks of one
+// gesture, in cells. Requiring the exact same cell reads as an intermittent
+// double-click on a real mouse: one cell is a handful of pixels, and the button
+// going down twice moves the pointer more than that often enough to notice.
+const multiClickSlop = 1
+
+// registerClick advances the multi-click counter for a press at a terminal cell
+// and returns how many clicks this one makes: 1, 2, or 3. A fourth click starts
+// a new gesture rather than continuing to climb, so click-click-click-click is
+// character, word, line, character.
+func registerClick(win *terminal.Window, termX, termY int) int {
+	near := termY == win.LastClickY && abs(termX-win.LastClickX) <= multiClickSlop
+	if !near || time.Since(win.LastClickTime) > multiClickInterval || win.ClickCount >= 3 {
+		win.ClickCount = 1
+	} else {
+		win.ClickCount++
+	}
+	win.LastClickTime = time.Now()
+	win.LastClickX = termX
+	win.LastClickY = termY
+	return win.ClickCount
+}
+
+// beginMouseSelection starts a selection gesture in an active copy-mode session
+// at a screen position. clicks is what registerClick returned: one click starts
+// a character selection the caller can drag out, two selects the word under the
+// pointer, three selects the line.
+//
+// A line rather than a sentence for three clicks: terminal content is
+// line-oriented, and sentence detection over shell output, log lines and code
+// would be guesswork.
+func beginMouseSelection(cm *terminal.CopyMode, window *terminal.Window, screenX, screenY, clicks int) {
+	switch clicks {
+	case 2:
+		HandleCopyModeMouseDrag(cm, window, screenX, screenY)
+		func() {
+			window.RLockIO()
+			defer window.RUnlockIO()
+			if !selectWordUnderCursor(cm, window) {
+				// Nothing word-shaped under the pointer. Leave the one-cell
+				// selection the drag started rather than inventing one.
+				cm.State = terminal.CopyModeNormal
+			}
+		}()
+		window.InvalidateCache()
+	case 3:
+		HandleCopyModeMouseDrag(cm, window, screenX, screenY)
+		func() {
+			window.RLockIO()
+			defer window.RUnlockIO()
+			enterVisualLine(cm, window)
+		}()
+		window.InvalidateCache()
+	default:
+		HandleCopyModeMouseDrag(cm, window, screenX, screenY)
+	}
+}
+
+// selectWordUnderCursor puts a visual-character selection around the word the
+// copy-mode cursor sits in. It reports false when the cursor is not on a word
+// character, which is the caller's cue to leave the selection alone rather than
+// select a lone space.
+//
+// Callers must hold the window's I/O read lock.
+func selectWordUnderCursor(cm *terminal.CopyMode, window *terminal.Window) bool {
+	absY := getAbsoluteY(cm, window)
+	cells := copyModeLineCells(window, absY)
+	if cm.CursorX < 0 || cm.CursorX >= len(cells) {
+		return false
+	}
+	if !isSelectionWordChar(cells[cm.CursorX]) {
+		return false
+	}
+
+	startX := cm.CursorX
+	for startX > 0 && isSelectionWordChar(cells[startX-1]) {
+		startX--
+	}
+	endX := cm.CursorX
+	for endX < len(cells)-1 && isSelectionWordChar(cells[endX+1]) {
+		endX++
+	}
+
+	cm.State = terminal.CopyModeVisualChar
+	cm.VisualStart = terminal.Position{X: startX, Y: absY}
+	cm.VisualEnd = terminal.Position{X: endX, Y: absY}
+	cm.CursorX = endX
+	return true
+}
+
+// isSelectionWordChar reports whether a cell belongs to a double-click word.
+// Letters and digits always do; the punctuation that also does is
+// appearance.word_characters, so a path, a URL or a flag like --no-vm comes out
+// as one word instead of a handful of fragments.
+func isSelectionWordChar(cell uv.Cell) bool {
+	if cell.Content == "" || cell.Content == " " {
+		return false
+	}
+	r := []rune(cell.Content)[0]
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return true
+	}
+	if unicode.IsSpace(r) {
+		return false
+	}
+	return strings.ContainsRune(config.WordCharacters, r)
+}
+
+// copyModeLineCells returns the cells of an absolute line, from the scrollback
+// ring or from the live screen. Callers must hold the window's I/O read lock.
+func copyModeLineCells(window *terminal.Window, absY int) []uv.Cell {
+	scrollbackLen := window.ScrollbackLen()
+	if absY < scrollbackLen {
+		return window.ScrollbackLine(absY)
+	}
+	if window.Terminal == nil {
+		return nil
+	}
+	return getScreenLineCells(window.Terminal, absY-scrollbackLen)
+}
+
+// finishMouseSelection ends a mouse selection gesture and, when
+// appearance.copy_on_select is on, puts the selected text on the clipboard.
+//
+// Copying on release is what a graphical terminal does (X11's primary
+// selection, kitty's copy_on_select), and it is why a selection here no longer
+// needs a separate keystroke to be useful. It is a setting because a stray drag
+// overwriting the clipboard is a real annoyance for some people.
+//
+// Two things it deliberately does not do. It does not copy a selection that
+// never moved, so an ordinary click cannot clobber the clipboard. And it leaves
+// the highlight up rather than clearing it, so the user can see what they got;
+// the next press clears it, as does typing.
+//
+// The clipboard path is the same tea.SetClipboard (OSC 52) that copy mode's y
+// has always used, so it reaches exactly the environments that already did,
+// including over SSH, and no more.
+func finishMouseSelection(o *app.OS, window *terminal.Window) tea.Cmd {
+	cm := window.CopyMode
+	if cm == nil || !cm.Active {
+		return nil
+	}
+
+	inVisual := cm.State == terminal.CopyModeVisualChar || cm.State == terminal.CopyModeVisualLine
+	moved := cm.VisualStart != cm.VisualEnd
+	// A double or triple click is a selection even when it lands on a
+	// one-character word or an empty line, so the counter speaks for it.
+	deliberate := moved || window.ClickCount >= 2
+
+	if !inVisual || !deliberate {
+		cm.State = terminal.CopyModeNormal
+		endImplicitSelection(window)
+		return nil
+	}
+
+	if !config.CopyOnSelect {
+		return nil
+	}
+
+	var text string
+	func() {
+		window.RLockIO()
+		defer window.RUnlockIO()
+		if window.Terminal != nil {
+			text = extractVisualText(cm, window)
+		}
+	}()
+	if text == "" {
+		return nil
+	}
+
+	// Deliberately not stored on window.SelectedText: that field drives the
+	// older, coordinate-based selection highlight, whose bounds this path never
+	// sets, so filling it would paint a stray highlight at the origin.
+	o.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", config.NotificationDuration)
+	return tea.SetClipboard(text)
+}
+
+// endImplicitSelection drops a copy-mode session that only existed to carry a
+// mouse gesture and has nothing left to show: no selection and nothing scrolled
+// back. Without it an ordinary click inside a pane would leave the session
+// hanging around until the next keystroke.
+func endImplicitSelection(window *terminal.Window) {
+	cm := window.CopyMode
+	if cm == nil || !cm.Active || !cm.Implicit {
+		return
+	}
+	if cm.ScrollOffset == 0 && cm.State == terminal.CopyModeNormal {
+		window.ExitCopyMode()
+	}
+}

--- a/internal/input/mouse_select_test.go
+++ b/internal/input/mouse_select_test.go
@@ -1,0 +1,326 @@
+package input
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// selectPane builds a focused, floating pane at the origin with one line of
+// text on screen. Screen cell (x, y) inside the content is at (x+1, y+1),
+// because a floating window spends one cell per border edge.
+func selectPane(t *testing.T, line string) (*app.OS, *terminal.Window) {
+	t.Helper()
+	em := vt.NewEmulator(40, 20)
+	t.Cleanup(func() { _ = em.Close() })
+	if _, err := em.Write([]byte(line)); err != nil {
+		t.Fatalf("paint fixture line: %v", err)
+	}
+	win := &terminal.Window{Terminal: em, X: 0, Y: 0, Width: 42, Height: 22}
+	o := &app.OS{
+		Mode:          app.TerminalMode,
+		FocusedWindow: 0,
+		Windows:       []*terminal.Window{win},
+		Width:         80,
+		Height:        30,
+	}
+	return o, win
+}
+
+// press sends a left button press at a content cell.
+func pressAt(o *app.OS, x, y int) {
+	handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: x + 1, Y: y + 1}, o)
+}
+
+// dragTo sends a motion with the button held to a content cell.
+func dragTo(o *app.OS, x, y int) {
+	handleMouseMotion(tea.MouseMotionMsg{Button: tea.MouseLeft, X: x + 1, Y: y + 1}, o)
+}
+
+// release lets the button up at a content cell and returns the command the
+// handler produced, which is the clipboard write when one happened.
+func release(o *app.OS, x, y int) tea.Cmd {
+	_, cmd := handleMouseRelease(tea.MouseReleaseMsg{Button: tea.MouseLeft, X: x + 1, Y: y + 1}, o)
+	return cmd
+}
+
+// selectedText reads back what the pane's visual selection covers.
+func selectedText(win *terminal.Window) string {
+	if win.CopyMode == nil {
+		return ""
+	}
+	win.RLockIO()
+	defer win.RUnlockIO()
+	return extractVisualText(win.CopyMode, win)
+}
+
+// A left drag over a pane's output used to grab the window, move it, and drop
+// the user into window management mode. In a terminal, dragging over text
+// selects the text.
+func TestDragInTerminalModeSelectsTextInsteadOfMovingTheWindow(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	cmd := release(o, 10, 0)
+
+	if o.Mode != app.TerminalMode {
+		t.Errorf("Mode = %v after a drag inside the pane, want terminal mode: clicking output "+
+			"must not throw the user out of the shell", o.Mode)
+	}
+	if win.X != 0 || win.Y != 0 {
+		t.Errorf("window moved to (%d,%d) during a text drag", win.X, win.Y)
+	}
+	if got, want := selectedText(win), "alpha bravo"; got != want {
+		t.Errorf("selection = %q, want %q", got, want)
+	}
+	if cmd == nil {
+		t.Error("releasing a selection did not copy it; copy_on_select is on by default")
+	}
+	if !hasNotificationPrefix(o, "Copied") {
+		t.Errorf("no copy confirmation in the dock; messages were %v", notificationMessages(o))
+	}
+}
+
+// A stray click must never clobber the clipboard.
+func TestPlainClickDoesNotCopy(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 4, 0)
+	cmd := release(o, 4, 0)
+
+	if cmd != nil {
+		t.Error("a click with no drag wrote to the clipboard")
+	}
+	if hasNotificationPrefix(o, "Copied") {
+		t.Errorf("a click with no drag reported a copy; messages were %v", notificationMessages(o))
+	}
+	if win.InCopyMode() {
+		t.Error("a click left the pane in a copy-mode session with nothing to show")
+	}
+}
+
+// Double-click selects a word, and a word in a terminal is more than a run of
+// letters: a path, a URL or a flag is one thing the user wants in one grab.
+func TestDoubleClickSelectsAWordIncludingItsPunctuation(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		at   int
+		want string
+	}{
+		{"path", "run /usr/bin/env now", 8, "/usr/bin/env"},
+		{"flag", "cargo build --no-vm ok", 14, "--no-vm"},
+		{"plain word", "alpha bravo charlie", 7, "bravo"},
+		{"host and query", "GET example.com/a?b=1 200", 10, "example.com/a?b=1"},
+		{"version", "installed v1.2.3-rc1 ok", 13, "v1.2.3-rc1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o, win := selectPane(t, tc.line)
+
+			pressAt(o, tc.at, 0)
+			pressAt(o, tc.at, 0)
+			release(o, tc.at, 0)
+
+			if got := selectedText(win); got != tc.want {
+				t.Errorf("double-click at column %d of %q selected %q, want %q",
+					tc.at, tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+// A colon is deliberately not a word character, so host:port and file:line come
+// apart into the pieces a user usually wants on their own.
+func TestDoubleClickStopsAtACharacterOutsideTheWordSet(t *testing.T) {
+	o, win := selectPane(t, "main.go:42:9 error")
+
+	pressAt(o, 2, 0)
+	pressAt(o, 2, 0)
+	release(o, 2, 0)
+
+	if got, want := selectedText(win), "main.go"; got != want {
+		t.Errorf("selection = %q, want %q", got, want)
+	}
+}
+
+// The word set is configurable, so a user who wants host:port in one grab can
+// have it.
+func TestWordCharactersIsConfigurable(t *testing.T) {
+	prev := config.WordCharacters
+	t.Cleanup(func() { config.WordCharacters = prev })
+	config.WordCharacters = prev + ":"
+
+	o, win := selectPane(t, "main.go:42:9 error")
+
+	pressAt(o, 2, 0)
+	pressAt(o, 2, 0)
+	release(o, 2, 0)
+
+	if got, want := selectedText(win), "main.go:42:9"; got != want {
+		t.Errorf("selection = %q, want %q", got, want)
+	}
+}
+
+// Double-clicking whitespace selects nothing rather than putting a space on the
+// clipboard.
+func TestDoubleClickOnWhitespaceSelectsNothing(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo")
+
+	pressAt(o, 5, 0)
+	pressAt(o, 5, 0)
+	cmd := release(o, 5, 0)
+
+	if cmd != nil {
+		t.Error("double-clicking a space wrote to the clipboard")
+	}
+	if win.InCopyMode() && win.CopyMode.State != terminal.CopyModeNormal {
+		t.Error("double-clicking a space left a selection behind")
+	}
+}
+
+// Three clicks take the line. A line, not a sentence: terminal content is
+// line-oriented and sentence detection over log lines or code is guesswork.
+func TestTripleClickSelectsTheLine(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	release(o, 6, 0)
+
+	if got, want := selectedText(win), "alpha bravo charlie"; got != want {
+		t.Errorf("triple-click selected %q, want the whole line %q", got, want)
+	}
+}
+
+// A fourth click starts a new gesture rather than continuing to climb, and a
+// click that arrives too late is a fresh single click, not the next step of the
+// last one.
+func TestMultiClickCountingWrapsAndTimesOut(t *testing.T) {
+	_, win := selectPane(t, "alpha bravo charlie")
+
+	for want := 1; want <= 3; want++ {
+		if got := registerClick(win, 4, 0); got != want {
+			t.Fatalf("click %d counted as %d", want, got)
+		}
+	}
+	if got := registerClick(win, 4, 0); got != 1 {
+		t.Errorf("a fourth click counted as %d, want 1: the gesture should start over", got)
+	}
+
+	win.LastClickTime = time.Now().Add(-2 * multiClickInterval)
+	if got := registerClick(win, 4, 0); got != 1 {
+		t.Errorf("a click %v after the last counted as %d, want 1", 2*multiClickInterval, got)
+	}
+
+	// A cell of pointer drift between clicks is a double-click, not two
+	// singles: one cell is a handful of pixels.
+	win.ClickCount = 0
+	win.LastClickTime = time.Time{}
+	if got := registerClick(win, 4, 0); got != 1 {
+		t.Fatalf("first click of a fresh gesture counted as %d", got)
+	}
+	if got := registerClick(win, 5, 0); got != 2 {
+		t.Errorf("a click one cell over counted as %d, want 2", got)
+	}
+	if got := registerClick(win, 9, 0); got != 1 {
+		t.Errorf("a click five cells over counted as %d, want 1", got)
+	}
+}
+
+// Some people do not want a stray drag overwriting their clipboard.
+func TestCopyOnSelectCanBeTurnedOff(t *testing.T) {
+	prev := config.CopyOnSelect
+	t.Cleanup(func() { config.CopyOnSelect = prev })
+	config.CopyOnSelect = false
+
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	cmd := release(o, 10, 0)
+
+	if cmd != nil {
+		t.Error("copy_on_select is off but the release still wrote to the clipboard")
+	}
+	if got, want := selectedText(win), "alpha bravo"; got != want {
+		t.Errorf("the selection itself should still be made: got %q, want %q", got, want)
+	}
+}
+
+// A pane whose application asked for the mouse owns the whole gesture, exactly
+// as it owns the wheel. Selection must not steal a press from vim.
+func TestPressInAMouseTrackingPaneIsNotStolenBySelection(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+	if _, err := win.Terminal.Write([]byte("\x1b[?1000h")); err != nil {
+		t.Fatalf("enable mouse tracking: %v", err)
+	}
+
+	pressAt(o, 4, 0)
+
+	if win.InCopyMode() {
+		t.Error("a press in a mouse-tracking pane started a tuios selection")
+	}
+	if o.Dragging {
+		t.Error("a press in a mouse-tracking pane started a tuios drag gesture")
+	}
+}
+
+// The selection stays highlighted after the copy, so the user can see what they
+// got, and the next press replaces it.
+func TestSelectionSurvivesTheCopyAndIsReplacedByTheNextPress(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	release(o, 10, 0)
+
+	if win.CopyMode.State != terminal.CopyModeVisualChar {
+		t.Fatalf("selection state after copy = %v, want the highlight to stay up", win.CopyMode.State)
+	}
+
+	pressAt(o, 12, 0)
+	dragTo(o, 18, 0)
+	release(o, 18, 0)
+
+	if got, want := selectedText(win), "charlie"; got != want {
+		t.Errorf("second selection = %q, want %q", got, want)
+	}
+}
+
+// Selecting is not entering copy mode: the dock must not start showing the
+// copy-mode key hints because someone dragged over a line.
+func TestSelectingDoesNotPresentAsCopyMode(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	release(o, 10, 0)
+
+	if win.CopyModeVisible() {
+		t.Error("a mouse selection put the pane into a visible copy mode")
+	}
+}
+
+// Typing after a selection returns the pane to normal, selection and all.
+func TestTypingClearsAMouseSelection(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	release(o, 10, 0)
+
+	HandleTerminalModeKey(tea.KeyPressMsg{Code: 'x', Text: "x"}, o)
+
+	if win.InCopyMode() {
+		t.Error("typing left the selection and its copy-mode session in place")
+	}
+}

--- a/internal/input/mouse_wheel.go
+++ b/internal/input/mouse_wheel.go
@@ -101,25 +101,18 @@ func handleMouseWheel(msg tea.MouseWheelMsg, o *app.OS) (*app.OS, tea.Cmd) {
 							focusedWindow.InvalidateCache()
 						}
 					}
-				} else if o.Mode == app.TerminalMode && focusedWindow.Terminal != nil && !focusedWindow.Terminal.HasMouseMode() && !focusedWindow.IsAltScreen() {
-					// No mouse tracking and not alt screen  - enter copy mode and scroll.
-					// Copy mode supports selection, search, and vim navigation.
-					if focusedWindow.CopyMode == nil || !focusedWindow.CopyMode.Active {
-						focusedWindow.EnterCopyMode()
-						o.ShowNotification("COPY MODE (hjkl/q)", "info", config.NotificationDuration)
-					}
-					if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
-						for range config.ScrollLines {
-							MoveUp(focusedWindow.CopyMode, focusedWindow)
-						}
-						focusedWindow.InvalidateCache()
-					}
-				} else if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
+				} else if focusedWindow.InCopyMode() {
 					// Already in copy mode  - scroll up
-					for range config.ScrollLines {
-						MoveUp(focusedWindow.CopyMode, focusedWindow)
-					}
-					focusedWindow.InvalidateCache()
+					scrollCopyModeUp(focusedWindow)
+				} else if o.Mode == app.TerminalMode && focusedWindow.Terminal != nil && !focusedWindow.Terminal.HasMouseMode() && !focusedWindow.IsAltScreen() && focusedWindow.ScrollbackLen() > 0 {
+					// No mouse tracking, not alt screen, and there is history to
+					// show: turn the wheel and the view scrolls. Copy mode is the
+					// only thing that can render scrollback, so it is switched on
+					// implicitly, without a notification and without the dock
+					// changing mode. Panes with no scrollback are left alone
+					// rather than dropped into an empty scrolled state.
+					focusedWindow.EnterCopyModeImplicit()
+					scrollCopyModeUp(focusedWindow)
 				}
 				return o, nil
 			case tea.MouseWheelDown:
@@ -132,17 +125,10 @@ func handleMouseWheel(msg tea.MouseWheelMsg, o *app.OS) (*app.OS, tea.Cmd) {
 						}
 						focusedWindow.InvalidateCache()
 					}
-				} else if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
+				} else if focusedWindow.InCopyMode() {
 					// In copy mode, scroll down
-					for range config.ScrollLines {
-						MoveDown(focusedWindow.CopyMode, focusedWindow)
-					}
-					// Exit copy mode if at bottom
-					if focusedWindow.CopyMode.ScrollOffset == 0 && focusedWindow.CopyMode.CursorY >= focusedWindow.Height-3 {
-						focusedWindow.ExitCopyMode()
-						o.ShowNotification("Copy Mode Exited", "info", config.NotificationDuration)
-					}
-					focusedWindow.InvalidateCache()
+					scrollCopyModeDown(focusedWindow)
+					leaveCopyModeAtBottom(focusedWindow)
 				}
 				return o, nil
 			}
@@ -155,28 +141,18 @@ func handleMouseWheel(msg tea.MouseWheelMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		if focusedWindow != nil && focusedWindow.Terminal != nil && !focusedWindow.IsAltScreen() {
 			switch msg.Button {
 			case tea.MouseWheelUp:
-				scrollbackLen := focusedWindow.ScrollbackLen()
-				if scrollbackLen > 0 {
-					if focusedWindow.CopyMode == nil || !focusedWindow.CopyMode.Active {
-						focusedWindow.EnterCopyMode()
-						o.ShowNotification("COPY MODE (hjkl/q)", "info", config.NotificationDuration)
-					}
-					if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
-						for range config.ScrollLines {
-							MoveUp(focusedWindow.CopyMode, focusedWindow)
-						}
-						focusedWindow.InvalidateCache()
-					}
+				if focusedWindow.InCopyMode() {
+					scrollCopyModeUp(focusedWindow)
+				} else if focusedWindow.ScrollbackLen() > 0 {
+					// Same silent entry as terminal mode: the wheel scrolls, it
+					// does not put the pane into a mode and teach keys for it.
+					focusedWindow.EnterCopyModeImplicit()
+					scrollCopyModeUp(focusedWindow)
 				}
 			case tea.MouseWheelDown:
-				if focusedWindow.CopyMode != nil && focusedWindow.CopyMode.Active {
-					for range config.ScrollLines {
-						MoveDown(focusedWindow.CopyMode, focusedWindow)
-					}
-					if focusedWindow.CopyMode.ScrollOffset == 0 && focusedWindow.CopyMode.CursorY >= focusedWindow.ContentHeight()-1 {
-						focusedWindow.ExitCopyMode()
-					}
-					focusedWindow.InvalidateCache()
+				if focusedWindow.InCopyMode() {
+					scrollCopyModeDown(focusedWindow)
+					leaveCopyModeAtBottom(focusedWindow)
 				}
 			}
 		}

--- a/internal/terminal/window.go
+++ b/internal/terminal/window.go
@@ -386,6 +386,17 @@ type CopyMode struct {
 	// Count prefix (e.g., 10j means move down 10 times)
 	PendingCount   int       // Accumulated count (0 means no count)
 	CountStartTime time.Time // When count entry started (for timeout)
+
+	// Implicit marks a copy mode session that the user never asked for.
+	//
+	// Rendering scrollback is copy mode's job, so a mouse wheel or a drag
+	// inside a pane has to turn it on to show anything at all. That is a
+	// mechanism, not a mode the user chose: an implicit session announces
+	// nothing, keeps the dock showing terminal mode, draws no copy-mode
+	// cursor, and ends the moment the view is back at the bottom or a key is
+	// pressed. Copy mode entered on purpose (the prefix binding, the command
+	// palette) leaves this false and behaves exactly as it always has.
+	Implicit bool
 }
 
 // NewWindow creates a new terminal window with the specified properties.

--- a/internal/terminal/window_scrollback.go
+++ b/internal/terminal/window_scrollback.go
@@ -119,11 +119,47 @@ func (w *Window) EnterCopyMode() {
 	w.CopyMode.CurrentMatch = 0
 	w.CopyMode.CaseSensitive = false
 	w.CopyMode.PendingGCount = false
+	w.CopyMode.Implicit = false
 
 	// Sync with window scrollback
 	w.ScrollbackOffset = 0
 
 	w.InvalidateCache()
+}
+
+// EnterCopyModeImplicit turns copy mode on as a mechanism rather than as a
+// mode: it is how a mouse wheel, a scrollbar drag, or a drag-selection gets
+// scrollback on screen at all. Nothing about the session is announced and the
+// dock keeps showing terminal mode, so scrolling looks like scrolling.
+//
+// See CopyMode.Implicit for what the flag changes.
+func (w *Window) EnterCopyModeImplicit() {
+	w.EnterCopyMode()
+	if w.CopyMode != nil {
+		w.CopyMode.Implicit = true
+	}
+}
+
+// InCopyMode reports whether copy mode is active at all, implicit sessions
+// included. Use it for anything that reads or writes copy-mode state.
+//
+// This and the two predicates below tolerate a nil window: the render and dock
+// paths ask about the focused window, and there is not always one.
+func (w *Window) InCopyMode() bool {
+	return w != nil && w.CopyMode != nil && w.CopyMode.Active
+}
+
+// CopyModeVisible reports whether copy mode should present itself as a mode:
+// the dock's copy-mode pill and key hints, and the block cursor. An implicit
+// session is a scrolled view, so it reports false.
+func (w *Window) CopyModeVisible() bool {
+	return w.InCopyMode() && !w.CopyMode.Implicit
+}
+
+// InImplicitCopyMode reports whether copy mode is active only because a scroll
+// or drag gesture needed it.
+func (w *Window) InImplicitCopyMode() bool {
+	return w.InCopyMode() && w.CopyMode.Implicit
 }
 
 // ExitCopyMode exits copy mode and returns to normal terminal mode.
@@ -132,6 +168,7 @@ func (w *Window) ExitCopyMode() {
 		w.CopyMode.Active = false
 		w.CopyMode.State = CopyModeNormal
 		w.CopyMode.ScrollOffset = 0
+		w.CopyMode.Implicit = false
 		// Clear search state
 		w.CopyMode.SearchQuery = ""
 		w.CopyMode.SearchMatches = nil


### PR DESCRIPTION
Scrolling the wheel announced a mode and spent its first several clicks doing nothing visible. Dragging to select moved the window instead. This makes both behave the way every graphical terminal has for decades.

## The dead wheel clicks

`mouse_wheel.go` drove the wheel through `MoveUp`/`MoveDown`, which deliberately keep the copy cursor near the pane midpoint and only scroll once it gets there:

```go
func moveUp(cm *terminal.CopyMode, window *terminal.Window) {
	midPoint := window.Height / 2
	if cm.CursorY > midPoint {
		cm.CursorY--                    // nothing scrolls
	} else if cm.ScrollOffset < window.ScrollbackLen() {
		cm.ScrollOffset++               // the actual scroll
```

The cursor sits at the shell prompt, so `CursorY > midPoint` holds and every iteration only decremented `CursorY`. On a 40-row pane that is about 20 dead iterations before anything moves, which at `ScrollLines` per notch is several whole clicks of nothing.

Shift+Up/Down never had this, because it moves `ScrollOffset` directly. Two paths to one intent, one correct. The wheel now takes the correct one. `moveUp`/`moveDown` are untouched, so `k`/`j` keep the midpoint behaviour that is right for keyboard navigation.

**Where the cursor goes:** it follows the *text* under it, not the screen row. `CursorY` is viewport-relative and the absolute position is `scrollbackLen - ScrollOffset + CursorY`, so leaving `CursorY` alone would silently slide the cursor onto different content, which matters the moment you press `v`. It is clamped to the drawn region on every step, so a line that scrolls off an edge leaves the cursor riding that edge rather than off-screen.

## Entering copy mode is now invisible rather than announced

Copy mode's machinery is genuinely required to render scrollback, so the mode cannot be avoided. It can be made silent. `CopyMode.Implicit` marks a session nobody asked for.

The announcement was much more than the notification: the dock swapped its terminal pill for cursor coordinates, replaced the CPU and RAM meters with `hjkl:move w/b/e:word ... y:yank i:term q:quit`, and parked a block cursor mid-pane. All three now key off whether the mode was asked for. The `60/285` scroll indicator on the border stays, because that is what a modern terminal does show.

Exits: reaching the bottom, any keystroke, and copy mode's own `q`/`esc`. All reset `ScrollbackOffset`, so you are never stranded up the scrollback. Typing snaps to live output and the key still reaches the shell. Esc is the one key not forwarded, since a bare Esc into zsh vi-mode or a readline meta prefix is not a no-op. A pane with no scrollback is left alone rather than entering an empty scrolled state, and the wheel no longer throws you out of a copy mode you actually asked for.

## Selection was unreachable code

`o.SelectionMode` is **never set true outside a test file**, yet it guards `selectWord`, `selectLine`, the double and triple-click block in `mouse_click.go`, and the "Press 'c' to copy" toast. All of it was dead.

Worse, `copy_selection` appears only in `validation.go`'s list of valid action names. Nothing ever registered or dispatched it, so the toast told users to press a key that did nothing.

What actually happened on a left-drag in terminal mode: **the window moved and you landed in window-management mode.**

Now a press inside pane content selects, in terminal mode too. Release copies (`appearance.copy_on_select`, default on; a press that never moved never writes, so a plain click cannot clobber the clipboard). Double-click selects a word, triple-click selects a **line**.

Line rather than sentence, deliberately: terminal content is line-oriented, and sentence detection over log lines or code is guesswork with no good answer.

`appearance.word_characters` defaults to kitty's `@-./_~?&=%+#`, so `/usr/bin/env`, `--no-vm` and `v1.2.3-rc1` come out whole. `:` is deliberately absent so `main.go:42` splits into a path and a line number. Multi-click window is 500 ms and one cell; a fourth click starts over.

Panes with mouse tracking never reach any of this, so vim, less and htop still get their own events.

## Trade-off worth knowing

Under `--shared-borders` a tiled pane's whole rect is content, so there is no title bar to grab and moving that pane by mouse now needs window-management mode. Normal tiling and floating keep their title bars.

## shift+arrow does not collide with extend_up/extend_down

Checked because it looked like it should. In terminal mode `keyboard_terminal.go` intercepts the chord first, and the function it would otherwise reach only dispatches the `terminal_mode` section, which does not contain `extend_up`. In window-management mode it does resolve to `extend_up`, whose handler is guarded by the dead `SelectionMode` and is therefore inert. The binding does nothing anywhere; it is vestigial alongside the dead selection code, and worth deleting separately.

## Evidence

Same screen, same 20 notches:

```
old:  dock reads  9:0  1:1  1  1 ... ▎ COPY MODE (hjkl/q)  +1
new:  dock reads  1:1  1  1          border shows 60/285
```

With mouse tracking on, the pane shows the forwarded SGR wheel report echoed by the tty while its own content stays put, proving tuios did not scroll underneath it.

Negative controls, all `-count=1`: 11 unit tests of which 8 fail on main; every selection test fails or panics on main; and against a merge-base binary 5 of 6 e2e tests fail, each naming the old behaviour, with the sixth passing because it guards something that already worked. Recorded in `e2e/tui/NEGATIVE_CONTROLS.md`.

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module all pass.