### PR TITLE
Make the context menu track the pointer, and make a pane one target

### DIFF
--- a/cmd/tuios/run.go
+++ b/cmd/tuios/run.go
@@ -112,6 +112,14 @@ func filterMouseMotion(model tea.Model, msg tea.Msg) tea.Msg {
 		return msg
 	}
 
+	// An open context menu highlights the row under the pointer, which it can
+	// only do if it is told the pointer moved. This filter is a whitelist that
+	// drops every motion event it does not recognise, so a hover handler added
+	// anywhere downstream is dead until the event is allowed through here.
+	if os.ContextMenuActive() {
+		return msg
+	}
+
 	// Allow motion events while a floating overlay panel is being dragged.
 	// Overlay drags don't set os.Dragging, so without this the motion events
 	// that move the panel are filtered out and the drag never tracks.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -344,17 +344,21 @@ the menu shows.
 
 | Target | Offers |
 |--------|--------|
-| Pane content | Copy selection, paste, split right, split down, zoom, close |
-| Pane title bar | Rename, zoom, minimize, close |
+| A pane, anywhere on it | Copy selection, paste, split right, split down, rename, zoom, minimize, close |
 | Dock entry | Restore that window, restore all |
 | Dock background | New window, toggle tiling, restore all |
 | Empty desktop | New window, toggle tiling, command palette, settings, help |
 
-Arrow keys or `j`/`k` move the selection, `Enter` runs it, `Esc` closes. Clicking
-away from the menu closes it without running anything. An action that has
-nothing to act on right now (copy with no selection, split with tiling off) is
-shown greyed out and is skipped by the arrow keys, so the menu keeps the same
-shape whether or not the action is available.
+A pane is one target. Its border rows are part of it, so the whole surface of a
+pane opens the same menu and there is nothing to aim at.
+
+Arrow keys or `j`/`k` move the selection, `Enter` runs it, `Esc` closes. Moving
+the pointer over the menu highlights the row under it. Clicking away from the
+menu closes it without running anything. An action that has nothing to act on
+right now (copy with no selection, split with tiling off) is shown greyed out
+and is skipped by the arrow keys, so the menu keeps the same shape whether or
+not the action is available. On a screen too short to show every row, the menu
+scrolls with the selection rather than drawing past the bottom edge.
 
 Plain right-click still resizes a window; the menu is on the shift chord so it
 takes nothing away.

--- a/e2e/tui/context_menu_test.go
+++ b/e2e/tui/context_menu_test.go
@@ -1,6 +1,7 @@
 package tuie2e
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -84,27 +85,27 @@ func TestContextMenuTargets(t *testing.T) {
 	waitWindowCount(t, term, 1, "after first window")
 	// A new window floats at a size the layout picks, so tile it: a single tiled
 	// window fills the usable area, which makes "inside the pane" and "on its
-	// title bar" fixed coordinates rather than a guess.
+	// top border row" fixed coordinates rather than a guess.
 	enableTiling(t, term)
 
-	// The pane's first row is its title bar; a row well inside it is content.
 	shiftRightClick(t, term, 20, 10)
-	waitMenu(t, term, "pane content", "Split right", "Copy selection")
+	waitMenu(t, term, "pane", "Split right", "Copy selection", "Rename")
 	if strings.Contains(term.Screen().Text(), "Command palette") {
-		t.Fatalf("the pane content menu is showing desktop rows\n%s", term.Snapshot())
+		t.Fatalf("the pane menu is showing desktop rows\n%s", term.Snapshot())
 	}
 	leftClick(t, term, 70, 30) // click away
-	waitMenuGone(t, term, "Split right", "after click-away on content menu")
+	waitMenuGone(t, term, "Split right", "after click-away on the pane menu")
 
+	// The pane's top border row is part of the pane and opens the same menu.
+	// There is no separate title-bar target: it was one row tall and sat on the
+	// opposite edge from the window's name, so it was a target users could not
+	// reliably hit.
 	shiftRightClick(t, term, 20, 0)
-	waitMenu(t, term, "pane title", "Rename", "Minimize")
-	if strings.Contains(term.Screen().Text(), "Split right") {
-		t.Fatalf("the title bar menu is showing content rows\n%s", term.Snapshot())
-	}
+	waitMenu(t, term, "pane top row", "Split right", "Rename", "Minimize")
 	if err := term.SendKeys(tuitest.Esc); err != nil {
 		t.Fatalf("esc: %v", err)
 	}
-	waitMenuGone(t, term, "Minimize", "after esc on title menu")
+	waitMenuGone(t, term, "Minimize", "after esc on the pane menu")
 
 	// The dock band is the last row.
 	_, rows := term.Screen().Size()
@@ -163,10 +164,13 @@ func TestContextMenuArrowsSkipDimmedRows(t *testing.T) {
 	enableTiling(t, term)
 
 	shiftRightClick(t, term, 20, 10)
-	waitMenu(t, term, "pane content", "Copy selection", "Split right", "Zoom")
+	waitMenu(t, term, "pane", "Copy selection", "Split right", "Zoom")
 
 	// One full lap of the runnable rows, ending back where it started.
-	lap := []string{"Split right", "Split down", "Zoom", "Close pane", "Split right"}
+	lap := []string{
+		"Split right", "Split down", "Rename", "Zoom", "Minimize", "Close pane",
+		"Split right",
+	}
 	for i, want := range lap {
 		if err := term.WaitFor(func(s tuitest.Screen) bool {
 			return strings.Contains(markedRow(s), want)
@@ -373,4 +377,141 @@ func renameFocused(t *testing.T, term *tuitest.Terminal, name string) {
 	if err := term.WaitForText(name, uiTimeout); err != nil {
 		t.Fatalf("window never took the name %q: %v\n%s", name, err, term.Snapshot())
 	}
+}
+
+// moveMouse sends a bare pointer motion: the mouse moving with no button held,
+// which is what hovering a menu actually produces.
+//
+// The report is written out rather than built with tuitest.MouseEvent because
+// the pinned harness has no "no button" constant, and its zero value encodes
+// button one, which is a drag. SGR button code 35 is the low two bits set to 3
+// ("no button") plus the motion bit (32), and the trailing M is a press-or-motion
+// report. Sending a drag here would still reach the handler, but it would not be
+// the event a hovering user generates.
+func moveMouse(t *testing.T, term *tuitest.Terminal, x, y int) {
+	t.Helper()
+	if err := term.SendKeys(fmt.Sprintf("\x1b[<35;%d;%dM", x+1, y+1)); err != nil {
+		t.Fatalf("mouse move to (%d,%d): %v", x, y, err)
+	}
+}
+
+// TestContextMenuHoverFollowsPointer drives hover through the real binary.
+//
+// This has to be an end-to-end test. The program installs a mouse-motion filter
+// (filterMouseMotion in cmd/tuios/run.go) as a bubbletea option, and that filter
+// is a whitelist: it drops every motion event that does not match one of a
+// handful of conditions. The filter exists only in the assembled program, so a
+// unit test of the motion handler passes whether or not the event can ever reach
+// it. The context menu's hover shipped broken for exactly that reason.
+//
+// The assertion is on the selection marker, which is the only thing on screen
+// that says which row enter would run.
+func TestContextMenuHoverFollowsPointer(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+
+	shiftRightClick(t, term, 40, 15)
+	waitMenu(t, term, "desktop", "New window", "Command palette")
+
+	// The menu opens with its first runnable row selected.
+	if got := markedRow(term.Screen()); !strings.Contains(got, "New window") {
+		t.Fatalf("menu opened with the marker on %q, want New window\n%s", got, term.Snapshot())
+	}
+
+	// Find the screen row holding a row further down the menu, then move the
+	// pointer onto it. Reading the row off the screen keeps the test honest
+	// about where the menu actually landed.
+	target := "Command palette"
+	row := rowContaining(term.Screen(), target)
+	if row < 0 {
+		t.Fatalf("%q is not on screen\n%s", target, term.Snapshot())
+	}
+
+	moveMouse(t, term, 42, row)
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return strings.Contains(markedRow(s), target)
+	}, uiTimeout); err != nil {
+		t.Fatalf("hovering row %d (%q) never moved the selection marker, which is still on %q. "+
+			"The motion event is most likely being dropped by filterMouseMotion in "+
+			"cmd/tuios/run.go before it reaches the handler: %v\n%s",
+			row, target, markedRow(term.Screen()), err, term.Snapshot())
+	}
+
+	// Moving back up tracks too, so this is following the pointer rather than
+	// latching onto the last row it saw.
+	back := rowContaining(term.Screen(), "Toggle tiling")
+	if back < 0 {
+		t.Fatalf("Toggle tiling is not on screen\n%s", term.Snapshot())
+	}
+	moveMouse(t, term, 42, back)
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return strings.Contains(markedRow(s), "Toggle tiling")
+	}, uiTimeout); err != nil {
+		t.Fatalf("hovering back up the menu did not move the marker (still on %q): %v\n%s",
+			markedRow(term.Screen()), err, term.Snapshot())
+	}
+
+	alive(t, term, "after hovering the context menu")
+}
+
+// rowContaining returns the screen row holding the given text, or -1.
+func rowContaining(s tuitest.Screen, text string) int {
+	_, rows := s.Size()
+	for r := range rows {
+		if strings.Contains(s.Line(r), text) {
+			return r
+		}
+	}
+	return -1
+}
+
+// TestContextMenuReachesTopWindowRowWithTopDock is the regression test for the
+// defect that made a pane unreachable at the top of the screen.
+//
+// With the dock at the top, the layout starts below it, so the topmost window's
+// first row is the row immediately after the dock. The dock band test used to be
+// inclusive of that row, so every shift+right-click on it opened the dock's menu
+// and the window under the pointer was never consulted.
+//
+// This test does not use the shared window-count helpers: they read the dock's
+// status field off the bottom rows, which is not where the dock is here.
+func TestContextMenuReachesTopWindowRowWithTopDock(t *testing.T) {
+	term, _ := start(t, startOpts{args: []string{"--dockbar-position", "top"}})
+	waitBoot(t, term)
+
+	if err := term.SendKeys("n"); err != nil {
+		t.Fatalf("new window: %v", err)
+	}
+	if err := term.SendKeys("t"); err != nil {
+		t.Fatalf("tile: %v", err)
+	}
+	// Wait for the tiled window's own frame rather than for a window count.
+	if err := term.WaitForText("Tiling Mode Enabled", uiTimeout); err != nil {
+		t.Fatalf("tiling never turned on: %v\n%s", err, term.Snapshot())
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// Find the window's top border: the first row below the dock's separator
+	// rule that carries a box-drawing corner.
+	top := -1
+	_, rows := term.Screen().Size()
+	for r := range rows {
+		if strings.Contains(term.Screen().Line(r), "╭") {
+			top = r
+			break
+		}
+	}
+	if top < 0 {
+		t.Fatalf("could not find the tiled window's top border\n%s", term.Snapshot())
+	}
+
+	shiftRightClick(t, term, 30, top)
+	waitMenu(t, term, "top window row under a top dock", "Split right", "Rename")
+
+	if strings.Contains(term.Screen().Text(), "Toggle tiling") {
+		t.Fatalf("row %d is the top window's first row but it opened the dock's menu; "+
+			"the dock band is claiming a row the dock does not draw on\n%s",
+			top, term.Snapshot())
+	}
+	alive(t, term, "after opening the pane menu on the top window row")
 }

--- a/internal/app/contextmenu.go
+++ b/internal/app/contextmenu.go
@@ -11,13 +11,23 @@ import (
 // the menu opens and the item list is built from it.
 type ContextMenuTarget int
 
+// A pane is one target, not two.
+//
+// There was briefly a separate target for a pane's title row. It was a bad
+// target twice over. It was one row tall, and it was the top border, which is
+// not the row a user reads as the title bar: appearance.window_title_position
+// defaults to "bottom", so the window's name is drawn on the opposite edge from
+// the row that opened the menu. Aiming at the name got the content menu and
+// aiming at the name's opposite edge got the title menu.
+//
+// Every action it offered now lives on the pane menu, which the whole surface
+// of a pane opens, title row included. A second target that is hard to hit and
+// offers nothing unique is worse than not having one.
 const (
 	// CtxTargetDesktop is empty space with no pane under it.
 	CtxTargetDesktop ContextMenuTarget = iota
-	// CtxTargetPaneContent is the inside of a pane, below its title row.
-	CtxTargetPaneContent
-	// CtxTargetPaneTitle is a pane's title row.
-	CtxTargetPaneTitle
+	// CtxTargetPane is anywhere on a pane, its border rows included.
+	CtxTargetPane
 	// CtxTargetDock is the dock bar away from any of its entries.
 	CtxTargetDock
 	// CtxTargetDockItem is one minimized-window entry in the dock.
@@ -76,6 +86,13 @@ type ContextMenu struct {
 	BoundsH   int
 	FirstRowY int
 	ItemH     int
+
+	// Scroll is the first item shown when the menu has more rows than the screen
+	// has room for. ScrollFrom is what the last frame actually drew from, and is
+	// what hit-testing maps against: a click has to resolve against the rows the
+	// user can see, not against a scroll offset that may have moved since.
+	Scroll     int
+	ScrollFrom int
 }
 
 // selectable reports whether row i can be highlighted and run.
@@ -115,7 +132,9 @@ func (cm *ContextMenu) HitTest(x, y int) int {
 	if cm.ItemH <= 0 {
 		return -1
 	}
-	idx := (y - cm.FirstRowY) / cm.ItemH
+	// The first drawn row is item ScrollFrom, not item zero, whenever the menu
+	// is taller than the screen and has scrolled.
+	idx := cm.ScrollFrom + (y-cm.FirstRowY)/cm.ItemH
 	if y < cm.FirstRowY || idx < 0 || idx >= len(cm.Items) {
 		return -1
 	}

--- a/internal/app/contextmenu_build.go
+++ b/internal/app/contextmenu_build.go
@@ -36,7 +36,7 @@ const (
 func (m *OS) OpenContextMenu(x, y int) {
 	target, windowIndex := m.contextMenuTargetAt(x, y)
 
-	if target == CtxTargetPaneContent || target == CtxTargetPaneTitle {
+	if target == CtxTargetPane {
 		m.FocusWindow(windowIndex)
 	}
 
@@ -50,10 +50,8 @@ func (m *OS) OpenContextMenu(x, y int) {
 	}
 
 	switch target {
-	case CtxTargetPaneContent:
-		cm.Title, cm.Items = m.paneContentMenu(windowIndex)
-	case CtxTargetPaneTitle:
-		cm.Title, cm.Items = m.paneTitleMenu(windowIndex)
+	case CtxTargetPane:
+		cm.Title, cm.Items = m.paneMenu(windowIndex)
 	case CtxTargetDockItem:
 		cm.Title, cm.Items = m.dockItemMenu(windowIndex)
 	case CtxTargetDock:
@@ -84,31 +82,28 @@ func (m *OS) contextMenuTargetAt(x, y int) (ContextMenuTarget, int) {
 		return CtxTargetDock, -1
 	}
 
-	idx := m.WindowAt(x, y)
-	if idx < 0 {
-		return CtxTargetDesktop, -1
+	// Anywhere on a pane, border rows included, opens that pane's menu. The
+	// title row is not a target of its own; see the note on the target
+	// constants.
+	if idx := m.WindowAt(x, y); idx >= 0 {
+		return CtxTargetPane, idx
 	}
-
-	// The window's first row is its title bar: it carries the name and the
-	// close/minimize buttons, and it is the row the existing click handling
-	// treats as chrome. A pane drawn without a border has no such row, and all
-	// of it is content.
-	win := m.Windows[idx]
-	if win.BorderOffset() > 0 && y == win.Y {
-		return CtxTargetPaneTitle, idx
-	}
-	return CtxTargetPaneContent, idx
+	return CtxTargetDesktop, -1
 }
 
-// inDockBand reports whether a screen row falls in the reserved dock band. It
-// mirrors the test the click handler uses so the two cannot disagree about
-// where the dock starts.
+// inDockBand reports whether a screen row falls in the reserved dock band.
+//
+// A dock of DockHeight rows at the top of the screen occupies rows 0 to
+// DockHeight-1, so the test is exclusive. Writing it inclusive, as the click
+// handler in internal/input still does, claims one row more than the dock draws
+// on: with the dock at the top that extra row is the first row of the topmost
+// window, which is how the pane menu came to be unreachable there.
 func (m *OS) inDockBand(y int) bool {
 	switch config.DockbarPosition {
 	case "hidden":
 		return false
 	case "top":
-		return y <= config.DockHeight
+		return y < config.DockHeight
 	default:
 		return y >= m.Height-config.DockHeight
 	}
@@ -203,9 +198,14 @@ func (m *OS) item(icon, label, action string, dim bool) ContextMenuItem {
 // separator is a divider row.
 func separator() ContextMenuItem { return ContextMenuItem{Sep: true} }
 
-// paneContentMenu is the menu for the inside of a pane: what you can do with
-// what is in it, and how to divide it.
-func (m *OS) paneContentMenu(windowIndex int) (string, []ContextMenuItem) {
+// paneMenu is the menu for a pane, opened from anywhere on it, border rows
+// included: what you can do with what is inside it, how to divide it, and what
+// to do with the pane itself.
+//
+// This is deliberately one menu rather than a content menu and a title-bar
+// menu. See the note on the target constants for why the title row stopped
+// being a target of its own.
+func (m *OS) paneMenu(windowIndex int) (string, []ContextMenuItem) {
 	win := m.GetFocusedWindow()
 
 	hasSelection := win != nil && win.SelectedText != ""
@@ -214,6 +214,9 @@ func (m *OS) paneContentMenu(windowIndex int) (string, []ContextMenuItem) {
 	// look live and do nothing.
 	canPaste := m.Mode == TerminalMode
 	canSplit := m.AutoTiling
+	// Renaming is refused outright when titles are hidden, since there would be
+	// nowhere for the new name to show up.
+	canRename := config.WindowTitlePosition != "hidden"
 
 	closeItem := m.item(glyphClose, "Close pane", "close_window", false)
 	closeItem.Warn = true
@@ -225,24 +228,9 @@ func (m *OS) paneContentMenu(windowIndex int) (string, []ContextMenuItem) {
 		m.item(glyphSplitV, "Split right", "split_vertical", !canSplit),
 		m.item(glyphSplitH, "Split down", "split_horizontal", !canSplit),
 		separator(),
-		m.item(glyphZoom, "Zoom", "toggle_zoom", false),
-		closeItem,
-	}
-}
-
-// paneTitleMenu is the menu for a pane's title bar: the pane as an object,
-// rather than what is running inside it.
-func (m *OS) paneTitleMenu(windowIndex int) (string, []ContextMenuItem) {
-	title := contextMenuWindowName(m, windowIndex, "Pane")
-
-	closeItem := m.item(glyphClose, "Close pane", "close_window", false)
-	closeItem.Warn = true
-
-	return title, []ContextMenuItem{
-		m.item(glyphRename, "Rename", "rename_window", config.WindowTitlePosition == "hidden"),
+		m.item(glyphRename, "Rename", "rename_window", !canRename),
 		m.item(glyphZoom, "Zoom", "toggle_zoom", false),
 		m.item(glyphMinimize, "Minimize", "minimize_window", false),
-		separator(),
 		closeItem,
 	}
 }

--- a/internal/app/contextmenu_test.go
+++ b/internal/app/contextmenu_test.go
@@ -33,8 +33,8 @@ func ctxAnchors(m *OS, w, h int) []struct {
 		name string
 		x, y int
 	}{
-		{"pane-title", 2, 0},
-		{"pane-content", 2, 2},
+		{"pane-top-row", 2, 0},
+		{"pane-inside", 2, 2},
 		{"desktop", w - 2, h / 2},
 		{"dock", 1, h - 1},
 		{"top-left", 0, 0},
@@ -429,8 +429,10 @@ func TestContextMenuTargetResolution(t *testing.T) {
 		x, y int
 		want ContextMenuTarget
 	}{
-		{"inside the pane", win.X + 2, win.Y + 3, CtxTargetPaneContent},
-		{"the pane's title row", win.X + 2, win.Y, CtxTargetPaneTitle},
+		{"inside the pane", win.X + 2, win.Y + 3, CtxTargetPane},
+		// The pane's border rows are part of the pane, not targets of their own.
+		{"the pane's top row", win.X + 2, win.Y, CtxTargetPane},
+		{"the pane's bottom row", win.X + 2, win.Y + win.Height - 1, CtxTargetPane},
 		{"empty space right of the pane", win.X + win.Width + 5, 10, CtxTargetDesktop},
 		{"the dock band", 1, 39, CtxTargetDock},
 	}
@@ -439,6 +441,44 @@ func TestContextMenuTargetResolution(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("%s: (%d,%d) resolved to target %d, want %d", tc.name, tc.x, tc.y, got, tc.want)
 		}
+	}
+}
+
+// TestContextMenuDockBandExcludesTopWindowRow is the regression test for the
+// defect that made a pane unreachable at the top of the screen.
+//
+// A dock of DockHeight rows at the top of the screen occupies rows 0 to
+// DockHeight-1. The band test used to be inclusive, so it also claimed row
+// DockHeight, which is exactly where the topmost window starts when the dock
+// pushes the layout down. Every shift+right-click on that row opened the dock's
+// menu, and the window under the pointer was never consulted.
+func TestContextMenuDockBandExcludesTopWindowRow(t *testing.T) {
+	oldPos := config.DockbarPosition
+	defer func() { config.DockbarPosition = oldPos }()
+	config.DockbarPosition = "top"
+
+	m := newNarrowOS(t, 120, 40)
+	// With the dock at the top the layout starts below it, so the window's first
+	// row is row DockHeight.
+	top := config.DockHeight
+	m.Windows = []*terminal.Window{
+		{ID: "a", CustomName: "editor", X: 0, Y: top, Width: 60, Height: 20, Workspace: 1},
+	}
+	m.CurrentWorkspace, m.FocusedWindow = 1, 0
+
+	for y := range config.DockHeight {
+		if !m.inDockBand(y) {
+			t.Errorf("row %d is drawn on by a %d-row top dock but is not in the dock band",
+				y, config.DockHeight)
+		}
+	}
+	if m.inDockBand(top) {
+		t.Errorf("row %d is the first row of the topmost window, but the dock band claims it; "+
+			"the pane is unreachable there", top)
+	}
+	if got, idx := m.contextMenuTargetAt(2, top); got != CtxTargetPane || idx != 0 {
+		t.Errorf("the topmost window's first row resolved to target %d (window %d), want the pane (%d, window 0)",
+			got, idx, CtxTargetPane)
 	}
 }
 
@@ -497,6 +537,71 @@ func TestContextMenuDimsUnavailableActions(t *testing.T) {
 		}
 		if it.Action == "split_vertical" && it.Dim {
 			t.Error("split is dimmed even though tiling is on")
+		}
+	}
+}
+
+// TestContextMenuHitTestWhileScrolled checks a click resolves to the row the
+// user can see when the menu is taller than the screen and has scrolled.
+//
+// The rows drawn at the top of a scrolled menu are not items 0, 1, 2, so a hit
+// test that maps screen position straight to item index runs the wrong action.
+// That is a click running something the user did not point at, which is the
+// worst failure this menu has available to it.
+func TestContextMenuHitTestWhileScrolled(t *testing.T) {
+	// A screen short enough that the pane menu cannot show all its rows.
+	m := ctxMenuOS(t, 120, 12)
+	m.OpenContextMenu(2, 2) // the pane
+	cm := m.ContextMenu
+
+	if len(cm.Items) <= max(12-panelChromeRows, 1) {
+		t.Skip("the pane menu fits this screen; nothing scrolls")
+	}
+
+	// Put the selection on the last row so the view has to scroll to it. Arrow
+	// navigation wraps, so stepping a fixed number of times lands wherever the
+	// runnable rows happen to fall; this test is about the scrolled hit test,
+	// not about navigation.
+	cm.Selected = len(cm.Items) - 1
+	m.renderOverlays()
+
+	if cm.ScrollFrom == 0 {
+		t.Fatalf("the menu never scrolled: %d items on a %d-row screen", len(cm.Items), 12)
+	}
+
+	// Every visible row must hit test to the item actually drawn on it.
+	_, visible := m.contextMenuRows(cm)
+	for row := range visible {
+		want := cm.ScrollFrom + row
+		got := cm.HitTest(cm.BoundsX+3, cm.FirstRowY+row)
+		if cm.Items[want].Sep || cm.Items[want].Dim {
+			if got != -1 {
+				t.Errorf("visible row %d holds a separator or dimmed item, hit test returned %d", row, got)
+			}
+			continue
+		}
+		if got != want {
+			t.Errorf("visible row %d shows item %d (%q) but hit test returned %d",
+				row, want, cm.Items[want].Label, got)
+		}
+	}
+}
+
+// TestContextMenuScrollKeepsSelectionVisible checks arrow navigation through a
+// menu taller than the screen keeps the highlighted row on screen. A selection
+// that scrolls out of view leaves the user pressing enter on something they
+// cannot see.
+func TestContextMenuScrollKeepsSelectionVisible(t *testing.T) {
+	m := ctxMenuOS(t, 120, 12)
+	m.OpenContextMenu(2, 2)
+	cm := m.ContextMenu
+
+	for step := range len(cm.Items) * 2 {
+		m.ContextMenuMove(1)
+		start, visible := m.contextMenuRows(cm)
+		if cm.Selected < start || cm.Selected >= start+visible {
+			t.Fatalf("step %d: selection %d is outside the drawn window [%d,%d)",
+				step, cm.Selected, start, start+visible)
 		}
 	}
 }

--- a/internal/app/render_context_menu.go
+++ b/internal/app/render_context_menu.go
@@ -66,8 +66,16 @@ func (m *OS) renderContextMenu() (string, overlay.Geometry) {
 	bg := pal.Surface
 	width := m.contextMenuWidth(cm)
 
-	lines := make([]string, 0, len(cm.Items))
-	for i, it := range cm.Items {
+	// A menu with more rows than the screen is tall scrolls rather than drawing
+	// past the bottom edge. Rows are dropped from the view, never from the menu,
+	// so no action becomes unreachable: arrow navigation walks the whole list
+	// and the window follows the selection.
+	start, visible := m.contextMenuRows(cm)
+	cm.ScrollFrom = start
+
+	lines := make([]string, 0, visible)
+	for i := start; i < start+visible; i++ {
+		it := cm.Items[i]
 		if it.Sep {
 			lines = append(lines, overlay.Rule(width, bg, pal))
 			continue
@@ -81,6 +89,23 @@ func (m *OS) renderContextMenu() (string, overlay.Geometry) {
 		Body:  strings.Join(lines, "\n"),
 	}
 	return panel.Render(pal)
+}
+
+// contextMenuRows returns the first item to draw and how many fit, clamping the
+// menu's scroll offset so the selected row stays in view.
+//
+// The row budget is the screen height less the panel's own chrome. Overlays
+// that ignore this draw their lower rows past the bottom of the screen, where
+// the terminal discards them.
+func (m *OS) contextMenuRows(cm *ContextMenu) (start, visible int) {
+	count := len(cm.Items)
+	rh := m.GetRenderHeight()
+	if rh <= 0 {
+		return 0, count // size not known yet; draw the lot
+	}
+	visible = min(count, max(rh-panelChromeRows, 1))
+	cm.Scroll = scrollWindow(cm.Scroll, cm.Selected, count, visible)
+	return cm.Scroll, visible
 }
 
 // contextMenuRow renders one runnable row, filled to the panel width so the

--- a/internal/input/contextmenu_test.go
+++ b/internal/input/contextmenu_test.go
@@ -33,8 +33,8 @@ var ctxMenuAnchors = []struct {
 	name string
 	x, y int
 }{
-	{"pane content", 5, 5},
-	{"pane title", 5, 0},
+	{"pane inside", 5, 5},
+	{"pane top row", 5, 0},
 	{"desktop", 100, 20},
 	{"dock", 1, 39},
 }

--- a/internal/input/mouse_click.go
+++ b/internal/input/mouse_click.go
@@ -74,8 +74,14 @@ func handleMouseClick(msg tea.MouseClickMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return o, nil
 	}
 
-	// Check if click is in the dock area (always reserved)
-	if ((config.DockbarPosition == "bottom") && (Y >= o.Height-config.DockHeight)) || ((config.DockbarPosition == "top") && (Y <= config.DockHeight)) {
+	// Check if click is in the dock area (always reserved).
+	//
+	// The top test is exclusive for the same reason the bottom one is: a dock of
+	// DockHeight rows at the top occupies rows 0 to DockHeight-1, so an inclusive
+	// test claims one row too many, and that row is the first row of the topmost
+	// window. With a top dock and any minimized window, an ordinary click on that
+	// row was being swallowed as a dock click.
+	if ((config.DockbarPosition == "bottom") && (Y >= o.Height-config.DockHeight)) || ((config.DockbarPosition == "top") && (Y < config.DockHeight)) {
 		// Handle dock click only if there are minimized windows
 		if o.HasMinimizedWindows() {
 			dockIndex := findDockItemClicked(X, Y, o)


### PR DESCRIPTION
Three problems found by using the menus, one of which turns out not to be about menus at all.

## Hover never followed the pointer

`cmd/tuios/run.go` installs `filterMouseMotion`, a whitelist that returns `nil` for every motion event unless a drag, resize, overlay drag, scrollback browser, active selection or an app with its own mouse mode is in play. The context menu was not in it, so with a menu open every motion event was discarded before reaching the hover handler. The handler was correct; nothing ever called it.

The test for this had to drive the real binary, because the filter only exists in the program's options and any in-process test would have passed. Against the unfixed filter it fails with the marker stuck where the menu opened:

```
hovering row 21 ("Command palette") never moved the selection marker,
which is still on " New window  n  ..."
```

It now tracks in both directions, so it is following rather than latching.

## The title target was unreachable, for two separate reasons

**A shared off-by-one, not a title-specific one.** The dock-band test used `y <= DockHeight`. `DockHeight` is 2 and a top dock occupies rows 0 and 1, so the test claimed row 2 as well, which is exactly where the topmost window begins when a top dock pushes the layout down. Measured against the real binary with a top dock:

```
before:  y=0 DOCK   y=1 DOCK   y=2 DOCK   y=3 PANE
after:   y=0 DOCK   y=1 DOCK   y=2 PANE
```

Row 2 was the window's top border, so the title menu was **100% unreachable** in that configuration.

**The target was on the wrong edge.** Measured on a floating window, the title target was a single row at the top border, while `WindowTitlePosition` defaults to `"bottom"`, so the window's name renders on the *bottom* border. Anyone aiming at the name got the content menu. That is the inconsistency.

## The same off-by-one was in ordinary clicking

This is the part worth caring about beyond menus. `handleMouseClick` carries the identical inclusive test, and note the asymmetry with its own sibling:

```go
(DockbarPosition == "bottom") && (Y >= o.Height - DockHeight)   // rows 38,39: exactly two
(DockbarPosition == "top")    && (Y <= DockHeight)              // rows 0,1,2: three
```

So with the dock at the top and any window minimized, **an ordinary left-click on the topmost window's first row was handled as a dock click** and never reached the window. Fixed here too, since it is the same defect and deleting the menu target would have left it in place.

## The title target is gone

Rename and Minimize fold into the pane menu, so a pane is now one target whose whole surface, border rows included, opens one menu. Clicking the title row falls through to the pane's own menu.

Pane menu: Copy selection, Paste, split right, split down, Rename, Zoom, Minimize, Close pane.

**That surfaced a regression the existing tests caught.** Two extra rows made the menu 14 lines, which does not fit a 12-row screen, and the menu had width fitting but no height fitting at all. It now scrolls with the selection, and hit-testing maps through the scroll offset so a click runs the row actually drawn under the pointer rather than the row that would have been there unscrolled.

## Theme

Untouched, still `theme.UI()` threaded through as a palette with no hardcoded colours, confirmed in the captured renders.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module in 150 s. Four negative controls, each failing the intended test and no other: the filter fix reverted, the off-by-one restored at both unit and e2e level, and the scrolled hit-test ignoring its offset.

One note on the hover test: the pinned tuitest has no "no button" constant and its zero value encodes button one, which is a drag. The test sends the raw SGR report so it exercises a genuine bare hover.