### PR TITLE
Defer a multi-click's clipboard write until the gesture has settled

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -299,6 +299,8 @@ Controls whether releasing a mouse selection puts the text on the clipboard stra
 
 A click that never moved is not a selection and never writes to the clipboard, whatever this is set to.
 
+A drag copies the moment the button comes up. A double-click or triple-click waits about a third of a second first, because a double-click is also the beginning of a triple-click and only the finished gesture should reach the clipboard. The highlight is immediate either way; only the clipboard write waits.
+
 **Valid values:** `true`, `false`
 
 **Default:** `true`

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -320,7 +320,7 @@ Access debug and development tools:
 - **Mouse Wheel**: Scroll the pane's scrollback (when no mouse tracking, not alt screen). No mode is entered and nothing is announced; scrolling back to the bottom returns to live output, and so does typing.
 - **Left Drag in a pane**: Select text. Releasing copies it (`copy_on_select`, on by default)
 - **Double Click**: Select the word under the pointer (`word_characters` decides what a word is)
-- **Triple Click**: Select the whole line
+- **Triple Click**: Select the whole line. The highlight is immediate, but a multi-click copies about a third of a second after the last click, so a triple-click never puts the word on the clipboard on its way to the line
 - **Left Drag Above/Below a pane**: Continues the selection and scrolls
 - **Left Click**: Focus window
 - **Left Drag on the title bar**: Move window (non-tiling) or swap windows (tiling). In window management mode the whole window is a drag handle

--- a/e2e/tui/NEGATIVE_CONTROLS.md
+++ b/e2e/tui/NEGATIVE_CONTROLS.md
@@ -42,8 +42,9 @@ a working negative control look like a broken one for half an hour.
 | Blank pane: `clipWindowContent` measured width from `lines[0]` | `b9f770b` | revert `internal/app/render_helpers.go` hunk | `TestAltScreenPaneSurvivesFocusSwitch`, `TestLeftmostTileWithBlankFirstLineIsNotDiscarded` | **caught** |
 | Blank pane: a transient blank frame became the render cache | `11a0023` | neuter the `isBlankRender` guard in `cacheRender` | none | **not caught** |
 | Torn cell buffer: emulator resized without the window I/O lock | `fd1463e` | drop both `LockIO`/`UnlockIO` pairs around `Terminal.Resize` in `internal/app/session.go` | none (2 full runs) | **not caught** |
-| Mouse: the wheel announced a mode, stranded the user in it, and a drag moved the window instead of selecting | whole change | build the merge-base (`2005b01`) and point `TUIOS_E2E_BIN` at it | `TestWheelScrollShowsScrollbackWithoutAnnouncingAMode`, `TestWheelDownToBottomReturnsToLiveOutput`, `TestTypingWhileScrolledSnapsBackToLiveOutput`, `TestDragSelectionCopiesOnRelease`, `TestDoubleClickCopiesAWordAndTripleClickTheLine` | **caught** |
+| Mouse: the wheel announced a mode, stranded the user in it, and a drag moved the window instead of selecting | whole change | build the merge-base (`2005b01`) and point `TUIOS_E2E_BIN` at it | `TestWheelScrollShowsScrollbackWithoutAnnouncingAMode`, `TestWheelDownToBottomReturnsToLiveOutput`, `TestTypingWhileScrolledSnapsBackToLiveOutput`, `TestDragSelectionCopiesOnRelease`, `TestDoubleClickCopiesTheWord` | **caught** |
 | Mouse: the wheel over a pane that asked for the mouse | n/a, never broken | same binary | none, and that is correct: `TestMouseTrackingAppKeepsItsOwnWheel` passes on both, because it guards behaviour that already worked | **guard, not a control** |
+| Mouse: a triple-click wrote the word to the clipboard before the line | whole change | build `f5a6f17` (the merge of #106 and #107) and point `TUIOS_E2E_BIN` at it | `TestTripleClickCopiesTheLineExactlyOnce`, reporting `2 clipboard writes: ["/opt/dblclick/word.txt" "PREFIX /opt/dblclick/word.txt SUFFIX"]` | **caught** |
 
 ### The mouse row is a whole-change control, not a single-hunk one
 
@@ -62,6 +63,13 @@ Each failure names the old behaviour: "COPY MODE" on the dock during a scroll,
 `echo` never producing its marker because the keystrokes were eaten as vim
 motions, and an empty list of clipboard writes because a drag moved the window
 instead of selecting.
+
+The triple-click control is run the same way against `f5a6f17`. It is worth
+noting why it needed the suite's own `clickAt` helper fixed first: the helper
+used to send three presses and one trailing release, so the whole gesture
+produced a single release and the intermediate word copy never happened. The
+bug was real and the harness could not see it. `clickAt` now sends a release
+per press, which is what a mouse does.
 
 ### Why the two blank-pane and torn-buffer entries are not caught, and what does cover them
 

--- a/e2e/tui/mouse_test.go
+++ b/e2e/tui/mouse_test.go
@@ -55,22 +55,35 @@ func dragSelect(t *testing.T, term *tuitest.Terminal, fromCol, toCol, row int) {
 	send(tuitest.MouseEvent{Col: toCol, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseRelease})
 }
 
-// clickAt sends n presses and a release at one cell, fast enough to count as a
-// single multi-click gesture.
+// clickAt performs n clicks at one cell, fast enough to count as a single
+// multi-click gesture.
+//
+// Each click is a press and its own release, which is what a real triple-click
+// is and what makes the double-then-triple sequence observable at all. An
+// earlier version sent n presses and one trailing release; that produced a
+// single release for the whole gesture, so the intermediate interpretations
+// never reached the clipboard and the double-copy bug was invisible to this
+// suite.
 func clickAt(t *testing.T, term *tuitest.Terminal, col, row, n int) {
 	t.Helper()
-	for range n {
+	send := func(action tuitest.MouseAction) {
+		t.Helper()
 		if err := term.SendMouse(tuitest.MouseEvent{
-			Col: col, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MousePress,
+			Col: col, Row: row, Button: tuitest.MouseLeft, Action: action,
 		}); err != nil {
 			t.Fatalf("click: %v", err)
 		}
-		time.Sleep(40 * time.Millisecond)
 	}
-	if err := term.SendMouse(tuitest.MouseEvent{
-		Col: col, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseRelease,
-	}); err != nil {
-		t.Fatalf("release: %v", err)
+	for i := range n {
+		if i > 0 {
+			// Well inside the multi-click window, so the clicks are one
+			// gesture, and long enough apart that tuios sees them as separate
+			// events rather than one burst.
+			time.Sleep(50 * time.Millisecond)
+		}
+		send(tuitest.MousePress)
+		time.Sleep(25 * time.Millisecond)
+		send(tuitest.MouseRelease)
 	}
 }
 
@@ -401,35 +414,78 @@ func TestDragSelectionCopiesOnRelease(t *testing.T) {
 	alive(t, term, "after a drag selection")
 }
 
-// TestDoubleClickCopiesAWordAndTripleClickTheLine covers the two gestures every
-// terminal has had since the nineties and tuios had neither of.
+// clipboardSettleTime is how long to keep watching after the expected write
+// lands, so a second, wrong write arriving late is caught rather than missed.
+// It is several times the multi-click window that gates a deferred copy.
+const clipboardSettleTime = 1500 * time.Millisecond
+
+// TestDoubleClickCopiesTheWord covers one of the two gestures every terminal
+// has had since the nineties and tuios had neither of.
 //
 // The word is a path so the assertion also pins the word-character set: a
-// double-click that stopped at every punctuation mark would select "usr" and
+// double-click that stopped at every punctuation mark would select "opt" and
 // the test would say so.
-func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
+func TestDoubleClickCopiesTheWord(t *testing.T) {
 	out := &lockedBuffer{}
 	term, _ := start(t, startOpts{out: out})
-	waitBoot(t, term)
-	newWindow(t, term)
-	enterTerminalMode(t, term)
-
-	const word = "/opt/dblclick/word.txt"
-	const line = "PREFIX " + word + " SUFFIX"
-	// The word is assembled from a variable so the shell's echo of the command
-	// does not itself contain it: otherwise findText lands on the command line
-	// rather than on the output, and the test asserts about the wrong row.
-	runInShell(t, term, `P=/opt; echo "PREFIX $P/dblclick/word.txt SUFFIX"`, word, shellTimeout)
-	row, col := findText(t, term, word)
+	row, col, word, _ := setupClickTarget(t, term)
 
 	clickAt(t, term, col+6, row, 2)
 	waitForClipboard(t, term, out, word)
 
-	// Let the multi-click window lapse, or the first press of the triple
-	// continues the double and the counts come out shifted.
-	time.Sleep(800 * time.Millisecond)
+	time.Sleep(clipboardSettleTime)
+	if got := clipboardWrites(out); len(got) != 1 {
+		t.Errorf("a double-click produced %d clipboard writes, want exactly 1: %q", len(got), got)
+	}
+	alive(t, term, "after a double-click")
+}
+
+// TestTripleClickCopiesTheLineExactlyOnce is the regression test for a
+// triple-click copying twice.
+//
+// A triple-click reaches tuios as a double-click followed by a third press, and
+// copying on each release wrote the word first and the line second. The
+// clipboard ended up correct, so an assertion on the final contents passed
+// while the bug was live; what was wrong is that the word was ever written at
+// all, because a paste landing in the gap got it. Hence "exactly one write",
+// which is only assertable because the harness keeps them all.
+func TestTripleClickCopiesTheLineExactlyOnce(t *testing.T) {
+	out := &lockedBuffer{}
+	term, _ := start(t, startOpts{out: out})
+	row, col, word, line := setupClickTarget(t, term)
 
 	clickAt(t, term, col+6, row, 3)
 	waitForClipboard(t, term, out, line)
-	alive(t, term, "after multi-click selection")
+
+	time.Sleep(clipboardSettleTime)
+	got := clipboardWrites(out)
+	if len(got) != 1 {
+		t.Fatalf("a triple-click produced %d clipboard writes, want exactly 1: %q", len(got), got)
+	}
+	for _, w := range got {
+		if strings.TrimSpace(w) == word {
+			t.Errorf("the word %q reached the clipboard on the way to the line; a paste "+
+				"landing between the two writes would have got it", word)
+		}
+	}
+	alive(t, term, "after a triple-click")
+}
+
+// setupClickTarget boots a pane with one line of output and returns where it is
+// on screen along with the word and the whole line, which are what the two
+// multi-click gestures should each produce.
+func setupClickTarget(t *testing.T, term *tuitest.Terminal) (row, col int, word, line string) {
+	t.Helper()
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	word = "/opt/dblclick/word.txt"
+	line = "PREFIX " + word + " SUFFIX"
+	// The word is assembled from a variable so the shell's echo of the command
+	// does not itself contain it: otherwise findText lands on the command line
+	// rather than on the output, and the test asserts about the wrong row.
+	runInShell(t, term, `P=/opt; echo "PREFIX $P/dblclick/word.txt SUFFIX"`, word, shellTimeout)
+	row, col = findText(t, term, word)
+	return row, col, word, line
 }

--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"fmt"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// PendingCopyMsg fires when a multi-click selection's window has closed and the
+// gesture can finally be read as what it was. Seq names the gesture it belongs
+// to; a message whose sequence has been superseded is dropped.
+type PendingCopyMsg struct {
+	Seq uint64
+}
+
+// The clipboard write for a multi-click selection is deferred, because until
+// the multi-click window closes nobody knows what the gesture is.
+//
+// A triple-click arrives as a double-click followed by a third press. Copying
+// on each release wrote the word first and the line second, so every
+// triple-click clobbered the clipboard with the wrong text on the way to the
+// right one, and a paste that landed in between got the word. Waiting until no
+// further click can join the gesture means only its final reading is ever
+// written.
+//
+// Only the write waits. The highlight is applied on the press, so a
+// double-click still shows the word instantly and visibly widens to the line
+// on the third click. Deferring the feedback as well would trade one problem
+// for a laggier one.
+
+// CopyToClipboard writes text to the system clipboard now and says so. It is
+// the unambiguous path: a drag release, where the gesture ended when the button
+// came up and nothing can supersede it.
+func (m *OS) CopyToClipboard(text string) tea.Cmd {
+	if text == "" {
+		return nil
+	}
+	m.CancelPendingCopy()
+	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", config.NotificationDuration)
+	return tea.SetClipboard(text)
+}
+
+// DeferCopyToClipboard holds text back until delay has passed with no further
+// click, then writes it. A press arriving in the meantime calls
+// CancelPendingCopy and this write never happens.
+//
+// The text is captured now rather than re-read when the timer fires: it is
+// correct at this instant, and the pane may have scrolled or been closed by the
+// time the message arrives.
+func (m *OS) DeferCopyToClipboard(text string, delay time.Duration) tea.Cmd {
+	if text == "" {
+		return nil
+	}
+	m.selectionSeq++
+	m.pendingCopy = text
+	seq := m.selectionSeq
+	return tea.Tick(max(delay, time.Millisecond), func(time.Time) tea.Msg {
+		return PendingCopyMsg{Seq: seq}
+	})
+}
+
+// CancelPendingCopy discards a deferred write and makes its timer a no-op when
+// it fires. Every press calls this, so the clipboard only ever ends up holding
+// what the last completed gesture selected.
+func (m *OS) CancelPendingCopy() {
+	m.selectionSeq++
+	m.pendingCopy = ""
+}
+
+// HandlePendingCopy performs a deferred write if seq is still the current
+// gesture. A superseded sequence means a later click reinterpreted the
+// selection, and the text this timer was carrying was never what the user
+// ended up with.
+func (m *OS) HandlePendingCopy(seq uint64) tea.Cmd {
+	if seq != m.selectionSeq || m.pendingCopy == "" {
+		return nil
+	}
+	text := m.pendingCopy
+	m.pendingCopy = ""
+	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", config.NotificationDuration)
+	return tea.SetClipboard(text)
+}
+
+// PendingCopyText reports the text a deferred write is holding, for tests and
+// for anything that needs to know a gesture has not settled yet.
+func (m *OS) PendingCopyText() string { return m.pendingCopy }

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -97,6 +97,7 @@ type OS struct {
 	DraggedWindowIndex       int // Index of window being dragged
 	AutoScrollDir            int // -1 = up, 0 = none, 1 = down (for drag auto-scroll)
 	AutoScrollActive         bool
+	SelectionDragged         bool // the pointer moved during the current selection gesture
 	ScrollbarDragging        bool
 	ScrollbarDragWindowIndex int // -1 when not dragging
 	Windows                  []*terminal.Window
@@ -181,6 +182,12 @@ type OS struct {
 	QuitConfirmSelection  int                     // 0 = Yes (left), 1 = No (right)
 	// Pending resize tracking for debouncing PTY resize during mouse drag
 	PendingResizes map[string][2]int // windowID -> [width, height] of pending PTY resize
+	// pendingCopy is text a settled multi-click selection will put on the
+	// clipboard, and selectionSeq names the gesture it belongs to. See
+	// clipboard_copy.go for why the write waits.
+	pendingCopy  string
+	selectionSeq uint64
+
 	// Performance optimization caches
 	cachedSeparator      string // Cached dock separator string
 	cachedSeparatorWidth int    // Width of cached separator

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -428,6 +428,9 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		m.renderSkipped = false
 		return m, ListenForPTYData(m.PTYDataChan)
 
+	case PendingCopyMsg:
+		return m, m.HandlePendingCopy(msg.Seq)
+
 	case AutoScrollTickMsg:
 		if !m.AutoScrollActive || m.AutoScrollDir == 0 {
 			return m, nil

--- a/internal/input/mouse_click.go
+++ b/internal/input/mouse_click.go
@@ -229,6 +229,12 @@ func handleMouseClick(msg tea.MouseClickMsg, o *app.OS) (*app.OS, tea.Cmd) {
 				// nothing is announced and the dock does not change.
 				clickedWindow.EnterCopyModeImplicit()
 			}
+			// Any press retires a clipboard write that has not landed yet:
+			// this press may be the third of a triple-click, in which case
+			// the word the double-click was about to copy is not what the
+			// user is selecting.
+			o.CancelPendingCopy()
+			o.SelectionDragged = false
 			beginMouseSelection(clickedWindow.CopyMode, clickedWindow, X, Y,
 				registerClick(clickedWindow, terminalX, terminalY))
 			o.Dragging = true

--- a/internal/input/mouse_motion.go
+++ b/internal/input/mouse_motion.go
@@ -75,6 +75,12 @@ func handleMouseMotion(msg tea.MouseMotionMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	if o.Dragging && o.DraggedWindowIndex >= 0 && o.DraggedWindowIndex < len(o.Windows) {
 		draggedWindow := o.Windows[o.DraggedWindowIndex]
 		if draggedWindow.CopyMode != nil && draggedWindow.CopyMode.Active {
+			// The pointer moved with the button down, so this gesture is a
+			// drag. Its release is unambiguous and copies at once, rather than
+			// waiting out a multi-click window that no longer applies. Cell
+			// motion is only reported when the cell actually changes, so this
+			// cannot be set by a stationary press.
+			o.SelectionDragged = true
 			scrollDir := HandleCopyModeMouseMotion(draggedWindow.CopyMode, draggedWindow, mouse.X, mouse.Y)
 			o.AutoScrollDir = scrollDir
 			if scrollDir != 0 && !o.AutoScrollActive {

--- a/internal/input/mouse_multiclick_test.go
+++ b/internal/input/mouse_multiclick_test.go
@@ -1,0 +1,249 @@
+package input
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+)
+
+// A triple-click arrives as a double-click plus a third press, so copying on
+// each release wrote the word and then the line. Every triple-click clobbered
+// the clipboard with the wrong text on the way to the right one, and a paste
+// landing between the two got the word.
+//
+// The rule these tests hold to: the clipboard is written once per gesture, with
+// the gesture's final reading.
+
+// copyCount returns how many clipboard writes have been reported. Notification
+// and write are issued together and only together, so counting the messages
+// counts the writes.
+func copyCount(o *app.OS) int {
+	n := 0
+	for _, m := range notificationMessages(o) {
+		if strings.HasPrefix(m, "Copied") {
+			n++
+		}
+	}
+	return n
+}
+
+// settle runs a deferred-copy timer to completion and applies it, returning the
+// clipboard command if the gesture was still the current one. Running the tick
+// really does wait out the multi-click window, so these tests exercise the same
+// delay the user sees.
+func settle(t *testing.T, o *app.OS, cmd tea.Cmd) tea.Cmd {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg, ok := cmd().(app.PendingCopyMsg)
+	if !ok {
+		t.Fatalf("expected a deferred copy, got %T", msg)
+	}
+	return o.HandlePendingCopy(msg.Seq)
+}
+
+// TestTripleClickCopiesTheLineExactlyOnce is the regression test for the bug.
+// Exactly one, not "the last one is right": the word reaching the clipboard at
+// all is the defect, however briefly it sits there.
+func TestTripleClickCopiesTheLineExactlyOnce(t *testing.T) {
+	const line = "alpha bravo charlie"
+	o, win := selectPane(t, line)
+
+	// The double-click half of the gesture.
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	wordCopy := release(o, 6, 0)
+	if got := selectedText(win); got != "bravo" {
+		t.Fatalf("double-click selected %q, want the word: the highlight must be immediate", got)
+	}
+	if n := copyCount(o); n != 0 {
+		t.Fatalf("the double-click wrote to the clipboard %d time(s) before its window closed", n)
+	}
+
+	// The third click, arriving inside the window.
+	pressAt(o, 6, 0)
+	lineCopy := release(o, 6, 0)
+	if got := selectedText(win); got != line {
+		t.Fatalf("triple-click selected %q, want the whole line", got)
+	}
+
+	// The word's timer fires and must find itself superseded.
+	if cmd := settle(t, o, wordCopy); cmd != nil {
+		t.Error("the word was written to the clipboard even though a third click superseded it")
+	}
+	// The line's timer fires and writes.
+	if cmd := settle(t, o, lineCopy); cmd == nil {
+		t.Fatal("the line was never written to the clipboard")
+	}
+
+	if n := copyCount(o); n != 1 {
+		t.Fatalf("a triple-click produced %d clipboard writes, want exactly 1: %v",
+			n, notificationMessages(o))
+	}
+	if want := len(line); !hasNotificationPrefix(o, "Copied "+itoa(want)) {
+		t.Errorf("the surviving write is not the line (%d chars): %v", want, notificationMessages(o))
+	}
+}
+
+// A double-click that stays a double-click still copies the word, once its
+// window has closed.
+func TestDoubleClickCopiesTheWordAfterItsWindowCloses(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	cmd := release(o, 6, 0)
+
+	if got := selectedText(win); got != "bravo" {
+		t.Fatalf("selection = %q, want the word highlighted immediately", got)
+	}
+	if got := o.PendingCopyText(); got != "bravo" {
+		t.Fatalf("pending copy = %q, want the word held back until the window closes", got)
+	}
+	if n := copyCount(o); n != 0 {
+		t.Fatalf("the word was written %d time(s) before the window closed", n)
+	}
+
+	if settled := settle(t, o, cmd); settled == nil {
+		t.Fatal("the word never reached the clipboard")
+	}
+	if n := copyCount(o); n != 1 {
+		t.Errorf("a double-click produced %d clipboard writes, want 1: %v", n, notificationMessages(o))
+	}
+}
+
+// A drag has nothing to wait out: the button coming up ended it and no later
+// click can reinterpret it. Making the user wait for that would be latency for
+// nothing.
+func TestDragReleaseCopiesWithoutWaiting(t *testing.T) {
+	o, _ := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 0, 0)
+	dragTo(o, 10, 0)
+	cmd := release(o, 10, 0)
+
+	if cmd == nil {
+		t.Fatal("a drag release did not copy")
+	}
+	if _, deferred := cmd().(app.PendingCopyMsg); deferred {
+		t.Error("a drag release was deferred behind the multi-click window; only a " +
+			"multi-click can be superseded")
+	}
+	if got := o.PendingCopyText(); got != "" {
+		t.Errorf("pending copy = %q, want nothing held back after a drag", got)
+	}
+	if n := copyCount(o); n != 1 {
+		t.Errorf("a drag release produced %d clipboard writes, want 1 immediately: %v",
+			n, notificationMessages(o))
+	}
+}
+
+// Dragging out from the second click of a double-click is a common way to
+// select several words. It is a drag, so it copies at once, and what it copies
+// is what the drag ended on rather than the word the double-click started with.
+func TestDragFromTheSecondClickCopiesTheDraggedRange(t *testing.T) {
+	o, win := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	dragTo(o, 18, 0)
+	cmd := release(o, 18, 0)
+
+	if _, deferred := cmd().(app.PendingCopyMsg); deferred {
+		t.Error("a drag out of a double-click was deferred")
+	}
+	if got, want := selectedText(win), "bravo charlie"; got != want {
+		t.Errorf("selection = %q, want %q", got, want)
+	}
+	if n := copyCount(o); n != 1 {
+		t.Errorf("produced %d clipboard writes, want 1: %v", n, notificationMessages(o))
+	}
+}
+
+// The window restarts on every click, so an unhurried triple-click resolves to
+// the line rather than copying the word because the timer expired mid-gesture.
+func TestASlowTripleClickStillResolvesToTheLine(t *testing.T) {
+	const line = "alpha bravo charlie"
+	o, _ := selectPane(t, line)
+
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	wordCopy := release(o, 6, 0)
+
+	// Late, but still inside the window.
+	time.Sleep(multiClickInterval * 2 / 3)
+
+	pressAt(o, 6, 0)
+	if got := o.PendingCopyText(); got != "" {
+		t.Errorf("pending copy = %q after the third press, want it retired", got)
+	}
+	lineCopy := release(o, 6, 0)
+	if got := o.PendingCopyText(); got != line {
+		t.Fatalf("pending copy = %q, want the whole line: the third click did not land as a third click", got)
+	}
+
+	if cmd := settle(t, o, wordCopy); cmd != nil {
+		t.Error("the word was written despite the third click")
+	}
+	if cmd := settle(t, o, lineCopy); cmd == nil {
+		t.Fatal("the line was never written")
+	}
+	if n := copyCount(o); n != 1 {
+		t.Errorf("produced %d clipboard writes, want 1: %v", n, notificationMessages(o))
+	}
+}
+
+// A fourth click restarts the cycle at a one-character selection, which is not
+// something a click copies. The clipboard is therefore left holding whatever it
+// had, rather than the line from the third click, because the clipboard always
+// ends up agreeing with what is highlighted.
+func TestAFourthClickLeavesTheClipboardAlone(t *testing.T) {
+	o, _ := selectPane(t, "alpha bravo charlie")
+
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	pressAt(o, 6, 0)
+	lineCopy := release(o, 6, 0)
+
+	pressAt(o, 6, 0)
+	release(o, 6, 0)
+
+	if cmd := settle(t, o, lineCopy); cmd != nil {
+		t.Error("the line was written after a fourth click reduced the selection to one character")
+	}
+	if n := copyCount(o); n != 0 {
+		t.Errorf("four clicks produced %d clipboard writes, want none: %v", n, notificationMessages(o))
+	}
+}
+
+// The interval is no longer only a detection threshold: it is how long the user
+// waits for the clipboard after a double-click. Guarding the range keeps it from
+// drifting back up to the half second that was fine when it cost nothing.
+func TestMultiClickIntervalStaysResponsive(t *testing.T) {
+	if multiClickInterval < 250*time.Millisecond || multiClickInterval > 350*time.Millisecond {
+		t.Errorf("multiClickInterval = %v, want 250-350ms: below that a deliberate "+
+			"double-click starts being read as two singles, above it the clipboard "+
+			"visibly lags the selection", multiClickInterval)
+	}
+}
+
+// itoa keeps the assertions above readable without pulling strconv into every
+// message.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/input/mouse_select.go
+++ b/internal/input/mouse_select.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"fmt"
 	"strings"
 	"time"
 	"unicode"
@@ -14,10 +13,25 @@ import (
 )
 
 // multiClickInterval is how long after a click a second one still counts as
-// part of the same gesture. 500ms is the top of the usual 250-500ms range and
-// what Windows and macOS default to; it is generous on purpose, because the
-// cost of guessing low is a double-click that silently behaves as two singles.
-const multiClickInterval = 500 * time.Millisecond
+// part of the same gesture, and therefore how long a multi-click selection's
+// clipboard write waits before it can be trusted.
+//
+// It was 500ms, matching the Windows and macOS defaults, back when it only
+// decided how a click sequence was read. Now that it also gates the clipboard
+// it is a delay the user waits through, and half a second is past the point
+// where a response stops feeling immediate: the usual figure for that is
+// around 300ms, beyond which an interface reads as reacting rather than
+// responding.
+//
+// 300ms is chosen against both ends. Below it: measured inter-click intervals
+// for an unhurried double-click sit around 100-250ms, and xterm has shipped a
+// 250ms multiClickTime for decades without being thought broken, so 300ms
+// still admits a comfortably slow double-click. Above it: GTK and Qt both
+// default to 400ms, which would work but spends another tenth of a second on
+// every copy. The cost of being wrong is asymmetric but small either way, a
+// deliberate triple-click read as a double plus a single, and the user can see
+// what got selected before it lands.
+const multiClickInterval = 300 * time.Millisecond
 
 // multiClickSlop is how far the pointer may drift between clicks of one
 // gesture, in cells. Requiring the exact same cell reads as an intermittent
@@ -148,6 +162,11 @@ func copyModeLineCells(window *terminal.Window, absY int) []uv.Cell {
 // needs a separate keystroke to be useful. It is a setting because a stray drag
 // overwriting the clipboard is a real annoyance for some people.
 //
+// A drag writes at once: the button coming up ended the gesture and nothing can
+// reinterpret it. A multi-click waits out the rest of its window first, because
+// a double-click is also the first two thirds of a triple-click; see
+// app/clipboard_copy.go.
+//
 // Two things it deliberately does not do. It does not copy a selection that
 // never moved, so an ordinary click cannot clobber the clipboard. And it leaves
 // the highlight up rather than clearing it, so the user can see what they got;
@@ -193,8 +212,22 @@ func finishMouseSelection(o *app.OS, window *terminal.Window) tea.Cmd {
 	// Deliberately not stored on window.SelectedText: that field drives the
 	// older, coordinate-based selection highlight, whose bounds this path never
 	// sets, so filling it would paint a stray highlight at the origin.
-	o.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", config.NotificationDuration)
-	return tea.SetClipboard(text)
+	if o.SelectionDragged || window.ClickCount < 2 {
+		return o.CopyToClipboard(text)
+	}
+	return o.DeferCopyToClipboard(text, remainingClickWindow(window))
+}
+
+// remainingClickWindow is how much of the multi-click window is left, measured
+// from the last press rather than from this release.
+//
+// Anchoring it to the press is what makes the wait exactly as long as the
+// period in which another click could still join the gesture, whatever the
+// button was held for. Anchoring it to the release would add the hold time on
+// top, so a deliberate press-and-hold would sit there with a stale clipboard
+// for as long as the user leaned on the button.
+func remainingClickWindow(window *terminal.Window) time.Duration {
+	return multiClickInterval - time.Since(window.LastClickTime)
 }
 
 // endImplicitSelection drops a copy-mode session that only existed to carry a


### PR DESCRIPTION
Triple-clicking wrote the clipboard twice: the double-click landed the word, then the third click landed the line. A paste in between got the wrong text, so this is a correctness problem rather than a flicker.

## The fix

A multi-click's clipboard write is held until the multi-click window closes, and any press retires a write that has not landed yet. So a double-click that turns out to be the first two thirds of a triple-click never reaches the clipboard at all.

The text is captured at release rather than re-read when the timer fires, since it is correct at that instant and the pane may have scrolled or closed by the time the message arrives.

**The highlight stays immediate.** Only the write is deferred: the word appears instantly and visibly widens to the line on the third click. Deferring the feedback would make it feel sluggish, which is the opposite of the point.

**A drag release still copies immediately.** There is no ambiguity to wait out, since a release unambiguously ends a drag. Only multi-click gestures can be superseded. `TestDragReleaseCopiesWithoutWaiting` checks this structurally, asserting the drag path returns a command that is not a pending-copy and leaves nothing outstanding, rather than by timing.

**The timer restarts per click**, anchored to the last press rather than the release, so the wait is exactly the period in which another click could still join, however long a button was held.

## 500 ms to 300 ms

The window used to decide only *interpretation*, where being generous cost nothing. Now it is latency the user waits through before their clipboard updates, and about 300 ms is where a response stops reading as immediate.

Below that: measured inter-click intervals for an unhurried double-click sit around 100 to 250 ms, and xterm has shipped a 250 ms `multiClickTime` for decades, so 300 ms still admits a slow double-click. Above: GTK and Qt both default to 400 ms, which works but spends another tenth of a second on every copy. `TestMultiClickIntervalStaysResponsive` guards the 250 to 350 ms range so it cannot quietly drift back now that it gates the clipboard.

## The two awkward cases

**Dragging from the second click**, a common way to select several words: it is a drag, so it copies immediately, and it copies the dragged range rather than the word the double-click started with.

**A fourth click** restarts the cycle at a one-character selection, which is not something a click copies, so it retires the pending line and writes nothing, leaving the clipboard as it was. The invariant settled on is that **the clipboard always ends up agreeing with what is highlighted**; letting the line land while a single character is highlighted would be worse.

## A harness bug this surfaced

`clickAt` sent *n* presses and one trailing release, so a triple-click produced a single release and the intermediate word copy never happened. **The suite structurally could not observe this bug**, no matter how carefully the assertions were read. It now sends a release per press, which is what a mouse does.

That is why the test asserts the **count** of clipboard writes rather than the final contents. The final contents were always right, which is exactly how this survived review.

## Verification

`TestTripleClickCopiesTheLineExactlyOnce` exists at both unit and e2e level.

- e2e negative control against a binary built from the previous main: `a triple-click produced 2 clipboard writes, want exactly 1: ["/opt/dblclick/word.txt" "PREFIX /opt/dblclick/word.txt SUFFIX"]`. It also asserts the word never appears among the writes.
- Unit negative control: the same sequence counts 2 writes on old code and 0 at that instant on the fix, with the surviving one landing when the window closes.
- `TestDoubleClickCopiesTheWord` confirms a plain double-click still copies the word exactly once after the window closes, and passes on old code too, as a guard should.
- `TestASlowTripleClickStillResolvesToTheLine` sleeps two thirds of the window between clicks and still resolves to the line.

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module. Recorded in `e2e/tui/NEGATIVE_CONTROLS.md`, including why the `clickAt` fix was a prerequisite.