### PR TITLE
Context menus on shift+right-click

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -35,6 +35,7 @@ TUIOS has two main modes:
 | `w` or `x` | Close focused window |
 | `r` | Rename focused window |
 | `m` | Minimize focused window |
+| `c` | Copy the focused pane's selection to the clipboard |
 | `Shift+M` | Restore all minimized windows |
 | `Tab` | Focus next window |
 | `Shift+Tab` | Focus previous window |
@@ -324,6 +325,7 @@ Access debug and development tools:
 - **Left Click**: Focus window
 - **Left Drag on the title bar**: Move window (non-tiling) or swap windows (tiling). In window management mode the whole window is a drag handle
 - **Right Drag**: Resize window (non-tiling only)
+- **Shift+Right Click**: Open the context menu for whatever is under the pointer
 - **Title Bar Buttons**: Minimize, maximize, or close window
 - **Click Dock Item**: Restore minimized window
 - **Copy Mode Click**: Move cursor to position
@@ -332,6 +334,30 @@ Access debug and development tools:
 
 Panes running an application that asked for the mouse (vim, less, htop) receive
 every one of these events themselves; tuios does not interpret them.
+
+### Context Menus
+
+Shift+right-click opens a short menu of the actions that make sense for what is
+under the pointer. Each row shows the key currently bound to the same action, so
+the menu doubles as a reminder of the keyboard; rebinding an action changes what
+the menu shows.
+
+| Target | Offers |
+|--------|--------|
+| Pane content | Copy selection, paste, split right, split down, zoom, close |
+| Pane title bar | Rename, zoom, minimize, close |
+| Dock entry | Restore that window, restore all |
+| Dock background | New window, toggle tiling, restore all |
+| Empty desktop | New window, toggle tiling, command palette, settings, help |
+
+Arrow keys or `j`/`k` move the selection, `Enter` runs it, `Esc` closes. Clicking
+away from the menu closes it without running anything. An action that has
+nothing to act on right now (copy with no selection, split with tiling off) is
+shown greyed out and is skipped by the arrow keys, so the menu keeps the same
+shape whether or not the action is available.
+
+Plain right-click still resizes a window; the menu is on the shift chord so it
+takes nothing away.
 
 ## Customization
 

--- a/e2e/tui/context_menu_test.go
+++ b/e2e/tui/context_menu_test.go
@@ -1,0 +1,376 @@
+package tuie2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// shiftRightClick sends the SGR mouse report for a shift+right-click at a cell.
+// That chord is what opens a context menu; plain right-click is a window resize
+// and must keep being one.
+func shiftRightClick(t *testing.T, term *tuitest.Terminal, x, y int) {
+	t.Helper()
+	if err := term.SendMouse(tuitest.MouseEvent{
+		Col: x, Row: y,
+		Button: tuitest.MouseRight,
+		Action: tuitest.MousePress,
+		Mods:   tuitest.ModShift,
+	}); err != nil {
+		t.Fatalf("shift+right-click at (%d,%d): %v", x, y, err)
+	}
+}
+
+// leftClick sends a plain left button press at a cell.
+func leftClick(t *testing.T, term *tuitest.Terminal, x, y int) {
+	t.Helper()
+	if err := term.SendMouse(tuitest.MouseEvent{
+		Col: x, Row: y,
+		Button: tuitest.MouseLeft,
+		Action: tuitest.MousePress,
+	}); err != nil {
+		t.Fatalf("left click at (%d,%d): %v", x, y, err)
+	}
+}
+
+// waitMenu fails unless every marker is on screen together within uiTimeout.
+func waitMenu(t *testing.T, term *tuitest.Terminal, what string, markers ...string) {
+	t.Helper()
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return screenHas(s, markers...)
+	}, uiTimeout); err != nil {
+		t.Fatalf("%s: context menu never showed %v: %v\n%s", what, markers, err, term.Snapshot())
+	}
+}
+
+// waitMenuGone fails unless the marker leaves the screen.
+func waitMenuGone(t *testing.T, term *tuitest.Terminal, marker, what string) {
+	t.Helper()
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return !strings.Contains(s.Text(), marker)
+	}, uiTimeout); err != nil {
+		t.Fatalf("%s: context menu never closed (%q still on screen): %v\n%s",
+			what, marker, err, term.Snapshot())
+	}
+}
+
+// TestContextMenuTargets drives a real tuios and asserts that shift+right-click
+// on each target puts up the menu that belongs to that target, and only that
+// menu.
+//
+// The assertions are on rows that are unique to one target, so a menu that
+// opened on the wrong thing fails rather than passing on a shared row like
+// "Close pane".
+func TestContextMenuTargets(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+
+	// Desktop: no window anywhere yet, so the middle of the screen is empty.
+	shiftRightClick(t, term, 40, 15)
+	waitMenu(t, term, "desktop", "Desktop", "New window", "Command palette")
+	// Escape closes without running anything: no window may appear.
+	if err := term.SendKeys(tuitest.Esc); err != nil {
+		t.Fatalf("esc: %v", err)
+	}
+	waitMenuGone(t, term, "Command palette", "after esc on desktop menu")
+	if n := countWindows(term.Screen()); n > 0 {
+		t.Fatalf("esc on the desktop menu created %d window(s); it must fire nothing\n%s",
+			n, term.Snapshot())
+	}
+
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "after first window")
+	// A new window floats at a size the layout picks, so tile it: a single tiled
+	// window fills the usable area, which makes "inside the pane" and "on its
+	// title bar" fixed coordinates rather than a guess.
+	enableTiling(t, term)
+
+	// The pane's first row is its title bar; a row well inside it is content.
+	shiftRightClick(t, term, 20, 10)
+	waitMenu(t, term, "pane content", "Split right", "Copy selection")
+	if strings.Contains(term.Screen().Text(), "Command palette") {
+		t.Fatalf("the pane content menu is showing desktop rows\n%s", term.Snapshot())
+	}
+	leftClick(t, term, 70, 30) // click away
+	waitMenuGone(t, term, "Split right", "after click-away on content menu")
+
+	shiftRightClick(t, term, 20, 0)
+	waitMenu(t, term, "pane title", "Rename", "Minimize")
+	if strings.Contains(term.Screen().Text(), "Split right") {
+		t.Fatalf("the title bar menu is showing content rows\n%s", term.Snapshot())
+	}
+	if err := term.SendKeys(tuitest.Esc); err != nil {
+		t.Fatalf("esc: %v", err)
+	}
+	waitMenuGone(t, term, "Minimize", "after esc on title menu")
+
+	// The dock band is the last row.
+	_, rows := term.Screen().Size()
+	shiftRightClick(t, term, 60, rows-1)
+	waitMenu(t, term, "dock", "Dock", "Restore all")
+	if err := term.SendKeys(tuitest.Esc); err != nil {
+		t.Fatalf("esc: %v", err)
+	}
+	waitMenuGone(t, term, "Restore all", "after esc on dock menu")
+
+	alive(t, term, "after opening every context menu target")
+}
+
+// TestContextMenuRunsRegistryAction proves a menu row actually runs the action
+// it names, through the same dispatcher a keybinding uses.
+//
+// "New window" is chosen because its effect is visible in the dock's window
+// count, which is real evidence rather than a repainted frame.
+func TestContextMenuRunsRegistryAction(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+
+	shiftRightClick(t, term, 40, 15)
+	waitMenu(t, term, "desktop", "New window")
+
+	// "New window" is the first row and the menu opens with it selected, so
+	// enter runs it.
+	if err := term.SendKeys(tuitest.Enter); err != nil {
+		t.Fatalf("enter: %v", err)
+	}
+	waitWindowCount(t, term, 1, "after running New window from the context menu")
+	waitMenuGone(t, term, "New window", "after activating a row")
+	alive(t, term, "after running a context menu action")
+}
+
+// TestContextMenuArrowsSkipDimmedRows checks on screen that arrow navigation
+// steps over an unavailable action instead of landing on it.
+//
+// The pane menu's first two rows are Copy selection and Paste. With no
+// selection made and the pane not in terminal mode, both are dimmed, and the
+// four rows below them are live. Two things then have to be true, and both are
+// read off the selection marker rather than off internal state:
+//
+//   - the menu opens with the marker on Split right, not on the dimmed Copy
+//     selection that is physically first;
+//   - arrowing down off the last row wraps past both dimmed rows straight back
+//     to Split right.
+//
+// The wrap is what makes this evidence. A menu that merely started lower down
+// would pass the first check while still letting an arrow land on a dimmed row.
+func TestContextMenuArrowsSkipDimmedRows(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "after first window")
+	enableTiling(t, term)
+
+	shiftRightClick(t, term, 20, 10)
+	waitMenu(t, term, "pane content", "Copy selection", "Split right", "Zoom")
+
+	// One full lap of the runnable rows, ending back where it started.
+	lap := []string{"Split right", "Split down", "Zoom", "Close pane", "Split right"}
+	for i, want := range lap {
+		if err := term.WaitFor(func(s tuitest.Screen) bool {
+			return strings.Contains(markedRow(s), want)
+		}, uiTimeout); err != nil {
+			t.Fatalf("step %d: selection never reached %q (marker is on %q); "+
+				"a dimmed row is reachable by arrow navigation: %v\n%s",
+				i, want, markedRow(term.Screen()), err, term.Snapshot())
+		}
+		if i < len(lap)-1 {
+			if err := term.SendKeys(tuitest.Down); err != nil {
+				t.Fatalf("down: %v", err)
+			}
+		}
+	}
+	alive(t, term, "after arrowing through the context menu")
+}
+
+// markedRow returns the text of the row carrying the selection marker, or "".
+// The marker is the only thing on screen that says which row enter would run,
+// so navigation assertions read it rather than trusting internal state.
+func markedRow(s tuitest.Screen) string {
+	_, rows := s.Size()
+	for r := range rows {
+		line := s.Line(r)
+		if idx := strings.Index(line, "› "); idx >= 0 {
+			return strings.TrimSpace(line[idx+len("› "):])
+		}
+	}
+	return ""
+}
+
+// TestContextMenuFitsAtScreenEdges opens the menu hard against the right and
+// bottom edges of a small screen and checks that every row of it is on screen.
+//
+// A menu anchored near an edge has to flip to the other side of the pointer. If
+// it did not, the rows would be drawn past the edge, where the terminal simply
+// discards them, and the user would see a menu with its right-hand side missing.
+func TestContextMenuFitsAtScreenEdges(t *testing.T) {
+	const cols, rows = 60, 20
+	term, _ := start(t, startOpts{cols: cols, rows: rows})
+	waitBoot(t, term)
+
+	for _, tc := range []struct {
+		name string
+		x, y int
+	}{
+		{"bottom-right", cols - 1, rows - 3},
+		{"top-right", cols - 1, 1},
+		{"bottom-left", 0, rows - 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shiftRightClick(t, term, tc.x, tc.y)
+			waitMenu(t, term, tc.name, "New window", "Command palette")
+
+			// Every row of the menu has to be complete. "Command palette" is the
+			// longest label plus the longest hint, so it is the row that goes
+			// missing first if the menu is hanging off an edge.
+			screen := term.Screen()
+			if !strings.Contains(screen.Text(), "ctrl+b") {
+				t.Fatalf("%s: the menu's key hints are drawn off the screen edge\n%s",
+					tc.name, term.Snapshot())
+			}
+			assertNoLineOverflow(t, screen, cols, tc.name)
+
+			if err := term.SendKeys(tuitest.Esc); err != nil {
+				t.Fatalf("esc: %v", err)
+			}
+			waitMenuGone(t, term, "Command palette", tc.name)
+		})
+	}
+	alive(t, term, "after opening the menu at every screen edge")
+}
+
+// assertNoLineOverflow checks no rendered line is wider than the terminal.
+func assertNoLineOverflow(t *testing.T, s tuitest.Screen, cols int, what string) {
+	t.Helper()
+	_, rows := s.Size()
+	for r := range rows {
+		if w := len([]rune(strings.TrimRight(s.Line(r), " "))); w > cols {
+			t.Errorf("%s: row %d is %d cells wide, screen is %d", what, r, w, cols)
+		}
+	}
+}
+
+// TestPlainRightClickStillResizes is the regression guard for the behaviour the
+// context menu was added alongside.
+//
+// Right-click on a pane has always started a corner resize. Adding a menu on
+// shift+right-click must not take that away, so this checks that a plain
+// right-click puts up no menu at all.
+func TestPlainRightClickStillResizes(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "after first window")
+
+	if err := term.SendMouse(tuitest.MouseEvent{
+		Col: 20, Row: 10,
+		Button: tuitest.MouseRight,
+		Action: tuitest.MousePress,
+	}); err != nil {
+		t.Fatalf("plain right-click: %v", err)
+	}
+	// Give the frame a beat to show a menu if it were going to.
+	time.Sleep(500 * time.Millisecond)
+
+	if text := term.Screen().Text(); strings.Contains(text, "Split right") ||
+		strings.Contains(text, "Close pane") {
+		t.Fatalf("a plain right-click opened a context menu; it must still start a resize\n%s",
+			term.Snapshot())
+	}
+	if err := term.SendMouse(tuitest.MouseEvent{
+		Col: 20, Row: 10,
+		Button: tuitest.MouseRight,
+		Action: tuitest.MouseRelease,
+	}); err != nil {
+		t.Fatalf("right-click release: %v", err)
+	}
+	alive(t, term, "after a plain right-click")
+}
+
+// TestContextMenuOnDockEntry checks the dock's own entries get a menu about
+// that window, not the dock's general one.
+//
+// The entry is found by its label on the dock row and clicked at that column.
+// The dock row is full of multi-byte powerline glyphs, so the byte offset of
+// the label is not its column and the runes before it have to be counted.
+func TestContextMenuOnDockEntry(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "after first window")
+
+	// Name the window so the dock entry is identifiable, then minimize it: only
+	// minimized windows appear in the dock.
+	renameFocused(t, term, "logs")
+	if err := term.SendKeys("m"); err != nil {
+		t.Fatalf("minimize: %v", err)
+	}
+	if err := term.WaitForText("1:logs", uiTimeout); err != nil {
+		t.Fatalf("the minimized window never appeared in the dock: %v\n%s", err, term.Snapshot())
+	}
+
+	_, rows := term.Screen().Size()
+	dockRow := term.Screen().Line(rows - 1)
+	b := strings.Index(dockRow, "logs")
+	if b < 0 {
+		t.Fatalf("no dock entry on the dock row %q\n%s", dockRow, term.Snapshot())
+	}
+	x := len([]rune(dockRow[:b]))
+
+	shiftRightClick(t, term, x, rows-1)
+	waitMenu(t, term, "dock entry", "Restore")
+
+	screen := term.Screen().Text()
+	// The dock entry's menu is titled after the window and offers Restore. The
+	// dock's own menu offers New window, so seeing that row means the click
+	// resolved to the dock background instead of to the entry on it.
+	if strings.Contains(screen, "New window") {
+		t.Fatalf("shift+right-click on the dock entry %q opened the dock's general menu\n%s",
+			"logs", term.Snapshot())
+	}
+	// The hint has to be the key the registry actually binds for restoring the
+	// first minimized window.
+	if !strings.Contains(screen, "shift+1") {
+		t.Fatalf("the Restore row does not show its registry keybinding\n%s", term.Snapshot())
+	}
+	alive(t, term, "after opening a dock entry's context menu")
+}
+
+// TestContextMenuDrawsOverZoomedPane guards the render fast path.
+//
+// A lone fullscreen pane is drawn by a path that skips the compositor entirely,
+// and every overlay has to disqualify it or it is never drawn. A context menu
+// that only appeared over tiled panes would be a subtle and very confusing bug.
+func TestContextMenuDrawsOverZoomedPane(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "after first window")
+
+	if err := term.SendKeys("z"); err != nil {
+		t.Fatalf("zoom: %v", err)
+	}
+	if err := term.WaitForText("ZOOM", uiTimeout); err != nil {
+		t.Fatalf("the pane never zoomed: %v\n%s", err, term.Snapshot())
+	}
+
+	shiftRightClick(t, term, 20, 10)
+	waitMenu(t, term, "over a zoomed pane", "Close pane", "Zoom")
+	alive(t, term, "after opening a menu over a zoomed pane")
+}
+
+// renameFocused gives the focused window a name through the rename keybinding.
+func renameFocused(t *testing.T, term *tuitest.Terminal, name string) {
+	t.Helper()
+	if err := term.SendKeys("r"); err != nil {
+		t.Fatalf("start rename: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if err := term.SendKeys(name, tuitest.Enter); err != nil {
+		t.Fatalf("type name: %v", err)
+	}
+	if err := term.WaitForText(name, uiTimeout); err != nil {
+		t.Fatalf("window never took the name %q: %v\n%s", name, err, term.Snapshot())
+	}
+}

--- a/internal/app/contextmenu.go
+++ b/internal/app/contextmenu.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// ContextMenuTarget names the thing a context menu was opened on. What is under
+// the pointer decides what the menu offers, so the target is resolved once when
+// the menu opens and the item list is built from it.
+type ContextMenuTarget int
+
+const (
+	// CtxTargetDesktop is empty space with no pane under it.
+	CtxTargetDesktop ContextMenuTarget = iota
+	// CtxTargetPaneContent is the inside of a pane, below its title row.
+	CtxTargetPaneContent
+	// CtxTargetPaneTitle is a pane's title row.
+	CtxTargetPaneTitle
+	// CtxTargetDock is the dock bar away from any of its entries.
+	CtxTargetDock
+	// CtxTargetDockItem is one minimized-window entry in the dock.
+	CtxTargetDockItem
+)
+
+// ContextMenuItem is one row of a context menu.
+//
+// Action is a keybind-registry action ID, and it is the only thing the row
+// knows how to do: the input layer hands it straight to the same
+// ActionDispatcher that keybindings dispatch through. A row carries no closure
+// of its own, so a menu entry cannot drift from the key that runs it.
+//
+// Hint is the key currently bound to Action, read from the registry when the
+// menu is built rather than written out here. Rebinding an action changes the
+// hint; an action with nothing bound to it shows no hint at all.
+//
+// Dim marks an action that exists but has nothing to act on right now. A dimmed
+// row is drawn greyed and skipped by arrow navigation and by hit-testing, so it
+// is visible without being reachable. Hiding it instead would change the menu's
+// shape from one open to the next and hide the fact that the action exists.
+type ContextMenuItem struct {
+	Icon   string
+	Label  string
+	Action string
+	Hint   string
+	Sep    bool
+	Dim    bool
+	// Warn draws the label in the destructive color.
+	Warn bool
+}
+
+// ContextMenu is an open context menu: its rows, the selection, the screen cell
+// it was anchored at, and where it actually landed after placement.
+//
+// BoundsX/Y/W/H, FirstRowY and ItemH are written by the renderer each frame.
+// Together they let HitTest map a screen Y to a row index by arithmetic instead
+// of walking rows, and let the click handler tell a click on the menu from a
+// click away from it.
+type ContextMenu struct {
+	Title  string
+	Target ContextMenuTarget
+	Items  []ContextMenuItem
+	// Selected is the highlighted row, or -1 when nothing is selectable.
+	Selected int
+	// WindowIndex is the pane or minimized window the menu was opened on, or -1
+	// for the desktop and the dock background.
+	WindowIndex int
+
+	AnchorX int
+	AnchorY int
+
+	BoundsX   int
+	BoundsY   int
+	BoundsW   int
+	BoundsH   int
+	FirstRowY int
+	ItemH     int
+}
+
+// selectable reports whether row i can be highlighted and run.
+func (cm *ContextMenu) selectable(i int) bool {
+	return i >= 0 && i < len(cm.Items) && !cm.Items[i].Sep && !cm.Items[i].Dim
+}
+
+// Next returns the nearest selectable row in the given direction (+1 or -1),
+// wrapping at the ends. Separators and dimmed rows are stepped over, so arrow
+// keys never land on something that cannot be run.
+func (cm *ContextMenu) Next(dir int) int {
+	if len(cm.Items) == 0 {
+		return -1
+	}
+	i := cm.Selected
+	for range cm.Items {
+		i = (i + dir + len(cm.Items)) % len(cm.Items)
+		if cm.selectable(i) {
+			return i
+		}
+	}
+	return cm.Selected
+}
+
+// Move highlights the next selectable row in the given direction.
+func (cm *ContextMenu) Move(dir int) {
+	cm.Selected = cm.Next(dir)
+}
+
+// HitTest returns the row index at screen (x, y), or -1 when the point is not
+// on a runnable row: outside the menu, on its chrome, or on a separator or
+// dimmed row. Coordinates are absolute screen cells.
+func (cm *ContextMenu) HitTest(x, y int) int {
+	if !cm.Contains(x, y) {
+		return -1
+	}
+	if cm.ItemH <= 0 {
+		return -1
+	}
+	idx := (y - cm.FirstRowY) / cm.ItemH
+	if y < cm.FirstRowY || idx < 0 || idx >= len(cm.Items) {
+		return -1
+	}
+	if !cm.selectable(idx) {
+		return -1
+	}
+	return idx
+}
+
+// Contains reports whether a screen cell falls anywhere on the menu, chrome
+// included. A click outside is what dismisses the menu.
+func (cm *ContextMenu) Contains(x, y int) bool {
+	return x >= cm.BoundsX && x < cm.BoundsX+cm.BoundsW &&
+		y >= cm.BoundsY && y < cm.BoundsY+cm.BoundsH
+}
+
+// ContextMenuActive reports whether a context menu is on screen.
+func (m *OS) ContextMenuActive() bool {
+	return m.ContextMenu != nil
+}
+
+// CloseContextMenu dismisses the menu without running anything.
+func (m *OS) CloseContextMenu() {
+	m.ContextMenu = nil
+}
+
+// ContextMenuSelectedAction returns the action ID of the highlighted row, or ""
+// when nothing runnable is selected. The caller dispatches it through the
+// action dispatcher; this type never runs anything itself.
+func (m *OS) ContextMenuSelectedAction() string {
+	cm := m.ContextMenu
+	if cm == nil || !cm.selectable(cm.Selected) {
+		return ""
+	}
+	return cm.Items[cm.Selected].Action
+}
+
+// ContextMenuMove moves the selection by delta, skipping separators and dimmed
+// rows.
+func (m *OS) ContextMenuMove(delta int) {
+	if m.ContextMenu == nil {
+		return
+	}
+	dir := 1
+	if delta < 0 {
+		dir = -1
+	}
+	for range absInt(delta) {
+		m.ContextMenu.Move(dir)
+	}
+}
+
+// ContextMenuClick routes a click at screen (x, y) while a menu is open. It
+// returns the action to run and whether the menu consumed the event.
+//
+// A click away from the menu closes it and fires nothing, which is the whole
+// point of returning the action separately from the consumed flag.
+func (m *OS) ContextMenuClick(x, y int) (action string, consumed bool) {
+	cm := m.ContextMenu
+	if cm == nil {
+		return "", false
+	}
+	if !cm.Contains(x, y) {
+		m.CloseContextMenu()
+		return "", true
+	}
+	idx := cm.HitTest(x, y)
+	if idx < 0 {
+		// On the menu but not on a runnable row (chrome, separator, dimmed):
+		// swallow the click so it cannot reach the pane underneath.
+		return "", true
+	}
+	cm.Selected = idx
+	action = cm.Items[idx].Action
+	m.CloseContextMenu()
+	return action, true
+}
+
+// ContextMenuHover highlights the row under the cursor, so moving the pointer
+// over the menu tracks like the keyboard selection does.
+func (m *OS) ContextMenuHover(x, y int) {
+	cm := m.ContextMenu
+	if cm == nil {
+		return
+	}
+	if idx := cm.HitTest(x, y); idx >= 0 {
+		cm.Selected = idx
+	}
+}
+
+// absInt is the absolute value of an int.
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// ============================================================================
+// Hints, read from the keybind registry
+// ============================================================================
+
+// subPrefixEntry maps an action name prefix to the action that enters the
+// prefix mode it lives in. A sub-prefix action's own key is only the last
+// keystroke of its chord, so the keys of the actions that lead there have to be
+// looked up too. Both lookups go through the registry, so the whole chord
+// follows a rebind.
+var subPrefixEntry = map[string]string{
+	"window_prefix_":    "prefix_window",
+	"minimize_prefix_":  "prefix_minimize",
+	"workspace_prefix_": "prefix_workspace",
+	"debug_prefix_":     "prefix_debug",
+	"tape_prefix_":      "prefix_tape",
+}
+
+// contextMenuHint returns the key currently bound to an action, formatted the
+// way a user would type it. It reads the live registry, so a rebound action
+// shows its new key and an unbound one shows no hint at all.
+//
+// Prefix-mode actions are stored under their bare chord key ("c"), because the
+// leader is what got the user into prefix mode in the first place. The leader,
+// and for a sub-prefix action the key that opens that sub-prefix, are prepended
+// here so the hint is the whole thing a user has to press.
+func contextMenuHint(registry *config.KeybindRegistry, action string) string {
+	if registry == nil || action == "" {
+		return ""
+	}
+	key := firstKey(registry, action)
+	if key == "" {
+		return ""
+	}
+	for name, entry := range subPrefixEntry {
+		if !strings.HasPrefix(action, name) {
+			continue
+		}
+		entryKey := firstKey(registry, entry)
+		if entryKey == "" {
+			return "" // no way in, so there is no chord to show
+		}
+		return config.LeaderKey + " " + entryKey + " " + key
+	}
+	if strings.HasPrefix(action, "prefix_") {
+		return config.LeaderKey + " " + key
+	}
+	return key
+}
+
+// firstKey returns the first key bound to an action, or "".
+func firstKey(registry *config.KeybindRegistry, action string) string {
+	keys := registry.GetKeys(action)
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
+}

--- a/internal/app/contextmenu_build.go
+++ b/internal/app/contextmenu_build.go
@@ -1,0 +1,289 @@
+package app
+
+import (
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// Row glyphs. These are Nerd Font codepoints, written as escapes so the source
+// stays readable in an editor without the font installed. They are dropped
+// wholesale when the user has asked for ASCII-only output.
+const (
+	glyphCopy     = ""
+	glyphPaste    = ""
+	glyphNew      = ""
+	glyphRename   = ""
+	glyphClose    = ""
+	glyphMinimize = ""
+	glyphZoom     = ""
+	glyphSplitV   = ""
+	glyphSplitH   = ""
+	glyphTiling   = ""
+	glyphPalette  = ""
+	glyphSettings = ""
+	glyphHelp     = ""
+	glyphRestore  = ""
+)
+
+// OpenContextMenu opens the context menu for whatever is under the screen cell
+// (x, y). The target decides the menu, so this is the only place that has to
+// know what lives where on screen.
+//
+// Opening on a pane focuses it first, the way clicking it would: every action
+// on the menu acts on the focused window, so focusing the pane the user pointed
+// at is what makes "Close" close the pane they right-clicked rather than the
+// one that happened to have focus. The mode is deliberately left alone, so
+// right-clicking from terminal mode does not kick the user out of it.
+func (m *OS) OpenContextMenu(x, y int) {
+	target, windowIndex := m.contextMenuTargetAt(x, y)
+
+	if target == CtxTargetPaneContent || target == CtxTargetPaneTitle {
+		m.FocusWindow(windowIndex)
+	}
+
+	cm := &ContextMenu{
+		Target:      target,
+		WindowIndex: windowIndex,
+		AnchorX:     x,
+		AnchorY:     y,
+		Selected:    -1,
+		ItemH:       1,
+	}
+
+	switch target {
+	case CtxTargetPaneContent:
+		cm.Title, cm.Items = m.paneContentMenu(windowIndex)
+	case CtxTargetPaneTitle:
+		cm.Title, cm.Items = m.paneTitleMenu(windowIndex)
+	case CtxTargetDockItem:
+		cm.Title, cm.Items = m.dockItemMenu(windowIndex)
+	case CtxTargetDock:
+		cm.Title, cm.Items = m.dockMenu()
+	default:
+		cm.Title, cm.Items = m.desktopMenu()
+	}
+
+	// Start on the first runnable row rather than on row zero, which may be a
+	// dimmed action or a separator.
+	cm.Selected = cm.Next(1)
+	m.ContextMenu = cm
+}
+
+// contextMenuTargetAt classifies the screen cell (x, y) into a menu target, and
+// returns the window or dock entry it belongs to (-1 when it belongs to
+// neither).
+//
+// The order matches the one handleMouseClick already uses, so the menu opens on
+// the same thing an ordinary click would act on: the dock band is reserved and
+// wins over any window drawn near it, then the topmost window under the point,
+// then the desktop.
+func (m *OS) contextMenuTargetAt(x, y int) (ContextMenuTarget, int) {
+	if m.inDockBand(y) {
+		if idx := m.DockItemAt(x, y); idx >= 0 {
+			return CtxTargetDockItem, idx
+		}
+		return CtxTargetDock, -1
+	}
+
+	idx := m.WindowAt(x, y)
+	if idx < 0 {
+		return CtxTargetDesktop, -1
+	}
+
+	// The window's first row is its title bar: it carries the name and the
+	// close/minimize buttons, and it is the row the existing click handling
+	// treats as chrome. A pane drawn without a border has no such row, and all
+	// of it is content.
+	win := m.Windows[idx]
+	if win.BorderOffset() > 0 && y == win.Y {
+		return CtxTargetPaneTitle, idx
+	}
+	return CtxTargetPaneContent, idx
+}
+
+// inDockBand reports whether a screen row falls in the reserved dock band. It
+// mirrors the test the click handler uses so the two cannot disagree about
+// where the dock starts.
+func (m *OS) inDockBand(y int) bool {
+	switch config.DockbarPosition {
+	case "hidden":
+		return false
+	case "top":
+		return y <= config.DockHeight
+	default:
+		return y >= m.Height-config.DockHeight
+	}
+}
+
+// WindowAt returns the index of the topmost visible window containing the
+// screen cell (x, y), or -1.
+func (m *OS) WindowAt(x, y int) int {
+	top, topZ := -1, -1
+	for i, win := range m.Windows {
+		if win == nil || win.Workspace != m.CurrentWorkspace || win.Minimized {
+			continue
+		}
+		if x < win.X || x >= win.X+win.Width || y < win.Y || y >= win.Y+win.Height {
+			continue
+		}
+		if win.Z > topZ {
+			top, topZ = i, win.Z
+		}
+	}
+	return top
+}
+
+// DockItemAt returns the window index of the dock entry at (x, y), or -1. It
+// reads the same layout the dock renders from, so the entry the user clicks is
+// the one they see.
+func (m *OS) DockItemAt(x, y int) int {
+	if y != m.GetDockbarContentYPosition() {
+		return -1
+	}
+	for _, pos := range m.CalculateDockLayout().ItemPositions {
+		if x >= pos.StartX && x < pos.EndX {
+			return pos.WindowIndex
+		}
+	}
+	return -1
+}
+
+// minimizedPosition returns the position of a window among the minimized
+// windows of the current workspace, counting from zero, or -1 when it is not
+// minimized. This is the index the restore_minimized_N actions count in.
+func (m *OS) minimizedPosition(windowIndex int) int {
+	pos := 0
+	for i, win := range m.Windows {
+		if win == nil || win.Workspace != m.CurrentWorkspace || !win.Minimized {
+			continue
+		}
+		if i == windowIndex {
+			return pos
+		}
+		pos++
+	}
+	return -1
+}
+
+// ============================================================================
+// Per-target menus
+// ============================================================================
+
+// contextMenuWindowName titles a menu after the window it acts on, so a menu
+// opened on one of several panes says which one it will affect.
+//
+// It resolves the name the same way the title bar does: the user's own name for
+// the window first, then a title the program inside it set, ignoring the
+// "Terminal <id>" default because naming a menu after that says nothing. The
+// fallback is the caller's generic word.
+func contextMenuWindowName(m *OS, windowIndex int, fallback string) string {
+	if windowIndex < 0 || windowIndex >= len(m.Windows) || m.Windows[windowIndex] == nil {
+		return fallback
+	}
+	win := m.Windows[windowIndex]
+	if win.CustomName != "" {
+		return win.CustomName
+	}
+	if title := win.Title(); title != "" && !isDefaultTitle(title, win.ID) {
+		return title
+	}
+	return fallback
+}
+
+// item builds a row, resolving its key hint from the live registry.
+func (m *OS) item(icon, label, action string, dim bool) ContextMenuItem {
+	return ContextMenuItem{
+		Icon:   icon,
+		Label:  label,
+		Action: action,
+		Hint:   contextMenuHint(m.KeybindRegistry, action),
+		Dim:    dim,
+	}
+}
+
+// separator is a divider row.
+func separator() ContextMenuItem { return ContextMenuItem{Sep: true} }
+
+// paneContentMenu is the menu for the inside of a pane: what you can do with
+// what is in it, and how to divide it.
+func (m *OS) paneContentMenu(windowIndex int) (string, []ContextMenuItem) {
+	win := m.GetFocusedWindow()
+
+	hasSelection := win != nil && win.SelectedText != ""
+	// Pasting reaches the shell only from terminal mode; the clipboard reply is
+	// dropped in every other mode. Dimming says so rather than letting the row
+	// look live and do nothing.
+	canPaste := m.Mode == TerminalMode
+	canSplit := m.AutoTiling
+
+	closeItem := m.item(glyphClose, "Close pane", "close_window", false)
+	closeItem.Warn = true
+
+	return contextMenuWindowName(m, windowIndex, "Pane"), []ContextMenuItem{
+		m.item(glyphCopy, "Copy selection", "copy_selection", !hasSelection),
+		m.item(glyphPaste, "Paste", "paste_clipboard", !canPaste),
+		separator(),
+		m.item(glyphSplitV, "Split right", "split_vertical", !canSplit),
+		m.item(glyphSplitH, "Split down", "split_horizontal", !canSplit),
+		separator(),
+		m.item(glyphZoom, "Zoom", "toggle_zoom", false),
+		closeItem,
+	}
+}
+
+// paneTitleMenu is the menu for a pane's title bar: the pane as an object,
+// rather than what is running inside it.
+func (m *OS) paneTitleMenu(windowIndex int) (string, []ContextMenuItem) {
+	title := contextMenuWindowName(m, windowIndex, "Pane")
+
+	closeItem := m.item(glyphClose, "Close pane", "close_window", false)
+	closeItem.Warn = true
+
+	return title, []ContextMenuItem{
+		m.item(glyphRename, "Rename", "rename_window", config.WindowTitlePosition == "hidden"),
+		m.item(glyphZoom, "Zoom", "toggle_zoom", false),
+		m.item(glyphMinimize, "Minimize", "minimize_window", false),
+		separator(),
+		closeItem,
+	}
+}
+
+// dockItemMenu is the menu for one minimized window in the dock.
+//
+// Restoring the nth minimized window is only an action for the first nine of
+// them, so a tenth entry shows the row dimmed rather than pretending.
+func (m *OS) dockItemMenu(windowIndex int) (string, []ContextMenuItem) {
+	title := contextMenuWindowName(m, windowIndex, "Window")
+
+	pos := m.minimizedPosition(windowIndex)
+	action := ""
+	if pos >= 0 && pos < 9 {
+		action = "restore_minimized_" + string(rune('1'+pos))
+	}
+
+	return title, []ContextMenuItem{
+		m.item(glyphRestore, "Restore", action, action == ""),
+		m.item(glyphRestore, "Restore all", "restore_all", false),
+	}
+}
+
+// dockMenu is the menu for the dock away from any of its entries.
+func (m *OS) dockMenu() (string, []ContextMenuItem) {
+	return "Dock", []ContextMenuItem{
+		m.item(glyphNew, "New window", "new_window", false),
+		m.item(glyphTiling, "Toggle tiling", "toggle_tiling", false),
+		m.item(glyphRestore, "Restore all", "restore_all", !m.HasMinimizedWindows()),
+	}
+}
+
+// desktopMenu is the menu for empty space: making something appear, and the
+// session-wide overlays.
+func (m *OS) desktopMenu() (string, []ContextMenuItem) {
+	return "Desktop", []ContextMenuItem{
+		m.item(glyphNew, "New window", "new_window", false),
+		m.item(glyphTiling, "Toggle tiling", "toggle_tiling", false),
+		separator(),
+		m.item(glyphPalette, "Command palette", "prefix_command_palette", false),
+		m.item(glyphSettings, "Settings", "prefix_settings", false),
+		m.item(glyphHelp, "Help", "toggle_help", false),
+	}
+}

--- a/internal/app/contextmenu_test.go
+++ b/internal/app/contextmenu_test.go
@@ -1,0 +1,502 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// ctxMenuOS builds an OS sized to a screen with one visible window filling the
+// left half, one minimized window, and a registry, which between them can reach
+// every context menu target.
+func ctxMenuOS(t *testing.T, w, h int) *OS {
+	t.Helper()
+	m := newNarrowOS(t, w, h)
+	m.Windows = []*terminal.Window{
+		{ID: "a", CustomName: "editor", X: 0, Y: 0, Width: max(w/2, 10), Height: max(h-2, 4), Workspace: 1},
+		{ID: "b", CustomName: "logs", Width: 20, Height: 10, Workspace: 1, Minimized: true},
+	}
+	m.CurrentWorkspace, m.FocusedWindow = 1, 0
+	return m
+}
+
+// ctxAnchors are one anchor per target, plus the screen corners, which is where
+// placement has to flip rather than draw off the edge.
+func ctxAnchors(m *OS, w, h int) []struct {
+	name string
+	x, y int
+} {
+	return []struct {
+		name string
+		x, y int
+	}{
+		{"pane-title", 2, 0},
+		{"pane-content", 2, 2},
+		{"desktop", w - 2, h / 2},
+		{"dock", 1, h - 1},
+		{"top-left", 0, 0},
+		{"top-right", w - 1, 0},
+		{"bottom-left", 0, h - 1},
+		{"bottom-right", w - 1, h - 1},
+		{"center", w / 2, h / 2},
+	}
+}
+
+// TestContextMenuFitsNarrowScreens renders a context menu for every target at
+// every anchor on every screen size and checks it never draws outside the
+// screen. An overlay wider or taller than the screen has the missing part
+// simply discarded by the terminal, and this codebase has shipped that bug
+// before.
+func TestContextMenuFitsNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := ctxMenuOS(t, sc.w, sc.h)
+			for _, a := range ctxAnchors(m, sc.w, sc.h) {
+				m.OpenContextMenu(a.x, a.y)
+				out, geo := m.renderContextMenu()
+				name := fmt.Sprintf("context menu[%s]", a.name)
+				assertFitsScreen(t, name, out, sc.w, sc.h)
+
+				x, y := m.contextMenuOrigin(m.ContextMenu, geo)
+				if x < 0 || y < 0 {
+					t.Errorf("%s: placed off the top-left at (%d,%d)", name, x, y)
+				}
+				if x+geo.Width > sc.w {
+					t.Errorf("%s: spans x=%d..%d, screen is %d wide", name, x, x+geo.Width, sc.w)
+				}
+				if y+geo.Height > sc.h {
+					t.Errorf("%s: spans y=%d..%d, screen is %d tall", name, y, y+geo.Height, sc.h)
+				}
+				m.CloseContextMenu()
+			}
+		})
+	}
+}
+
+// TestContextMenuLayerFitsNarrowScreens checks the placed layer, which is what
+// the compositor actually draws, rather than the panel string alone.
+func TestContextMenuLayerFitsNarrowScreens(t *testing.T) {
+	for _, sc := range narrowScreens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := ctxMenuOS(t, sc.w, sc.h)
+			for _, a := range ctxAnchors(m, sc.w, sc.h) {
+				m.OpenContextMenu(a.x, a.y)
+				var found bool
+				for _, layer := range m.renderOverlays() {
+					if layer.GetID() != "context-menu" {
+						continue
+					}
+					found = true
+					assertFitsScreen(t, "context-menu layer", layer.GetContent(), sc.w, sc.h)
+					if layer.GetX() < 0 || layer.GetY() < 0 ||
+						layer.GetX()+layer.Width() > sc.w || layer.GetY()+layer.Height() > sc.h {
+						t.Errorf("%s/%s: layer at (%d,%d) size %dx%d, screen is %dx%d",
+							sc.name, a.name, layer.GetX(), layer.GetY(),
+							layer.Width(), layer.Height(), sc.w, sc.h)
+					}
+				}
+				if !found {
+					t.Errorf("%s/%s: no context-menu layer rendered", sc.name, a.name)
+				}
+				m.CloseContextMenu()
+			}
+		})
+	}
+}
+
+// TestContextMenuAnchorPlacement pins the flip behaviour: the menu opens down
+// and right of the pointer when there is room, and flips to the other side of
+// the anchor when there is not, rather than being slid along the edge.
+func TestContextMenuAnchorPlacement(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+
+	// Plenty of room below and to the right: the anchor is the top-left corner.
+	m.OpenContextMenu(10, 5)
+	_, geo := m.renderContextMenu()
+	if x, y := m.contextMenuOrigin(m.ContextMenu, geo); x != 10 || y != 5 {
+		t.Errorf("with room, menu origin = (%d,%d), want the anchor (10,5)", x, y)
+	}
+	m.CloseContextMenu()
+
+	// Hard against the right and bottom: the anchor becomes the bottom-right
+	// corner instead.
+	m.OpenContextMenu(119, 39)
+	_, geo = m.renderContextMenu()
+	x, y := m.contextMenuOrigin(m.ContextMenu, geo)
+	if wantX := 119 - geo.Width + 1; x != wantX {
+		t.Errorf("at the right edge, menu x = %d, want %d (flipped left of the anchor)", x, wantX)
+	}
+	if wantY := 39 - geo.Height + 1; y != wantY {
+		t.Errorf("at the bottom edge, menu y = %d, want %d (flipped above the anchor)", y, wantY)
+	}
+}
+
+// TestContextMenuHitTest checks a click lands on the row the user aimed at, and
+// that clicks on the menu's chrome, on a separator, on a dimmed row, and off
+// the menu entirely all resolve to no row.
+func TestContextMenuHitTest(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.OpenContextMenu(10, 5)
+	m.renderOverlays() // places the menu and records its bounds
+	cm := m.ContextMenu
+
+	if cm.BoundsW == 0 || cm.ItemH != 1 {
+		t.Fatalf("menu bounds were not recorded: %+v", cm)
+	}
+
+	x := cm.BoundsX + 3 // a column inside the rows
+	for i, it := range cm.Items {
+		y := cm.FirstRowY + i
+		got := cm.HitTest(x, y)
+		switch {
+		case it.Sep:
+			if got != -1 {
+				t.Errorf("row %d is a separator, hit test returned %d", i, got)
+			}
+		case it.Dim:
+			if got != -1 {
+				t.Errorf("row %d (%q) is dimmed, hit test returned %d; a dimmed row must not be clickable",
+					i, it.Label, got)
+			}
+		default:
+			if got != i {
+				t.Errorf("click on row %d (%q) hit %d", i, it.Label, got)
+			}
+		}
+	}
+
+	// Chrome above the first row, and past the last row.
+	if got := cm.HitTest(x, cm.BoundsY); got != -1 {
+		t.Errorf("click on the title chrome hit row %d", got)
+	}
+	if got := cm.HitTest(x, cm.FirstRowY+len(cm.Items)); got != -1 {
+		t.Errorf("click below the last row hit row %d", got)
+	}
+	// Outside the menu in both axes.
+	for _, p := range [][2]int{
+		{cm.BoundsX - 1, cm.FirstRowY},
+		{cm.BoundsX + cm.BoundsW, cm.FirstRowY},
+		{x, cm.BoundsY - 1},
+		{x, cm.BoundsY + cm.BoundsH},
+	} {
+		if got := cm.HitTest(p[0], p[1]); got != -1 {
+			t.Errorf("click outside the menu at (%d,%d) hit row %d", p[0], p[1], got)
+		}
+		if cm.Contains(p[0], p[1]) {
+			t.Errorf("(%d,%d) is outside the menu but Contains says otherwise", p[0], p[1])
+		}
+	}
+}
+
+// TestContextMenuClickOutsideClosesWithoutFiring is the guard on the most
+// destructive way this could go wrong: a click meant to dismiss the menu
+// running whatever row happened to be selected.
+func TestContextMenuClickOutsideClosesWithoutFiring(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.OpenContextMenu(10, 5)
+	m.renderOverlays()
+	cm := m.ContextMenu
+
+	action, consumed := m.ContextMenuClick(cm.BoundsX+cm.BoundsW+5, cm.BoundsY+2)
+	if !consumed {
+		t.Error("a click while the menu is open must be consumed by it")
+	}
+	if action != "" {
+		t.Errorf("clicking away from the menu returned action %q; it must fire nothing", action)
+	}
+	if m.ContextMenuActive() {
+		t.Error("clicking away from the menu left it open")
+	}
+}
+
+// TestContextMenuClickOnChromeFiresNothing checks a click that lands on the
+// menu but not on a row neither runs anything nor closes the menu. Closing on a
+// stray click on the panel's own padding would be a surprise.
+func TestContextMenuClickOnChromeFiresNothing(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.OpenContextMenu(10, 5)
+	m.renderOverlays()
+	cm := m.ContextMenu
+
+	action, consumed := m.ContextMenuClick(cm.BoundsX+2, cm.BoundsY)
+	if !consumed || action != "" {
+		t.Errorf("click on menu chrome: action=%q consumed=%v, want \"\" and true", action, consumed)
+	}
+	if !m.ContextMenuActive() {
+		t.Error("a click on the menu's own chrome closed it")
+	}
+}
+
+// TestContextMenuClickRunsTheClickedRow checks the click path returns the
+// action of the row under the cursor and closes the menu.
+func TestContextMenuClickRunsTheClickedRow(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.OpenContextMenu(120/2, 20) // desktop: no dimmed rows at the top
+	m.renderOverlays()
+	cm := m.ContextMenu
+
+	want := ""
+	row := -1
+	for i, it := range cm.Items {
+		if !it.Sep && !it.Dim {
+			want, row = it.Action, i
+			break
+		}
+	}
+	if row < 0 {
+		t.Fatal("no runnable row in the desktop menu")
+	}
+
+	action, consumed := m.ContextMenuClick(cm.BoundsX+3, cm.FirstRowY+row)
+	if !consumed {
+		t.Fatal("click on a row was not consumed")
+	}
+	if action != want {
+		t.Errorf("click on row %d returned %q, want %q", row, action, want)
+	}
+	if m.ContextMenuActive() {
+		t.Error("running a row left the menu open")
+	}
+}
+
+// TestContextMenuArrowsSkipDimmedAndSeparators checks arrow navigation over
+// every menu: it must never rest on a separator or a dimmed row, and a full lap
+// in either direction must return to where it started.
+func TestContextMenuArrowsSkipDimmedAndSeparators(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+
+	for _, a := range ctxAnchors(m, 120, 40)[:4] {
+		t.Run(a.name, func(t *testing.T) {
+			m.OpenContextMenu(a.x, a.y)
+			cm := m.ContextMenu
+
+			runnable := 0
+			for _, it := range cm.Items {
+				if !it.Sep && !it.Dim {
+					runnable++
+				}
+			}
+			if runnable == 0 {
+				t.Skip("menu has no runnable rows")
+			}
+
+			if cm.Selected < 0 || cm.Items[cm.Selected].Sep || cm.Items[cm.Selected].Dim {
+				t.Fatalf("menu opened on row %d, which is a separator or dimmed", cm.Selected)
+			}
+
+			start := cm.Selected
+			for _, dir := range []int{1, -1} {
+				for step := range runnable {
+					m.ContextMenuMove(dir)
+					sel := cm.Selected
+					if sel < 0 || sel >= len(cm.Items) {
+						t.Fatalf("dir %d step %d: selection out of range: %d", dir, step, sel)
+					}
+					if cm.Items[sel].Sep {
+						t.Fatalf("dir %d step %d: selection landed on a separator (row %d)", dir, step, sel)
+					}
+					if cm.Items[sel].Dim {
+						t.Fatalf("dir %d step %d: selection landed on the dimmed row %q (row %d)",
+							dir, step, cm.Items[sel].Label, sel)
+					}
+				}
+				if cm.Selected != start {
+					t.Errorf("dir %d: a full lap of %d runnable rows ended on %d, started on %d",
+						dir, runnable, cm.Selected, start)
+				}
+			}
+			m.CloseContextMenu()
+		})
+	}
+}
+
+// TestContextMenuAllDimmedHasNoSelection checks a menu whose rows are all
+// unavailable selects nothing rather than falling back to a dimmed row.
+func TestContextMenuAllDimmedHasNoSelection(t *testing.T) {
+	cm := &ContextMenu{Items: []ContextMenuItem{
+		{Label: "a", Dim: true},
+		{Sep: true},
+		{Label: "b", Dim: true},
+	}, Selected: -1}
+
+	if got := cm.Next(1); got != -1 {
+		t.Errorf("Next on an all-dimmed menu returned %d, want -1", got)
+	}
+	cm.Move(1)
+	if cm.Selected != -1 {
+		t.Errorf("Move on an all-dimmed menu selected row %d", cm.Selected)
+	}
+}
+
+// TestContextMenuHintsMatchRegistry is the guard against this menu becoming the
+// second thing in this codebase that documents keys from a hand-written table.
+//
+// Every row's hint has to be what the registry actually has bound to that row's
+// action, and every row has to name an action the registry knows a description
+// for. Rebinding an action in the config must move the hint with it, which the
+// second half checks by rebinding one and rebuilding the menus.
+func TestContextMenuHintsMatchRegistry(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+
+	for _, a := range ctxAnchors(m, 120, 40)[:4] {
+		m.OpenContextMenu(a.x, a.y)
+		for _, it := range m.ContextMenu.Items {
+			if it.Sep {
+				continue
+			}
+			if it.Action == "" {
+				// Only a dimmed placeholder may carry no action.
+				if !it.Dim {
+					t.Errorf("%s: row %q is runnable but names no action", a.name, it.Label)
+				}
+				continue
+			}
+			if want := contextMenuHint(m.KeybindRegistry, it.Action); it.Hint != want {
+				t.Errorf("%s: row %q hint = %q, registry says %q", a.name, it.Label, it.Hint, want)
+			}
+			keys := m.KeybindRegistry.GetKeys(it.Action)
+			if len(keys) == 0 {
+				if it.Hint != "" {
+					t.Errorf("%s: row %q has nothing bound but shows hint %q", a.name, it.Label, it.Hint)
+				}
+				continue
+			}
+			// The hint must contain the bound key, not some other string.
+			if !strings.Contains(it.Hint, keys[0]) {
+				t.Errorf("%s: row %q is bound to %q but its hint is %q",
+					a.name, it.Label, keys[0], it.Hint)
+			}
+		}
+		m.CloseContextMenu()
+	}
+}
+
+// TestContextMenuHintFollowsRebind rebinds an action and checks the menu says
+// so. This is the half of the registry guard that a hand-written table would
+// fail.
+func TestContextMenuHintFollowsRebind(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Keybindings.WindowManagement["new_window"] = []string{"ctrl+t"}
+	m := ctxMenuOS(t, 120, 40)
+	m.KeybindRegistry = config.NewKeybindRegistry(cfg)
+
+	m.OpenContextMenu(60, 20) // desktop menu carries New window
+	var hint string
+	var found bool
+	for _, it := range m.ContextMenu.Items {
+		if it.Action == "new_window" {
+			hint, found = it.Hint, true
+		}
+	}
+	if !found {
+		t.Fatal("the desktop menu no longer has a New window row")
+	}
+	if hint != "ctrl+t" {
+		t.Errorf("after rebinding new_window to ctrl+t, the menu shows %q; the hint is not "+
+			"coming from the registry", hint)
+	}
+}
+
+// TestContextMenuPrefixHintIncludesLeader checks an action that lives behind
+// the leader key shows the whole chord, not just the last keystroke, and that
+// the leader shown is the configured one.
+func TestContextMenuPrefixHintIncludesLeader(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.OpenContextMenu(60, 20)
+
+	for _, it := range m.ContextMenu.Items {
+		if !strings.HasPrefix(it.Action, "prefix_") {
+			continue
+		}
+		if !strings.HasPrefix(it.Hint, config.LeaderKey+" ") {
+			t.Errorf("row %q runs the prefix action %q but its hint %q does not start with the leader %q",
+				it.Label, it.Action, it.Hint, config.LeaderKey)
+		}
+	}
+}
+
+// TestContextMenuTargetResolution checks the pointer position picks the menu,
+// which is the whole idea of a context menu.
+func TestContextMenuTargetResolution(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	win := m.Windows[0]
+
+	cases := []struct {
+		name string
+		x, y int
+		want ContextMenuTarget
+	}{
+		{"inside the pane", win.X + 2, win.Y + 3, CtxTargetPaneContent},
+		{"the pane's title row", win.X + 2, win.Y, CtxTargetPaneTitle},
+		{"empty space right of the pane", win.X + win.Width + 5, 10, CtxTargetDesktop},
+		{"the dock band", 1, 39, CtxTargetDock},
+	}
+	for _, tc := range cases {
+		got, _ := m.contextMenuTargetAt(tc.x, tc.y)
+		if got != tc.want {
+			t.Errorf("%s: (%d,%d) resolved to target %d, want %d", tc.name, tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+// TestContextMenuOnPaneFocusesIt checks that opening a menu on a pane focuses
+// it, so the actions on the menu act on the pane the user pointed at rather
+// than on whichever one happened to have focus.
+func TestContextMenuOnPaneFocusesIt(t *testing.T) {
+	m := newNarrowOS(t, 120, 40)
+	m.Windows = []*terminal.Window{
+		{ID: "a", CustomName: "left", X: 0, Y: 0, Width: 50, Height: 30, Workspace: 1, Z: 1},
+		{ID: "b", CustomName: "right", X: 60, Y: 0, Width: 50, Height: 30, Workspace: 1, Z: 2},
+	}
+	m.CurrentWorkspace, m.FocusedWindow = 1, 0
+
+	m.OpenContextMenu(65, 5) // inside the second window
+	if m.FocusedWindow != 1 {
+		t.Errorf("opening a menu on the right pane left focus on window %d", m.FocusedWindow)
+	}
+	if m.ContextMenu.Title != "right" {
+		t.Errorf("menu title = %q, want the pane's name %q", m.ContextMenu.Title, "right")
+	}
+}
+
+// TestContextMenuDimsUnavailableActions pins the states that dim a row, since
+// the dim flag is what the arrow-skipping and hit-testing rules key off.
+func TestContextMenuDimsUnavailableActions(t *testing.T) {
+	m := ctxMenuOS(t, 120, 40)
+	m.AutoTiling = false
+	m.Mode = WindowManagementMode
+	m.Windows[0].SelectedText = ""
+
+	m.OpenContextMenu(2, 2) // pane content
+	dim := map[string]bool{}
+	for _, it := range m.ContextMenu.Items {
+		if !it.Sep {
+			dim[it.Action] = it.Dim
+		}
+	}
+	for _, action := range []string{"copy_selection", "split_vertical", "split_horizontal", "paste_clipboard"} {
+		if !dim[action] {
+			t.Errorf("%s should be dimmed: no selection, no tiling, and not in terminal mode", action)
+		}
+	}
+	if dim["toggle_zoom"] || dim["close_window"] {
+		t.Error("zoom and close always apply to a pane and must not be dimmed")
+	}
+
+	// With a selection and tiling on, the same rows come alive.
+	m.CloseContextMenu()
+	m.AutoTiling = true
+	m.Windows[0].SelectedText = "hello"
+	m.OpenContextMenu(2, 2)
+	for _, it := range m.ContextMenu.Items {
+		if it.Action == "copy_selection" && it.Dim {
+			t.Error("copy is dimmed even though the pane has a selection")
+		}
+		if it.Action == "split_vertical" && it.Dim {
+			t.Error("split is dimmed even though tiling is on")
+		}
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -407,6 +407,12 @@ type OS struct {
 	// overlays, bottom to top. Clicking a panel moves it to the end (top).
 	OverlayZOrder []string
 
+	// ContextMenu is the open shift+right-click menu, or nil. It is deliberately
+	// not one of the draggable overlay kinds: a context menu is anchored to the
+	// cell it was opened on and is dismissed by the next click, so it has no use
+	// for a drag offset or a place in the click-to-raise order.
+	ContextMenu *ContextMenu
+
 	// UserConfig is the loaded user configuration. The settings page mutates
 	// it in place and persists it so live changes survive a restart. May be
 	// nil if the config failed to load at startup.

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -306,7 +306,7 @@ func (m *OS) fullscreenFastWindow() (*terminal.Window, bool) {
 	if m.ShowHelp || m.ShowCommandPalette || m.ShowSessionSwitcher || m.ShowLayoutPicker ||
 		m.ShowQuitConfirm || m.ShowScrollbackBrowser || m.ShowLogs || m.ShowCacheStats ||
 		m.ShowAggregateView || m.ShowTapeManager || m.ShowTapeReview || m.ShowSettings || m.ShowThemePicker ||
-		m.PrefixActive {
+		m.PrefixActive || m.ContextMenu != nil {
 		return nil, false
 	}
 	if (config.ShowClock && !config.HideClock) || (m.TapeRecorder != nil && m.TapeRecorder.IsRecording()) {

--- a/internal/app/render_context_menu.go
+++ b/internal/app/render_context_menu.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/overlay"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
+)
+
+const (
+	// contextMenuMinWidth is the narrowest inner width worth laying a menu out
+	// at. Below this a row has nowhere to put a marker, an icon and a label.
+	contextMenuMinWidth = 16
+	// contextMenuMaxWidth caps the menu on a wide screen. A context menu is a
+	// short list of short labels; letting it grow to the width of the widest
+	// hint would make a floating panel out of what should read as a small popup.
+	contextMenuMaxWidth = 36
+	// contextMenuGap is the minimum run of spaces between a label and its hint.
+	contextMenuGap = 2
+)
+
+// contextMenuWidth returns the inner content width to lay the menu out at: wide
+// enough for its widest row, capped, and then fitted to the screen so the panel
+// never draws past the right-hand edge.
+func (m *OS) contextMenuWidth(cm *ContextMenu) int {
+	widest := lipgloss.Width(cm.Title) + 2 // the title chip is padded
+	for _, it := range cm.Items {
+		if it.Sep {
+			continue
+		}
+		w := lipgloss.Width(contextMenuRowLeft(it)) + lipgloss.Width(it.Hint)
+		if it.Hint != "" {
+			w += contextMenuGap
+		}
+		if w > widest {
+			widest = w
+		}
+	}
+	widest = max(min(widest, contextMenuMaxWidth), contextMenuMinWidth)
+	return m.panelWidth(widest)
+}
+
+// contextMenuRowLeft is the left-hand part of a row: the selection marker, the
+// icon, and the label, unstyled. It exists so the width measurement and the
+// renderer cannot disagree about how much room the left side takes.
+func contextMenuRowLeft(it ContextMenuItem) string {
+	icon := ""
+	if it.Icon != "" && !config.UseASCIIOnly {
+		icon = it.Icon + " "
+	}
+	return "  " + icon + it.Label
+}
+
+// renderContextMenu renders the open context menu and returns the panel and its
+// geometry. It returns an empty string when no menu is open.
+func (m *OS) renderContextMenu() (string, overlay.Geometry) {
+	cm := m.ContextMenu
+	if cm == nil {
+		return "", overlay.Geometry{}
+	}
+
+	pal := theme.UI()
+	bg := pal.Surface
+	width := m.contextMenuWidth(cm)
+
+	lines := make([]string, 0, len(cm.Items))
+	for i, it := range cm.Items {
+		if it.Sep {
+			lines = append(lines, overlay.Rule(width, bg, pal))
+			continue
+		}
+		lines = append(lines, m.contextMenuRow(it, i == cm.Selected, width, bg, pal))
+	}
+
+	panel := overlay.Panel{
+		Title: cm.Title,
+		Width: width,
+		Body:  strings.Join(lines, "\n"),
+	}
+	return panel.Render(pal)
+}
+
+// contextMenuRow renders one runnable row, filled to the panel width so the
+// selection highlight spans it.
+//
+// A dimmed row is drawn in the muted color and never takes the highlight, even
+// if the selection somehow points at it: the colors are the only thing telling
+// the user the action is unavailable, so they do not get overridden.
+func (m *OS) contextMenuRow(it ContextMenuItem, selected bool, width int, bg color.Color, pal overlay.Palette) string {
+	rowBg := bg
+	if selected && !it.Dim {
+		rowBg = pal.RowSel
+	}
+
+	labelColor := pal.Fg
+	iconColor := pal.AccentBright
+	hintColor := pal.FgDim
+	switch {
+	case it.Dim:
+		labelColor, iconColor, hintColor = pal.FgMute, pal.FgMute, pal.FgMute
+	case it.Warn:
+		labelColor, iconColor = pal.Warn, pal.Warn
+	}
+
+	marker := "  "
+	if selected && !it.Dim {
+		marker = "› "
+		if config.UseASCIIOnly {
+			marker = "> "
+		}
+	}
+
+	left := overlay.Style(rowBg).Foreground(pal.Accent).Bold(true).Render(marker)
+	if it.Icon != "" && !config.UseASCIIOnly {
+		left += overlay.Style(rowBg).Foreground(iconColor).Render(it.Icon + " ")
+	}
+
+	// The label gives up room before the hint does: the hint is what the user
+	// came for when they are learning the keyboard, and it is already short.
+	hintW := lipgloss.Width(it.Hint)
+	if hintW > 0 {
+		hintW += contextMenuGap
+	}
+	labelRoom := max(width-lipgloss.Width(left)-hintW, 1)
+	left += overlay.Style(rowBg).
+		Foreground(labelColor).
+		Bold(selected && !it.Dim).
+		Render(overlay.Truncate(it.Label, labelRoom))
+
+	if it.Hint == "" {
+		return overlay.Fill(left, width, rowBg)
+	}
+	hint := overlay.Style(rowBg).Foreground(hintColor).Render(it.Hint)
+	gap := max(width-lipgloss.Width(left)-lipgloss.Width(hint), 1)
+	return overlay.Fill(left+overlay.Style(rowBg).Render(strings.Repeat(" ", gap))+hint, width, rowBg)
+}
+
+// contextMenuOrigin places the menu against its anchor.
+//
+// The menu opens down and to the right of the pointer, which is where a user
+// expects it. When that would run past an edge it flips to the other side of
+// the anchor rather than being nudged along it, so the pointer stays on a
+// corner of the menu instead of landing in the middle of a row the user did not
+// aim at. The clamp afterwards is a backstop for a menu taller or wider than
+// the screen itself, where neither side fits and drawing off the edge is the
+// only other option.
+func (m *OS) contextMenuOrigin(cm *ContextMenu, geo overlay.Geometry) (int, int) {
+	rw, rh := m.GetRenderWidth(), m.GetRenderHeight()
+
+	x := cm.AnchorX
+	if x+geo.Width > rw {
+		x = cm.AnchorX - geo.Width + 1
+	}
+	y := cm.AnchorY
+	if y+geo.Height > rh {
+		y = cm.AnchorY - geo.Height + 1
+	}
+
+	x = max(min(x, rw-geo.Width), 0)
+	y = max(min(y, rh-geo.Height), 0)
+	return x, y
+}
+
+// placeContextMenu draws the menu as a layer and records where it landed, so
+// the mouse handlers can map a screen cell to a row without redoing the layout.
+func (m *OS) placeContextMenu(layers []*lipgloss.Layer) []*lipgloss.Layer {
+	cm := m.ContextMenu
+	if cm == nil {
+		return layers
+	}
+	content, geo := m.renderContextMenu()
+	if content == "" {
+		return layers
+	}
+	x, y := m.contextMenuOrigin(cm, geo)
+
+	cm.BoundsX, cm.BoundsY = x, y
+	cm.BoundsW, cm.BoundsH = geo.Width, geo.Height
+	cm.FirstRowY = y + geo.BodyY
+	cm.ItemH = 1
+
+	return append(layers, lipgloss.NewLayer(content).
+		X(x).Y(y).Z(config.ZIndexContextMenu).ID("context-menu"))
+}

--- a/internal/app/render_overlays.go
+++ b/internal/app/render_overlays.go
@@ -689,5 +689,10 @@ func (m *OS) renderOverlays() []*lipgloss.Layer {
 		}
 	}
 
+	// The context menu is placed last so it sits above everything else it may
+	// have been opened on top of, and so its recorded bounds are from the frame
+	// the user is actually looking at.
+	layers = m.placeContextMenu(layers)
+
 	return layers
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -931,6 +931,12 @@ const (
 	// panel brings it above the others.
 	ZIndexOverlayBase = 1100
 
+	// ZIndexContextMenu is the z-index for the shift+right-click context menu. It
+	// sits above every floating panel because it is opened on top of whatever is
+	// already on screen and is dismissed by the next click either way, so nothing
+	// is served by letting another panel cover it.
+	ZIndexContextMenu = 1500
+
 	// ZIndexNotifications is the z-index for notifications
 	ZIndexNotifications = 2000
 )

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -318,6 +318,7 @@ var ActionDescriptions = map[string]string{
 	"quit":                "Quit",
 
 	// Clipboard
+	"copy_selection":  "Copy selection to clipboard",
 	"paste_clipboard": "Paste from clipboard",
 
 	// System

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -201,6 +201,10 @@ func DefaultConfig() *UserConfig {
 				"minimize_window": {"m"},
 				"restore_all":     {"M"},
 				"toggle_zoom":     {"z"},
+				// Finishing a mouse selection has always told the user to press
+				// 'c' to copy it. Until this binding existed, nothing was
+				// listening.
+				"copy_selection":  {"c"},
 				"next_window":     {"tab"},
 				"prev_window":     {"shift+tab"},
 				"select_window_1": {"1"},

--- a/internal/input/actions.go
+++ b/internal/input/actions.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -103,6 +104,7 @@ func (d *ActionDispatcher) registerHandlers() {
 	d.Register("quit", handleQuit)
 
 	// Clipboard actions
+	d.Register("copy_selection", handleCopySelection)
 	d.Register("paste_clipboard", handlePasteClipboard)
 
 	// System actions
@@ -583,6 +585,26 @@ func handleToggleCacheStats(_ tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		o.LogInfo("Cache statistics viewer opened")
 	}
 	return o, nil
+}
+
+// handleCopySelection copies the focused pane's mouse selection to the system
+// clipboard.
+//
+// The selection text is already extracted and stored on the window when the
+// selection is made, so this only has to hand it to the terminal; it does not
+// re-derive the region and cannot disagree with what is highlighted on screen.
+//
+// This closes a gap the release handler had been advertising: finishing a
+// selection tells the user to "Press 'c' to copy", and until now nothing was
+// listening for it.
+func handleCopySelection(_ tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
+	focusedWindow := o.GetFocusedWindow()
+	if focusedWindow == nil || focusedWindow.SelectedText == "" {
+		return o, nil
+	}
+	text := focusedWindow.SelectedText
+	o.ShowNotification(fmt.Sprintf("Copied %d characters", len(text)), "success", config.NotificationDuration)
+	return o, tea.SetClipboard(text)
 }
 
 func handlePasteClipboard(_ tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {

--- a/internal/input/contextmenu.go
+++ b/internal/input/contextmenu.go
@@ -1,0 +1,56 @@
+package input
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+)
+
+// runContextMenuAction dispatches an action chosen from a context menu.
+//
+// It goes through the same ActionDispatcher that every keybinding goes through,
+// which is the point: a menu row carries an action ID and nothing else, so it
+// runs exactly the code the key runs. A menu that held its own copy of the
+// behaviour would drift from the keybinding the moment either side changed, and
+// there is already one popup in this codebase describing keys from a
+// hand-written table rather than from the registry.
+//
+// An empty action means the click landed on the menu but not on a runnable row,
+// or that the menu was dismissed; either way nothing runs.
+//
+// The zero KeyPressMsg is deliberate. Dispatch passes it to the handler, and no
+// action reachable from a context menu reads the originating key: the handlers
+// that do take their argument are the number-key window selectors, which no
+// menu offers.
+func runContextMenuAction(action string, o *app.OS) (*app.OS, tea.Cmd) {
+	if action == "" {
+		return o, nil
+	}
+	dispatcher := GetDispatcher()
+	if !dispatcher.HasAction(action) {
+		return o, nil
+	}
+	return dispatcher.Dispatch(action, tea.KeyPressMsg{}, o)
+}
+
+// handleContextMenuKey drives an open context menu from the keyboard: arrows or
+// j/k move the selection, enter runs it, escape closes without running
+// anything.
+//
+// Every other key is swallowed. The menu is modal while it is up, so a
+// keystroke meant for it can never fall through to a window-manager binding or
+// to the shell.
+func handleContextMenuKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		o.CloseContextMenu()
+	case "up", "k", "shift+tab":
+		o.ContextMenuMove(-1)
+	case "down", "j", "tab":
+		o.ContextMenuMove(1)
+	case "enter", " ":
+		action := o.ContextMenuSelectedAction()
+		o.CloseContextMenu()
+		return runContextMenuAction(action, o)
+	}
+	return o, nil
+}

--- a/internal/input/contextmenu_test.go
+++ b/internal/input/contextmenu_test.go
@@ -1,0 +1,282 @@
+package input
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// ctxOS builds an OS with a registry, a visible pane and a minimized one, which
+// between them can reach every context menu target.
+func ctxOS(t *testing.T) *app.OS {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	o := app.NewOS(app.OSOptions{
+		UserConfig:      cfg,
+		KeybindRegistry: config.NewKeybindRegistry(cfg),
+	})
+	o.Width, o.Height = 120, 40
+	o.EffectiveWidth, o.EffectiveHeight = 120, 40
+	o.Windows = []*terminal.Window{
+		{ID: "a", CustomName: "editor", X: 0, Y: 0, Width: 60, Height: 30, Workspace: 1},
+		{ID: "b", CustomName: "logs", Width: 20, Height: 10, Workspace: 1, Minimized: true},
+	}
+	o.CurrentWorkspace, o.FocusedWindow = 1, 0
+	return o
+}
+
+// ctxMenuAnchors is one anchor per target.
+var ctxMenuAnchors = []struct {
+	name string
+	x, y int
+}{
+	{"pane content", 5, 5},
+	{"pane title", 5, 0},
+	{"desktop", 100, 20},
+	{"dock", 1, 39},
+}
+
+// TestContextMenuActionsAreRegistered is the guard that makes a context menu
+// row more than a string.
+//
+// Every row names an action ID and nothing else, and the input layer hands that
+// ID to the same ActionDispatcher a keybinding goes through. If a row named an
+// action nobody registered, clicking it would silently do nothing, and the only
+// way to find out would be to click it. This checks every row of every menu
+// against the dispatcher.
+func TestContextMenuActionsAreRegistered(t *testing.T) {
+	o := ctxOS(t)
+	dispatcher := GetDispatcher()
+
+	seen := 0
+	for _, a := range ctxMenuAnchors {
+		o.OpenContextMenu(a.x, a.y)
+		if o.ContextMenu == nil {
+			t.Fatalf("%s: no menu opened at (%d,%d)", a.name, a.x, a.y)
+		}
+		for _, it := range o.ContextMenu.Items {
+			if it.Sep || it.Action == "" {
+				continue
+			}
+			seen++
+			if !dispatcher.HasAction(it.Action) {
+				t.Errorf("%s: row %q names action %q, which the dispatcher does not have; "+
+					"clicking it would do nothing", a.name, it.Label, it.Action)
+			}
+			if _, ok := config.ActionDescriptions[it.Action]; !ok {
+				t.Errorf("%s: row %q names action %q, which has no description in the registry",
+					a.name, it.Label, it.Action)
+			}
+		}
+		o.CloseContextMenu()
+	}
+	if seen == 0 {
+		t.Fatal("no menu rows were checked; the menus are empty")
+	}
+}
+
+// TestContextMenuEscapeClosesWithoutFiring checks the escape key dismisses the
+// menu and runs nothing. The evidence is that the window count does not change:
+// the desktop menu's selected row is New window, so a menu that fired on escape
+// would leave a window behind.
+func TestContextMenuEscapeClosesWithoutFiring(t *testing.T) {
+	o := ctxOS(t)
+	before := len(o.Windows)
+
+	o.OpenContextMenu(100, 20) // desktop
+	if got := o.ContextMenuSelectedAction(); got != "new_window" {
+		t.Fatalf("the desktop menu opened with %q selected, want new_window", got)
+	}
+
+	o, _ = HandleKeyPress(ctxKey("esc"), o)
+
+	if o.ContextMenuActive() {
+		t.Error("esc did not close the context menu")
+	}
+	if len(o.Windows) != before {
+		t.Errorf("esc created a window (%d -> %d); it must fire nothing", before, len(o.Windows))
+	}
+}
+
+// TestContextMenuEnterRunsSelectedAction checks enter runs the highlighted row
+// through the dispatcher and closes the menu.
+func TestContextMenuEnterRunsSelectedAction(t *testing.T) {
+	o := ctxOS(t)
+	before := len(o.Windows)
+
+	o.OpenContextMenu(100, 20) // desktop, New window selected
+	o, _ = HandleKeyPress(ctxKey("enter"), o)
+
+	if o.ContextMenuActive() {
+		t.Error("enter left the context menu open")
+	}
+	if len(o.Windows) != before+1 {
+		t.Errorf("enter on New window changed the count %d -> %d, want %d",
+			before, len(o.Windows), before+1)
+	}
+}
+
+// TestContextMenuSwallowsKeys checks the menu is modal to the keyboard: a key
+// that would otherwise be a window-manager binding must not reach it while the
+// menu is up. "n" is new_window, which would be silently destructive to the
+// user's sense of what the menu is doing.
+func TestContextMenuSwallowsKeys(t *testing.T) {
+	o := ctxOS(t)
+	before := len(o.Windows)
+
+	o.OpenContextMenu(100, 20)
+	for _, k := range []string{"n", "q", "t", "z"} {
+		o, _ = HandleKeyPress(ctxKey(k), o)
+		if !o.ContextMenuActive() {
+			t.Fatalf("%q closed the context menu", k)
+		}
+	}
+	if len(o.Windows) != before {
+		t.Errorf("keys leaked past the open menu: window count %d -> %d", before, len(o.Windows))
+	}
+}
+
+// TestContextMenuArrowKeysMoveSelection checks the arrow keys reach the menu
+// and skip its dimmed rows, through the real key handler rather than by calling
+// the mover directly.
+func TestContextMenuArrowKeysMoveSelection(t *testing.T) {
+	o := ctxOS(t)
+	o.AutoTiling = false // dims both split rows
+	o.OpenContextMenu(5, 5)
+
+	cm := o.ContextMenu
+	if cm == nil {
+		t.Fatal("no pane menu opened")
+	}
+	for step := range len(cm.Items) * 2 {
+		o, _ = HandleKeyPress(ctxKey("down"), o)
+		sel := o.ContextMenu.Selected
+		if o.ContextMenu.Items[sel].Dim || o.ContextMenu.Items[sel].Sep {
+			t.Fatalf("step %d: down arrow landed on row %d (%q), which is dimmed or a separator",
+				step, sel, o.ContextMenu.Items[sel].Label)
+		}
+	}
+}
+
+// TestShiftRightClickOpensMenuAndPlainRightClickDoesNot pins the chord. Plain
+// right-click has always started a window resize, and the menu must not take
+// that away.
+func TestShiftRightClickOpensMenuAndPlainRightClickDoesNot(t *testing.T) {
+	o := ctxOS(t)
+
+	o, _ = handleMouseClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseRight}, o)
+	if o.ContextMenuActive() {
+		t.Error("a plain right-click opened a context menu; it must still start a resize")
+	}
+	if !o.Resizing {
+		t.Error("a plain right-click on a pane no longer starts a resize")
+	}
+
+	o = ctxOS(t)
+	o, _ = handleMouseClick(tea.MouseClickMsg{
+		X: 5, Y: 5, Button: tea.MouseRight, Mod: tea.ModShift,
+	}, o)
+	if !o.ContextMenuActive() {
+		t.Fatal("shift+right-click did not open a context menu")
+	}
+	if o.Resizing {
+		t.Error("shift+right-click started a resize as well as opening the menu")
+	}
+}
+
+// TestContextMenuClickOutsideFiresNothing checks the mouse path: a click away
+// from an open menu closes it and runs nothing, and does not fall through to
+// the pane underneath.
+func TestContextMenuClickOutsideFiresNothing(t *testing.T) {
+	o := ctxOS(t)
+	before := len(o.Windows)
+
+	o, _ = handleMouseClick(tea.MouseClickMsg{
+		X: 100, Y: 20, Button: tea.MouseRight, Mod: tea.ModShift,
+	}, o)
+	if !o.ContextMenuActive() {
+		t.Fatal("shift+right-click did not open a context menu")
+	}
+
+	// The renderer records the menu's bounds each frame; this test is about
+	// where a click is routed, not about layout, so it stands the bounds up
+	// directly rather than driving a whole render. The layout itself is checked
+	// against the real renderer in internal/app.
+	cm := o.ContextMenu
+	cm.BoundsX, cm.BoundsY, cm.BoundsW, cm.BoundsH = 40, 10, 24, 10
+	cm.FirstRowY, cm.ItemH = 13, 1
+
+	away := cm.BoundsX + cm.BoundsW + 4
+	o, _ = handleMouseClick(tea.MouseClickMsg{X: away, Y: cm.BoundsY + 2, Button: tea.MouseLeft}, o)
+
+	if o.ContextMenuActive() {
+		t.Error("a click away from the menu left it open")
+	}
+	if len(o.Windows) != before {
+		t.Errorf("a click away from the menu fired an action: window count %d -> %d",
+			before, len(o.Windows))
+	}
+	if o.Dragging || o.Resizing {
+		t.Error("the dismissing click fell through to the layer underneath and started a gesture")
+	}
+}
+
+// ctxKey builds a KeyPressMsg for a named key, matching what msg.String() returns
+// for the keys the menu handles.
+func ctxKey(name string) tea.KeyPressMsg {
+	switch name {
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEscape}
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	default:
+		return tea.KeyPressMsg{Code: rune(name[0]), Text: name}
+	}
+}
+
+// TestContextMenuHoverTracksPointer checks moving the pointer over the menu
+// highlights the row under it, so the row that runs on a click is the row the
+// cursor is on, and that motion does not fall through to the pane underneath.
+func TestContextMenuHoverTracksPointer(t *testing.T) {
+	o := ctxOS(t)
+	o, _ = handleMouseClick(tea.MouseClickMsg{
+		X: 100, Y: 20, Button: tea.MouseRight, Mod: tea.ModShift,
+	}, o)
+	if !o.ContextMenuActive() {
+		t.Fatal("shift+right-click did not open a context menu")
+	}
+
+	cm := o.ContextMenu
+	cm.BoundsX, cm.BoundsY, cm.BoundsW, cm.BoundsH = 40, 10, 24, 12
+	cm.FirstRowY, cm.ItemH = 13, 1
+
+	// Find a runnable row that is not the one already selected.
+	target := -1
+	for i, it := range cm.Items {
+		if !it.Sep && !it.Dim && i != cm.Selected {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		t.Skip("menu has only one runnable row")
+	}
+
+	o, _ = handleMouseMotion(tea.MouseMotionMsg{X: cm.BoundsX + 3, Y: cm.FirstRowY + target}, o)
+	if o.ContextMenu.Selected != target {
+		t.Errorf("hovering row %d left the selection on %d", target, o.ContextMenu.Selected)
+	}
+
+	// Hovering the menu's chrome must not move the selection off a real row.
+	o, _ = handleMouseMotion(tea.MouseMotionMsg{X: cm.BoundsX + 3, Y: cm.BoundsY}, o)
+	if o.ContextMenu.Selected != target {
+		t.Errorf("hovering the menu chrome moved the selection to %d", o.ContextMenu.Selected)
+	}
+}

--- a/internal/input/handler.go
+++ b/internal/input/handler.go
@@ -217,6 +217,14 @@ func HandleKeyPress(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return o, nil
 	}
 
+	// An open context menu owns the keyboard until it is dismissed. It is
+	// checked before the mode split so it is navigable from terminal mode too:
+	// the menu can be opened there, and arrow keys meant for it must not be
+	// forwarded to the shell underneath.
+	if o.ContextMenuActive() {
+		return handleContextMenuKey(msg, o)
+	}
+
 	// Terminal-mode keystrokes are recorded at the point they are actually
 	// forwarded to the PTY (see recordTerminalKey in HandleTerminalModeKey), not
 	// here: recording before prefix/overlay routing captured prefix chords,

--- a/internal/input/mouse_click.go
+++ b/internal/input/mouse_click.go
@@ -18,6 +18,24 @@ func handleMouseClick(msg tea.MouseClickMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	X := mouse.X
 	Y := mouse.Y
 
+	// An open context menu is modal to the mouse: it either runs the row that
+	// was clicked or, for a click anywhere else, closes without running
+	// anything. Either way the click stops here, so it cannot also focus a pane
+	// or start a drag underneath the menu.
+	if o.ContextMenuActive() {
+		if action, consumed := o.ContextMenuClick(X, Y); consumed {
+			return runContextMenuAction(action, o)
+		}
+	}
+
+	// Shift+right-click opens the context menu for whatever is under the
+	// pointer. Plain right-click is already a window resize, and shift is free
+	// on click, so the menu is added without taking anything away.
+	if msg.Button == tea.MouseRight && msg.Mod&tea.ModShift != 0 {
+		o.OpenContextMenu(X, Y)
+		return o, nil
+	}
+
 	// Floating overlay panels (help, settings, palette, theme picker) consume
 	// clicks before they can reach the window layer: select a tab/row/control,
 	// grab the title bar or right-drag to move, or click away to dismiss.

--- a/internal/input/mouse_motion.go
+++ b/internal/input/mouse_motion.go
@@ -18,6 +18,15 @@ func handleMouseMotion(msg tea.MouseMotionMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	o.LastMouseX = mouse.X
 	o.LastMouseY = mouse.Y
 
+	// An open context menu tracks the pointer, so the row that would run on a
+	// click is the row the cursor is on. It also stops here rather than falling
+	// through: the pane underneath is behind a modal menu and has no business
+	// seeing motion over it.
+	if o.ContextMenuActive() {
+		o.ContextMenuHover(mouse.X, mouse.Y)
+		return o, nil
+	}
+
 	// Drag an overlay panel that was grabbed by its title bar / right-click.
 	if o.OverlayMouseMotion(mouse.X, mouse.Y) {
 		return o, nil


### PR DESCRIPTION
Right-click a pane, its title bar, the dock or empty desktop with shift held, and get a short menu of the actions that make sense there. Modelled on the pattern in yeetui.

## What is on each menu

| Target | Rows |
| --- | --- |
| Pane content | Copy selection, Paste, split right, split down, Zoom, Close pane |
| Pane title bar | Rename, Zoom, Minimize, Close pane |
| Dock entry | Restore, Restore all |
| Dock background | New window, Toggle tiling, Restore all |
| Empty desktop | New window, Toggle tiling, Command palette, Settings, Help |

Move-to-workspace was deliberately left off: the only action available is `move_and_follow_N`, which would mean nine rows or a submenu, and a context menu that needs scrolling has stopped being one.

## Nothing is duplicated from the keybindings

Rows carry an action ID and nothing else, no closures. `internal/app` resolves each hint through `KeybindRegistry.GetKeys`, prepending the leader for `prefix_*` actions and the sub-prefix key for two-level chords. `internal/input` hands the ID to `GetDispatcher().Dispatch`, the same call the keyboard handler makes.

This matters because the audit found tuios already shipping the opposite: the which-key popup renders a hand-written table rather than the registry that dispatches, so rebinding a key silently desyncs the on-screen documentation. Zellij had that exact bug and fixed it four years ago. Guards here: every row's action must exist in both the dispatcher and `ActionDescriptions`, and rebinding `new_window` to `ctrl+t` must change what the menu shows. A negative control that replaces the hints with a hand-written table fails eight assertions.

## A missing action this needed

`copy_selection` did not exist. `validation.go` listed it among the valid action names, nothing ever registered it, and `mouse_release.go` has always told users "Press 'c' to copy" with nothing listening. It is registered now and bound to the free `c`, reading the already-stored selection so it does not touch extraction.

## Existing right-click is untouched

Right-click was already taken twice: on a pane it starts a corner resize, and on a floating overlay it grabs the panel to drag. Both still work. The menu is on the shift chord precisely so it takes nothing away, and `TestPlainRightClickStillResizes` asserts a plain right-click resizes and opens no menu.

## Behaviour

Arrows or `j`/`k` move, `Enter` runs, `Esc` closes, and a click anywhere else closes without running anything. An action with nothing to act on right now, such as copy with no selection or split with tiling off, is drawn greyed and **skipped by the arrow keys**, so the menu keeps the same shape whether or not the action is available and you still learn the action exists.

An open menu is modal to the mouse: clicks and motion stop at the menu rather than reaching the pane underneath.

## What looking at renders changed

1. **Pane menus were titled "Pane" rather than the window's name.** I had used the terminal-reported title; the real precedence is the custom name, then a non-default title.
2. **The menu never drew over a zoomed pane**, because a lone fullscreen window takes a fast path that skips the compositor.
3. **Two bugs in my own tests, which only looking caught.** A new window floats rather than filling the screen, so "inside the pane" coordinates were landing on the desktop; and the dock row is full of multi-byte powerline glyphs, so a byte offset is not a column and the dock-entry click was hitting the dock background. Both would have produced a green suite testing the wrong thing.
4. The dimmed-row test now walks a full lap and wraps past the dimmed rows, since merely starting below them would pass while an arrow could still land on one.

Captured and inspected: every target, all three screen corners at 60x20, a 34-column width, over a zoomed pane, and a dock entry whose hint correctly reads `shift+1`.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module (148 s). Three negative controls, each failing the intended tests: dimmed rows made selectable, hints replaced with a hand-written table, and the keyboard hook removed.

Rebased onto the mouse work in #106; the two touch the same dispatch entry points and compose cleanly, with the menu consuming events before selection logic runs. Verified by running both feature sets' tests together.