### PR TITLE
Gate the scrollbar on whether a pane has a border to draw it on

### DIFF
--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -251,6 +251,30 @@ func fitToContentBox(content string, w, h int) string {
 	return lipgloss.NewStyle().MaxWidth(w).MaxHeight(h).Render(content)
 }
 
+// rendersBorderless reports whether window is drawn with no border box of its
+// own, so its rectangle is guest output from edge to edge and nothing may be
+// painted on its perimeter.
+//
+// It is bare window.Tiled because that is what the geometry already says:
+// ContentWidth, ContentHeight and BorderOffset (internal/terminal) reserve
+// border cells on !Tiled alone, and Resize sizes the emulator by the same rule.
+// A renderer predicate that disagreed with those would either overflow the
+// pane's rectangle or paint over the guest's own columns.
+//
+// Tiling assigns Tiled from config.SharedBorders, so in practice a borderless
+// pane is a tiled pane under shared borders. There the lines between panes are
+// a compositor overlay (renderSeparatorOverlay) sitting in the gaps between
+// rectangles rather than chrome belonging to either neighbour, which is exactly
+// why no pane has a spare column.
+//
+// Zoom does not change this. A zoomed pane under shared borders is still
+// borderless and full-rect; the separator overlay stands down because a zoomed
+// pane has no neighbours to be separated from, so it has no border cell either.
+// windowNeedsScrollbar reads the same predicate, so the two never disagree.
+func rendersBorderless(window *terminal.Window) bool {
+	return window.Tiled
+}
+
 // renderWindowBox renders a window's content, wrapped in its border unless the
 // window is borderless. Shared by the compositor path and the fullscreen fast
 // path so both produce identical output.
@@ -259,7 +283,7 @@ func (m *OS) renderWindowBox(window *terminal.Window, index int, isFocused bool,
 		m.renderTerminal(window, isFocused, m.Mode == TerminalMode),
 		window.ContentWidth(), window.ContentHeight(),
 	)
-	if window.Tiled && (!window.Zoomed || config.SharedBorders) {
+	if rendersBorderless(window) {
 		return content
 	}
 	box := lipgloss.NewStyle().

--- a/internal/app/render_scrollbar.go
+++ b/internal/app/render_scrollbar.go
@@ -22,9 +22,16 @@ func windowNeedsScrollbar(window *terminal.Window) bool {
 	if window.Terminal == nil || window.IsAltScreen() {
 		return false
 	}
-	// Tiled-borderless windows have no border column to host the thumb without
-	// covering content, and multi-pane shared-border layouts would clutter.
-	if window.Tiled && (!window.Zoomed || config.SharedBorders) {
+	// A borderless pane has no scrollbar. This is deliberate and it has no
+	// exceptions: the thumb is drawn on the pane's right border cell, and a
+	// borderless pane has none, so the only column available is the rightmost
+	// column of the guest's own output. Shared borders is therefore a
+	// scrollbar-free mode by choice, zoomed panes included - a zoomed pane is
+	// still full-rect and still borderless, so there is no more room for a thumb
+	// there than in a two-pane split. Putting one on the separator overlay was
+	// considered and rejected: that line lies between two rectangles and belongs
+	// to neither, and shared borders is a mode chosen for a quieter screen.
+	if rendersBorderless(window) {
 		return false
 	}
 	scrollbackLen := window.ScrollbackLenSync()
@@ -42,13 +49,22 @@ func windowNeedsScrollbar(window *terminal.Window) bool {
 
 // renderScrollbarLayer creates a 1-column layer overlaying the right border
 // with a scrollbar indicator. Hidden during window manipulation, when the
-// scrollbar is disabled via config, or when the border style is "hidden"
-// (no border to overlay the thumb on).
+// scrollbar is disabled via config, when the border style is "hidden", or when
+// the pane is borderless (no border cell to overlay the thumb on).
 func renderScrollbarLayer(window *terminal.Window, borderColor color.Color, zIndex int) *lipgloss.Layer {
 	if window.IsBeingManipulated {
 		return nil
 	}
 	if config.HideScrollbar || config.BorderStyle == "hidden" {
+		return nil
+	}
+
+	// Repeated from windowNeedsScrollbar rather than left to the callers. Every
+	// call site gates on windowNeedsScrollbar today, but this function is what
+	// actually writes the cells, and the cells it would write on a borderless
+	// pane are the guest's output. A guard that only lives in the caller is one
+	// forgotten call away from painting over a user's terminal.
+	if rendersBorderless(window) {
 		return nil
 	}
 

--- a/internal/app/render_scrollbar_test.go
+++ b/internal/app/render_scrollbar_test.go
@@ -1,0 +1,223 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
+)
+
+// fillScrollback pushes enough lines through the emulator that the pane has a
+// scrollback deep enough for a thumb shorter than the viewport, which is the
+// last of windowNeedsScrollbar's arithmetic gates.
+func fillScrollback(t *testing.T, win *terminal.Window, lines int) {
+	t.Helper()
+	win.LockIO()
+	for i := range lines {
+		_, _ = win.Terminal.Write([]byte("scrollback line " + itoa(i) + "\r\n"))
+	}
+	win.UnlockIO()
+	win.MarkContentDirty()
+	if n := win.ScrollbackLenSync(); n <= 0 {
+		t.Fatalf("pane has no scrollback after %d lines: the test cannot exercise the scrollbar", lines)
+	}
+}
+
+// withSharedBorders sets config.SharedBorders for the duration of fn.
+func withSharedBorders(t *testing.T, shared bool, fn func()) {
+	t.Helper()
+	prev := config.SharedBorders
+	config.SharedBorders = shared
+	defer func() { config.SharedBorders = prev }()
+	fn()
+}
+
+// The scrollbar's whole truth table, recorded rather than inferred.
+//
+// The thumb is drawn on the pane's right border cell. Whether a pane has one is
+// decided by terminal.Window.ContentWidth/BorderOffset, which reserve border
+// cells on !Tiled alone - so a Tiled pane's rectangle is guest output from edge
+// to edge and there is no cell a thumb could take that is not the user's own
+// terminal content. Tiling assigns Tiled from config.SharedBorders, which makes
+// shared borders a deliberately scrollbar-free mode.
+//
+// Zoom is the case this pins hardest, because it is the one that reads like an
+// exception and is not: a zoomed pane under shared borders is still borderless
+// and still full-rect (renderSeparatorOverlay stands down for a zoomed pane
+// rather than drawing it a frame), so it gets no thumb either. Without shared
+// borders a tiled pane is Tiled=false and carries its own border box, zoomed or
+// not, so the thumb has a real cell to sit on.
+func TestWindowNeedsScrollbarTruthTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		tiled  bool
+		zoomed bool
+		shared bool
+		want   bool
+	}{
+		{"floating pane", false, false, false, true},
+		{"floating pane, shared borders on", false, false, true, true},
+		{"bordered tiled pane", false, false, false, true},
+		{"bordered tiled pane zoomed", false, true, false, true},
+		{"borderless pane", true, false, true, false},
+		// The reported case: zoom under shared borders stays borderless, so it
+		// stays scrollbar-free. Not an oversight, and not a special case either.
+		{"borderless pane zoomed", true, true, true, false},
+		// Only reachable transiently, while a shared-borders toggle has landed
+		// but the retile that resets Tiled has not. Borderless is borderless:
+		// what decides is the flag the geometry uses, not the config setting.
+		{"borderless pane zoomed, shared borders off", true, true, false, false},
+		{"borderless pane, shared borders off", true, false, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			win := newTestWindow(t, "sbtt-"+strings.ReplaceAll(tc.name, " ", "-"), 60, 20)
+			fillScrollback(t, win, 200)
+			win.Tiled = tc.tiled
+			win.Zoomed = tc.zoomed
+
+			withSharedBorders(t, tc.shared, func() {
+				if got := windowNeedsScrollbar(win); got != tc.want {
+					t.Errorf("windowNeedsScrollbar = %v, want %v (tiled=%v zoomed=%v shared=%v)",
+						got, tc.want, tc.tiled, tc.zoomed, tc.shared)
+				}
+			})
+		})
+	}
+}
+
+// windowNeedsScrollbar is consulted by four render paths (compositor cached,
+// sync-hold, redraw, fullscreen fast path) to decide whether a thumb exists,
+// while renderScrollbarLayer is what actually draws it. If the two ever
+// disagree, the layout believes something the screen does not show, or the
+// layer paints where the layout left no room. Pin that they agree on every row
+// of the table above, plus the config gates.
+func TestScrollbarLayerAgreesWithWindowNeedsScrollbar(t *testing.T) {
+	type variant struct {
+		name           string
+		tiled, zoomed  bool
+		shared, hide   bool
+		borderStyle    string
+		altScreen      bool
+		emptyScrollbck bool
+	}
+	variants := []variant{
+		{name: "bordered pane"},
+		{name: "borderless pane", tiled: true, shared: true},
+		{name: "borderless pane zoomed", tiled: true, zoomed: true, shared: true},
+		{name: "bordered pane zoomed", zoomed: true},
+		{name: "scrollbar disabled", hide: true},
+		{name: "borders hidden", borderStyle: "hidden"},
+		{name: "no scrollback", emptyScrollbck: true},
+	}
+
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			win := newTestWindow(t, "sbagree-"+strings.ReplaceAll(v.name, " ", "-"), 60, 20)
+			if !v.emptyScrollbck {
+				fillScrollback(t, win, 200)
+			}
+			win.Tiled = v.tiled
+			win.Zoomed = v.zoomed
+
+			prevHide, prevStyle := config.HideScrollbar, config.BorderStyle
+			config.HideScrollbar = v.hide
+			if v.borderStyle != "" {
+				config.BorderStyle = v.borderStyle
+			}
+			t.Cleanup(func() {
+				config.HideScrollbar, config.BorderStyle = prevHide, prevStyle
+			})
+
+			withSharedBorders(t, v.shared, func() {
+				need := windowNeedsScrollbar(win)
+				layer := renderScrollbarLayer(win, theme.BorderUnfocused(), 1)
+				if need != (layer != nil) {
+					t.Fatalf("windowNeedsScrollbar = %v but renderScrollbarLayer returned %v: "+
+						"the layout and the layer disagree about whether a thumb is present",
+						need, layer != nil)
+				}
+			})
+		})
+	}
+}
+
+// The layer renderer must refuse a borderless pane on its own, not only because
+// its callers happen to check first. It is the code that writes the cells, and
+// on a borderless pane those cells are the guest's output.
+func TestScrollbarLayerRefusesBorderlessPaneDirectly(t *testing.T) {
+	win := newTestWindow(t, "sbdirect-0001", 60, 20)
+	fillScrollback(t, win, 200)
+	win.Tiled = true
+
+	withSharedBorders(t, true, func() {
+		for _, zoomed := range []bool{false, true} {
+			win.Zoomed = zoomed
+			if layer := renderScrollbarLayer(win, theme.BorderUnfocused(), 1); layer != nil {
+				t.Errorf("renderScrollbarLayer drew a thumb on a borderless pane (zoomed=%v); "+
+					"it would land on the rightmost column of terminal output", zoomed)
+			}
+		}
+	})
+}
+
+// The pairing that matters on screen: a pane gets a thumb exactly when it gets
+// a border box to hang it on. renderWindowBox and windowNeedsScrollbar read the
+// same predicate, and this asserts against the rendered box rather than against
+// the predicate, so a future divergence between them is caught by what the user
+// would see.
+func TestThumbAppearsExactlyWhenTheBoxHasABorder(t *testing.T) {
+	cases := []struct {
+		name          string
+		tiled, zoomed bool
+		shared        bool
+	}{
+		{"bordered pane", false, false, false},
+		{"bordered pane zoomed", false, true, false},
+		{"borderless pane", true, false, true},
+		{"borderless pane zoomed", true, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			win := newTestWindow(t, "sbbox-"+strings.ReplaceAll(tc.name, " ", "-"), 60, 20)
+			fillScrollback(t, win, 200)
+			// SetTiled rather than the bare flag: it re-syncs the emulator to
+			// the borderless size, which is what makes the rendered box the
+			// pane's full rectangle. Setting the flag alone leaves the emulator
+			// two cells short in each axis and the box would not be what the
+			// compositor actually composites.
+			win.SetTiled(tc.tiled)
+			win.Zoomed = tc.zoomed
+			m := newTestOS(win)
+
+			withSharedBorders(t, tc.shared, func() {
+				box := m.renderWindowBox(win, 0, true, theme.BorderUnfocused())
+				lines := strings.Split(box, "\n")
+				hasBorder := strings.Contains(lines[len(lines)-1], config.GetWindowBorderBottomLeft())
+
+				if got := windowNeedsScrollbar(win); got != hasBorder {
+					t.Fatalf("box has a border = %v but windowNeedsScrollbar = %v: "+
+						"a thumb without a border cell lands on terminal content, and a border "+
+						"with no thumb loses the scroll position the pane could show",
+						hasBorder, got)
+				}
+
+				// A borderless pane must also be exactly its rectangle, which is
+				// what leaves no cell to spare in the first place.
+				if !hasBorder {
+					w, h := lipgloss.Size(box)
+					if w != win.ContentWidth() || h != win.ContentHeight() {
+						t.Errorf("borderless box is %dx%d, want the pane's full rect %dx%d",
+							w, h, win.ContentWidth(), win.ContentHeight())
+					}
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
The scrollbar is missing under `--shared-borders`. That is correct and stays correct, but the condition expressing it was wrong in a way that would have painted on the user's output, and it hid a misleading field name.

## The field name is the trap

`window.Tiled` does not mean "in the tiling layout". Every tiling path assigns it from the config setting:

```
internal/app/tiling.go:85          visibleWindows[i].Tiled = config.SharedBorders
internal/app/tiling_bsp.go:171,203,213   win.Tiled = config.SharedBorders
```

So `Tiled` means **drawn borderless**, and it is true only under shared borders. The geometry already agrees: `ContentWidth`, `ContentHeight` and `BorderOffset` reserve border cells on `!Tiled` alone, and `Resize` sizes the emulator by the same rule.

That collapses the truth table people reason about. With shared borders off, tiled panes are `Tiled=false` and each carries its own border box, so `tiled, zoomed, no shared borders` is not a state that exists. Captured at 120x40 with three panes and no `--shared-borders`: every pane has its own frame, adjacent panes show two border columns, and the focused pane's thumb sits on its own border column with content untouched. Zoomed, the same: 118 columns of content in a 120-wide box, thumb on the border, `12/366` on the bottom border. **The thumb has room. That case was never a bug.**

## What was actually wrong

`window.Tiled && (!window.Zoomed || config.SharedBorders)` differs from bare `window.Tiled` only for `Tiled && Zoomed && !SharedBorders`, which is reachable only in the gap between toggling shared borders off and the retile that resets `Tiled`. In that transient state the old expression asked for a border box around content the emulator had already sized to the full rectangle, overflowing by two columns.

`rendersBorderless(window)` replaces it, and is bare `window.Tiled`, matching what the geometry functions already do. A renderer predicate that disagrees with them either overflows the rect or paints on the guest's columns.

The guard is also added to `renderScrollbarLayer` itself. Every call site gates on `windowNeedsScrollbar` today, but the layer renderer is what writes the cells, and on a borderless pane those cells are the user's terminal. That also makes the doc comment's claim that the two "mirror" each other true, which it previously was not: `windowNeedsScrollbar` was strictly stronger.

**No behaviour change in any reachable state.** All four capture pairs, zoomed and three-pane, with and without `--shared-borders`, each also in copy mode scrolled back, are byte-identical before and after.

## Shared borders stays scrollbar-free, deliberately

The comment now says so, and says zoom is not an exception, and records that a thumb on the separator overlay was considered and rejected: the separator is shared between two panes and belongs to neither, and a pane's content occupies its whole rect, so there is no column to host a thumb that is not the user's output.

## Worth knowing, not changed

Under shared borders the `n/N` scroll readout is missing too, for the same structural reason: it is built in `addToBorder`, which only bordered panes reach. So the mode's only scroll feedback is the dock indicator. Consistent with the decision, but the gap is slightly wider than the thumb alone if anyone revisits it.

## Tests

Four, in `internal/app/render_scrollbar_test.go`: the full truth table, layer-versus-predicate agreement across the config gates too, a direct assertion that the layer renderer refuses a borderless pane on its own, and one asserting against the *rendered box* that a thumb appears exactly when the box has a border and that a borderless box is exactly the pane's rect.

Two negative controls: restoring the old expression fails the transient-state row, and applying the "zoom is an exception" change that seemed obvious before the field name was understood fails three tests, including the layer-agreement one.

`go build`, `go vet`, `gofmt`, `go test ./...` and the nested `e2e/tui` module all pass.