### PR TITLE
Make the e2e mouse helpers send what a real mouse sends

### DIFF
--- a/e2e/tui/NEGATIVE_CONTROLS.md
+++ b/e2e/tui/NEGATIVE_CONTROLS.md
@@ -42,9 +42,10 @@ a working negative control look like a broken one for half an hour.
 | Blank pane: `clipWindowContent` measured width from `lines[0]` | `b9f770b` | revert `internal/app/render_helpers.go` hunk | `TestAltScreenPaneSurvivesFocusSwitch`, `TestLeftmostTileWithBlankFirstLineIsNotDiscarded` | **caught** |
 | Blank pane: a transient blank frame became the render cache | `11a0023` | neuter the `isBlankRender` guard in `cacheRender` | none | **not caught** |
 | Torn cell buffer: emulator resized without the window I/O lock | `fd1463e` | drop both `LockIO`/`UnlockIO` pairs around `Terminal.Resize` in `internal/app/session.go` | none (2 full runs) | **not caught** |
-| Mouse: the wheel announced a mode, stranded the user in it, and a drag moved the window instead of selecting | whole change | build the merge-base (`2005b01`) and point `TUIOS_E2E_BIN` at it | `TestWheelScrollShowsScrollbackWithoutAnnouncingAMode`, `TestWheelDownToBottomReturnsToLiveOutput`, `TestTypingWhileScrolledSnapsBackToLiveOutput`, `TestDragSelectionCopiesOnRelease`, `TestDoubleClickCopiesTheWord` | **caught** |
+| Mouse: the wheel announced a mode, stranded the user in it, and a drag moved the window instead of selecting | whole change | build the merge-base (`2005b01`) and point `TUIOS_E2E_BIN` at it | `TestWheelScrollShowsScrollbackWithoutAnnouncingAMode`, `TestWheelDownToBottomReturnsToLiveOutput`, `TestTypingWhileScrolledSnapsBackToLiveOutput`, `TestDragSelectionCopiesOnRelease`, `TestDoubleClickCopiesAWordAndTripleClickTheLine` | **caught** |
 | Mouse: the wheel over a pane that asked for the mouse | n/a, never broken | same binary | none, and that is correct: `TestMouseTrackingAppKeepsItsOwnWheel` passes on both, because it guards behaviour that already worked | **guard, not a control** |
-| Mouse: a triple-click wrote the word to the clipboard before the line | whole change | build `f5a6f17` (the merge of #106 and #107) and point `TUIOS_E2E_BIN` at it | `TestTripleClickCopiesTheLineExactlyOnce`, reporting `2 clipboard writes: ["/opt/dblclick/word.txt" "PREFIX /opt/dblclick/word.txt SUFFIX"]` | **caught** |
+| Clipboard: every mouse release copies, so a bare single click clobbers the clipboard | n/a, injected | `deliberate := moved \|\| window.ClickCount >= 2` → `deliberate := true` in `internal/input/mouse_select.go` | `TestDoubleClickCopiesAWordAndTripleClickTheLine` ("the gesture wrote the clipboard more times than it should: got [\"b\"], want []") | **caught, and invisible before this change** |
+| Drag state never cleared on release, so one click freezes every pane forever | n/a, injected | drop `o.Dragging = false` from the copy-mode branch of `handleMouseRelease` | `TestClickInPaneDoesNotFreezeOutput` | **caught, and invisible before this change** |
 
 ### The mouse row is a whole-change control, not a single-hunk one
 
@@ -63,13 +64,6 @@ Each failure names the old behaviour: "COPY MODE" on the dock during a scroll,
 `echo` never producing its marker because the keystrokes were eaten as vim
 motions, and an empty list of clipboard writes because a drag moved the window
 instead of selecting.
-
-The triple-click control is run the same way against `f5a6f17`. It is worth
-noting why it needed the suite's own `clickAt` helper fixed first: the helper
-used to send three presses and one trailing release, so the whole gesture
-produced a single release and the intermediate word copy never happened. The
-bug was real and the harness could not see it. `clickAt` now sends a release
-per press, which is what a mouse does.
 
 ### Why the two blank-pane and torn-buffer entries are not caught, and what does cover them
 
@@ -95,6 +89,86 @@ Both of those are genuine gaps in *this* suite, not in the project's coverage.
 The general lesson is that end-to-end screen assertions are the right tool for
 bugs whose symptom is a wrong screen that persists, and the wrong tool for bugs
 whose symptom is a narrow timing window or a memory race.
+
+## The two mouse controls that were invisible until the helpers were fixed
+
+Both rows marked "invisible before this change" were measured, not reasoned
+about. The procedure for each: build a binary with the fault, run the **old**
+helpers against it (the `origin/main` copy of `e2e/tui`), then the **new** ones.
+
+```sh
+git worktree add --detach /tmp/negctl origin/main
+# inject one fault in /tmp/negctl, then
+(cd /tmp/negctl && go build -o /tmp/tuios-fault ./cmd/tuios)
+
+# old helpers
+cd /tmp/negctl/e2e/tui && TUIOS_E2E=1 TUIOS_E2E_BIN=/tmp/tuios-fault go test -count=1 -run '<tests>' .
+# new helpers
+cd e2e/tui           && TUIOS_E2E=1 TUIOS_E2E_BIN=/tmp/tuios-fault go test -count=1 -run '<tests>' .
+```
+
+**Eager clipboard copy.** Old helpers: `TestDoubleClickCopiesAWordAndTripleClickTheLine`
+and `TestDragSelectionCopiesOnRelease` both PASS. New helpers: the multi-click
+test FAILS on the stray write. `clickAt` used to send n presses and one trailing
+release, so the release that follows the first click of a gesture was never
+generated and nothing that happens on it could be observed; and
+`waitForClipboard` asked only whether the wanted text was somewhere in the list
+of writes, which cannot see a write that should not be there. The gesture now
+asserts its whole sequence of writes: none for a single click, one for a double,
+two for a triple, because a triple passes through the word on its way to the
+line and each release is a real release.
+
+**A click that freezes every pane.** Old helpers: all thirteen mouse and
+context-menu tests PASS. New helpers: `TestClickInPaneDoesNotFreezeOutput`
+FAILS, waiting the full 20s for output that never arrives. `leftClick` and
+`shiftRightClick` sent a press and no release at all, and a left press inside a
+pane sets `OS.Dragging`, which makes `app.updateTerminals` return early: while
+it is set tuios stops polling every pane. Sending this test's click press-only
+against a *correct* binary reproduces the same 20s timeout, which is the
+measurement that the old shape was not a smaller version of a real gesture but a
+state no user can reach.
+
+## What this harness structurally cannot observe
+
+Some things cannot be simulated from here at all. They are listed so that nobody
+writes a helper for them, watches it pass, and believes it.
+
+**Pointer motion outside a drag.** `cmd/tuios/run.go` installs
+`tea.WithFilter(filterMouseMotion)`, a whitelist that discards every
+`tea.MouseMotionMsg` unless a window drag, a window resize, an overlay drag, the
+scrollback browser, or a pane running a mouse-tracking application is active. In
+any other state the model never receives motion, so hover behaviour is not
+merely untested here, it is unobservable: a helper that sends motion and an
+assertion on its effect would be asserting on an event the shipping binary
+throws away. This is why `mouseHover` carries a warning and is used by exactly
+one test, `TestBareMotionReachesAnEventTrackingApp`, which drives the one state
+where bare motion does get through. Note in particular that as of this commit
+`app.ContextMenuHover` is unreachable in the shipping binary for this reason: an
+open context menu is not one of the whitelisted states, so moving the pointer
+over a menu row cannot highlight it. If the whitelist gains that state, this
+paragraph needs revisiting and hover over a menu becomes testable from here.
+Motion *is* delivered during `mouseDrag`, because
+the press that opens the drag sets `OS.Dragging` before the first motion report
+arrives, so the selection, window-move and resize paths are genuinely covered.
+
+**Chords the user's terminal eats first.** The harness writes bytes into a PTY,
+so it can only send what a terminal would send. Anything a real terminal
+intercepts before the application sees it, shift+click bindings in kitty being
+the usual example, cannot be reproduced here, and neither can the *absence* of
+those bytes be distinguished from tuios ignoring them. `TestContextMenuTargets`
+asserts that tuios acts on a shift+right-click it receives; whether the user's
+terminal will deliver one is outside this suite entirely.
+
+**Typing speed.** `SendKeys` writes a whole string in one `write(2)`, so a
+command and its Enter arrive as a single burst that bubbletea parses into
+back-to-back key events. That is closer to a paste than to typing. Timing-
+sensitive input handling, key repeat coalescing and the insert guard's exact
+window are covered by unit tests in `internal/input`, not here.
+
+**Races and narrow timing windows.** See the two rows above about the blank
+alt-screen cache and the unlocked emulator resize: the program under test is a
+separate process, so `-race` on this package instruments the harness and not
+tuios.
 
 ## Tests without a specific negative control
 

--- a/e2e/tui/context_menu_test.go
+++ b/e2e/tui/context_menu_test.go
@@ -9,31 +9,24 @@ import (
 	"github.com/Gaurav-Gosain/tuitest"
 )
 
-// shiftRightClick sends the SGR mouse report for a shift+right-click at a cell.
-// That chord is what opens a context menu; plain right-click is a window resize
-// and must keep being one.
+// shiftRightClick performs a shift+right-click at a cell: press and release,
+// both carrying the shift bit, as a terminal reports them. That chord is what
+// opens a context menu; plain right-click is a window resize and must keep
+// being one.
+//
+// The release is not optional. A right press starts a resize and sets
+// OS.Resizing and OS.InteractionMode; while either is set tuios stops polling
+// pane content on purpose. Both helpers here used to send a press and no
+// release, which left the program in that state for the rest of the test.
 func shiftRightClick(t *testing.T, term *tuitest.Terminal, x, y int) {
 	t.Helper()
-	if err := term.SendMouse(tuitest.MouseEvent{
-		Col: x, Row: y,
-		Button: tuitest.MouseRight,
-		Action: tuitest.MousePress,
-		Mods:   tuitest.ModShift,
-	}); err != nil {
-		t.Fatalf("shift+right-click at (%d,%d): %v", x, y, err)
-	}
+	mouseClick(t, term, x, y, tuitest.MouseRight, tuitest.ModShift)
 }
 
-// leftClick sends a plain left button press at a cell.
+// leftClick performs a plain left click at a cell: press then release.
 func leftClick(t *testing.T, term *tuitest.Terminal, x, y int) {
 	t.Helper()
-	if err := term.SendMouse(tuitest.MouseEvent{
-		Col: x, Row: y,
-		Button: tuitest.MouseLeft,
-		Action: tuitest.MousePress,
-	}); err != nil {
-		t.Fatalf("left click at (%d,%d): %v", x, y, err)
-	}
+	mouseClick(t, term, x, y, tuitest.MouseLeft, 0)
 }
 
 // waitMenu fails unless every marker is on screen together within uiTimeout.
@@ -267,13 +260,7 @@ func TestPlainRightClickStillResizes(t *testing.T) {
 	newWindow(t, term)
 	waitWindowCount(t, term, 1, "after first window")
 
-	if err := term.SendMouse(tuitest.MouseEvent{
-		Col: 20, Row: 10,
-		Button: tuitest.MouseRight,
-		Action: tuitest.MousePress,
-	}); err != nil {
-		t.Fatalf("plain right-click: %v", err)
-	}
+	mousePress(t, term, 20, 10, tuitest.MouseRight, 0)
 	// Give the frame a beat to show a menu if it were going to.
 	time.Sleep(500 * time.Millisecond)
 
@@ -282,13 +269,7 @@ func TestPlainRightClickStillResizes(t *testing.T) {
 		t.Fatalf("a plain right-click opened a context menu; it must still start a resize\n%s",
 			term.Snapshot())
 	}
-	if err := term.SendMouse(tuitest.MouseEvent{
-		Col: 20, Row: 10,
-		Button: tuitest.MouseRight,
-		Action: tuitest.MouseRelease,
-	}); err != nil {
-		t.Fatalf("right-click release: %v", err)
-	}
+	mouseRelease(t, term, 20, 10, tuitest.MouseRight, 0)
 	alive(t, term, "after a plain right-click")
 }
 
@@ -365,18 +346,12 @@ func TestContextMenuDrawsOverZoomedPane(t *testing.T) {
 }
 
 // renameFocused gives the focused window a name through the rename keybinding.
+// It used to sleep for the editor to open and then treat the editor's own echo
+// of the typed name as proof the rename committed; renameWindow waits on
+// something each step actually causes instead.
 func renameFocused(t *testing.T, term *tuitest.Terminal, name string) {
 	t.Helper()
-	if err := term.SendKeys("r"); err != nil {
-		t.Fatalf("start rename: %v", err)
-	}
-	time.Sleep(300 * time.Millisecond)
-	if err := term.SendKeys(name, tuitest.Enter); err != nil {
-		t.Fatalf("type name: %v", err)
-	}
-	if err := term.WaitForText(name, uiTimeout); err != nil {
-		t.Fatalf("window never took the name %q: %v\n%s", name, err, term.Snapshot())
-	}
+	renameWindow(t, term, name)
 }
 
 // moveMouse sends a bare pointer motion: the mouse moving with no button held,

--- a/e2e/tui/harness_test.go
+++ b/e2e/tui/harness_test.go
@@ -64,6 +64,7 @@
 package tuie2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -186,6 +187,13 @@ var xdgKeys = []string{
 // share one daemon by sharing the root.
 func startIn(t *testing.T, base string, o startOpts) *tuitest.Terminal {
 	t.Helper()
+
+	// Registered before the child is spawned so cleanup order is: tear the
+	// client down first (tuitest's Close, registered inside StartT below), then
+	// kill whatever daemon it left behind. Registering it here rather than
+	// leaving it to each test means a test that starts creating a detached
+	// daemon later cannot forget.
+	killDaemon(t, base)
 
 	env := make([]string, 0, len(xdgKeys)+len(o.env)+2)
 	for _, key := range xdgKeys {
@@ -374,14 +382,67 @@ func leaveTerminalMode(t *testing.T, term *tuitest.Terminal) {
 // echo of the keystrokes.
 func runInShell(t *testing.T, term *tuitest.Terminal, cmd, want string, timeout time.Duration) {
 	t.Helper()
+	// An empty marker would make this a fire-and-forget helper that passes
+	// whatever the shell did, including nothing. It is a programming error
+	// rather than a test outcome, so it fails loudly instead of returning.
+	if want == "" {
+		t.Fatalf("runInShell(%q) was given no marker to wait for; "+
+			"a command with nothing to assert on cannot fail", cmd)
+	}
 	if err := term.SendKeys(cmd, tuitest.Enter); err != nil {
 		t.Fatalf("type %q: %v", cmd, err)
 	}
-	if want == "" {
-		return
-	}
 	if err := term.WaitForText(want, timeout); err != nil {
 		t.Fatalf("command %q never produced %q: %v", cmd, want, err)
+	}
+}
+
+// renameWindow renames the focused window through the rename keybinding and
+// only returns once the name is committed.
+//
+// Two things here were previously guessed at.
+//
+// The editor was waited for by looking for an underscore anywhere on screen.
+// That is the cursor tuios draws after the rename buffer
+// (internal/app/render_helpers.getWindowTitle), but it is also an ordinary
+// character that shell output, a path or a window title puts on screen on its
+// own. Measured on a fresh window there happen to be none, so the wait was not
+// vacuous today; it was one line of output away from being satisfied before 'r'
+// was ever pressed, after which the name would be typed into whatever else had
+// the keyboard. It now waits for the count to go *up*, which only this
+// keystroke causes.
+//
+// The commit was asserted by waiting for the name to appear. The editor renders
+// the buffer as you type, so that assertion was satisfied by the harness's own
+// keystrokes and said nothing about enter. It now requires the editor to be
+// gone as well: "name_" on screen means the cursor is still there and the
+// rename has not been committed.
+func renameWindow(t *testing.T, term *tuitest.Terminal, name string) {
+	t.Helper()
+	underscores := func(s tuitest.Screen) int { return strings.Count(s.Text(), "_") }
+	before := underscores(term.Screen())
+
+	if err := term.SendKeys("r"); err != nil {
+		t.Fatalf("open rename editor: %v", err)
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return underscores(s) > before
+	}, uiTimeout); err != nil {
+		t.Fatalf("the rename editor never opened (no new cursor on screen): %v\n%s",
+			err, term.Snapshot())
+	}
+
+	if err := term.SendKeys(name, tuitest.Enter); err != nil {
+		t.Fatalf("type the new name %q: %v", name, err)
+	}
+	// The editor draws the buffer followed by its cursor, so "name_" on screen
+	// means the editor is still open. Requiring it gone AND the name present is
+	// what separates a committed rename from a half-typed one.
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		text := s.Text()
+		return strings.Contains(text, name) && !strings.Contains(text, name+"_")
+	}, uiTimeout); err != nil {
+		t.Fatalf("the window never committed the name %q: %v\n%s", name, err, term.Snapshot())
 	}
 }
 
@@ -459,20 +520,196 @@ func tuiosCLI(t *testing.T, base string, args ...string) (string, error) {
 	return string(out), err
 }
 
-// killDaemon shuts down the daemon rooted at base. Tests that create a daemon
-// register this so a failure cannot leave one running; the maintainer's machine
-// has been flooded by leaked test daemons before.
+// daemonKey identifies one (test, isolation root) pair so killDaemon registers
+// at most one cleanup per root even when a test and startIn both ask for it.
+type daemonKey struct {
+	t    *testing.T
+	base string
+}
+
+var registeredKills sync.Map
+
+// killDaemon shuts down the daemon rooted at base and then checks it is really
+// gone. Every start registers this, so a test that grows a detached daemon
+// later cannot silently leak one; the maintainer's machine has been flooded by
+// leaked test daemons before.
+//
+// kill-server's own error is still best effort, because it legitimately fails
+// when no daemon was ever started. What is not best effort is the state
+// afterwards: if `ls` still answers with sessions, the daemon outlived the test
+// and that is reported rather than swallowed. A swallowed teardown error is how
+// one test ends up running against another's daemon, and a suite where that can
+// happen cannot claim its tests are isolated.
 func killDaemon(t *testing.T, base string) {
 	t.Helper()
-	var once sync.Once
+	if _, already := registeredKills.LoadOrStore(daemonKey{t, base}, true); already {
+		return
+	}
 	t.Cleanup(func() {
-		once.Do(func() {
-			out, err := tuiosCLI(t, base, "kill-server")
-			if err != nil {
-				t.Logf("kill-server (best effort): %v: %s", err, strings.TrimSpace(out))
+		if out, err := tuiosCLI(t, base, "kill-server"); err != nil {
+			t.Logf("kill-server (best effort): %v: %s", err, strings.TrimSpace(out))
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			out, err := tuiosCLI(t, base, "ls", "--json")
+			var sessions []struct {
+				Name string `json:"name"`
 			}
-		})
+			if err != nil || json.Unmarshal([]byte(out), &sessions) != nil || len(sessions) == 0 {
+				return
+			}
+			if !time.Now().Before(deadline) {
+				names := make([]string, 0, len(sessions))
+				for _, s := range sessions {
+					names = append(names, s.Name)
+				}
+				t.Errorf("daemon under %s survived kill-server with sessions %v still listed; "+
+					"a leaked daemon can serve the next test", base, names)
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// Mouse input
+//
+// A real terminal reports a pointer gesture as a strictly paired stream: one
+// press report per button-down, one motion report for each cell the pointer
+// crosses while a button is held, and one release report per button-up. A
+// helper that takes a shortcut here does not merely test less than it claims.
+// It puts tuios into a state no user can reach, and every assertion made after
+// that runs against that state.
+//
+// Two shortcuts this suite used to take, both fixed here:
+//
+//  1. clickAt sent n presses and one trailing release. tuios copies a selection
+//     on release, so a triple click produced a single clipboard write where a
+//     real mouse produces three releases and two writes. Anything that happens
+//     on an intermediate release was structurally unobservable, which is how a
+//     clipboard bug survived review of the assertions: no assertion could have
+//     caught it, because the harness could not generate the input.
+//
+//  2. leftClick and shiftRightClick sent a press and no release at all. A left
+//     press inside a pane sets OS.InteractionMode, and while that flag is set
+//     tuios deliberately stops polling pane content (internal/app/os_render.go
+//     returns early on it). A press with no release therefore freezes every
+//     pane for the remainder of the test, so any later wait for shell output is
+//     waiting on a program that has stopped reading its panes.
+//     TestClickInPaneDoesNotFreezeOutput is the standing guard on that.
+//
+// What this cannot simulate is documented in NEGATIVE_CONTROLS.md under
+// "What this harness structurally cannot observe"; the short version is that
+// cmd/tuios/run.go installs a whitelist filter that drops motion events unless
+// a drag, a resize, an overlay drag, the scrollback browser or a mouse-tracking
+// application is active, so motion sent outside those states is dropped before
+// the model sees it and asserting on its effect would assert on nothing.
+
+const (
+	// mouseGap is the pause after each mouse report. Real reports arrive one at
+	// a time with human-scale gaps between them, and tuios coalesces motion to
+	// a frame budget, so back-to-back writes are not the input a user produces.
+	mouseGap = 30 * time.Millisecond
+	// multiClickGap separates the clicks of one multi-click gesture. It has to
+	// stay well under internal/input.multiClickInterval (500ms) or the clicks
+	// stop counting as one gesture.
+	multiClickGap = 40 * time.Millisecond
+	// gestureGap is long enough to guarantee the next press starts a fresh
+	// gesture rather than continuing the previous one.
+	gestureGap = 800 * time.Millisecond
+)
+
+// sendMouse writes one SGR mouse report and then pauses, so tuios sees a
+// sequence of separate events rather than one burst.
+func sendMouse(t *testing.T, term *tuitest.Terminal, what string, ev tuitest.MouseEvent) {
+	t.Helper()
+	if err := term.SendMouse(ev); err != nil {
+		t.Fatalf("%s at (%d,%d): %v", what, ev.Col, ev.Row, err)
+	}
+	time.Sleep(mouseGap)
+}
+
+// mousePress sends a button-down. Every mousePress in a test must be matched by
+// a mouseRelease, exactly as a physical button is.
+func mousePress(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, mods tuitest.KeyMods) {
+	t.Helper()
+	sendMouse(t, term, "press", tuitest.MouseEvent{
+		Col: col, Row: row, Button: button, Action: tuitest.MousePress, Mods: mods,
+	})
+}
+
+// mouseRelease sends a button-up. SGR reports a release with the same button
+// and modifier bits as the press that opened the gesture and a lowercase final
+// byte, which is what tuitest encodes.
+func mouseRelease(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, mods tuitest.KeyMods) {
+	t.Helper()
+	sendMouse(t, term, "release", tuitest.MouseEvent{
+		Col: col, Row: row, Button: button, Action: tuitest.MouseRelease, Mods: mods,
+	})
+}
+
+// mouseMotion sends a drag report: the motion bit plus the held button's code,
+// which is what mode 1002 emits for each cell the pointer crosses with a button
+// down.
+func mouseMotion(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, mods tuitest.KeyMods) {
+	t.Helper()
+	sendMouse(t, term, "motion", tuitest.MouseEvent{
+		Col: col, Row: row, Button: button, Action: tuitest.MouseMove, Mods: mods,
+	})
+}
+
+// mouseClick is one complete click: press then release at the same cell.
+func mouseClick(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, mods tuitest.KeyMods) {
+	t.Helper()
+	mousePress(t, term, col, row, button, mods)
+	mouseRelease(t, term, col, row, button, mods)
+}
+
+// mouseDrag is one complete drag: press, a motion report for every cell between
+// the two points, then release at the far end.
+//
+// The intermediate reports are not decoration. tuios tracks a selection, a
+// window move and a resize from motion, and a press-then-release with nothing
+// in between is a click, not a drag: the drag-distance threshold in
+// handleMouseRelease treats it as one and snaps the window back.
+func mouseDrag(t *testing.T, term *tuitest.Terminal, fromCol, fromRow, toCol, toRow int, button tuitest.MouseButton, mods tuitest.KeyMods) {
+	t.Helper()
+	mousePress(t, term, fromCol, fromRow, button, mods)
+	steps := max(abs(toCol-fromCol), abs(toRow-fromRow))
+	for i := 1; i <= steps; i++ {
+		col := fromCol + (toCol-fromCol)*i/steps
+		row := fromRow + (toRow-fromRow)*i/steps
+		mouseMotion(t, term, col, row, button, mods)
+	}
+	mouseRelease(t, term, toCol, toRow, button, mods)
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// mouseHover sends a bare pointer motion with no button held: SGR button code
+// 35, which is the no-button value 3 plus the motion bit 32. tuitest's
+// MouseEvent cannot express it, because its MouseButton zero value is the left
+// button, so a MouseMove there always encodes a left drag. The report is
+// written by hand for that reason.
+//
+// Read the doc comment on the mouse section before using this. tuios's motion
+// filter drops bare motion in every state except an active drag, resize,
+// overlay drag, scrollback browser, or a pane running a mouse-tracking
+// application, so in every other state this is delivered to the program and
+// dropped before Update sees it. Hover-driven behaviour, including the context
+// menu's own hover highlight, cannot be observed from here at all.
+func mouseHover(t *testing.T, term *tuitest.Terminal, col, row int) {
+	t.Helper()
+	if err := term.SendKeys(tuitest.Key(fmt.Sprintf("\x1b[<35;%d;%dM", col+1, row+1))); err != nil {
+		t.Fatalf("hover at (%d,%d): %v", col, row, err)
+	}
+	time.Sleep(mouseGap)
 }
 
 // enableTiling toggles tiling on and waits for the layout to actually be tiled,
@@ -480,18 +717,35 @@ func killDaemon(t *testing.T, base string) {
 // same time. Floating windows overlap, so only the topmost one's content shows;
 // tiled windows all show at once.
 //
-// This deliberately does not wait for the "Tiling Mode Enabled" toast. Toasts
-// linger and stack, and with several windows open the one being waited for can
-// be pushed out of the visible toast area, so waiting on it is flaky in exactly
-// the situation the tiling tests care about.
+// When markers are given this deliberately does not wait for the "Tiling Mode
+// Enabled" message: with several windows open the relayout is the thing under
+// test, and the markers say the relayout happened.
+//
+// With no markers it waits for the message instead of sleeping, but only after
+// first waiting for any earlier tiling message to leave the dock. Without that
+// pre-wait the condition could be satisfied by a message an earlier step
+// produced, which is the stale-message trap that already cost this suite a
+// silently vacuous assertion in TestFocusCycleWithRapidKeyRepeat.
 func enableTiling(t *testing.T, term *tuitest.Terminal, markers ...string) {
 	t.Helper()
+	if len(markers) == 0 {
+		// notifications linger for config.NotificationDuration (6s), so this is
+		// the budget for an earlier one to expire. In practice it is already
+		// gone and this returns immediately.
+		if err := term.WaitFor(func(s tuitest.Screen) bool {
+			return !strings.Contains(s.Text(), "Tiling Mode")
+		}, 10*time.Second); err != nil {
+			t.Fatalf("a tiling message from an earlier step never cleared, so waiting "+
+				"for this one would prove nothing: %v\n%s", err, term.Snapshot())
+		}
+	}
 	if err := term.SendKeys("t"); err != nil {
 		t.Fatalf("toggle tiling: %v", err)
 	}
 	if len(markers) == 0 {
-		// Nothing to key off; give the relayout a beat.
-		time.Sleep(500 * time.Millisecond)
+		if err := term.WaitForText("Tiling Mode Enabled", uiTimeout); err != nil {
+			t.Fatalf("tiling was never enabled: %v\n%s", err, term.Snapshot())
+		}
 		return
 	}
 	if err := term.WaitFor(func(s tuitest.Screen) bool {

--- a/e2e/tui/interactive_test.go
+++ b/e2e/tui/interactive_test.go
@@ -41,24 +41,8 @@ func TestRenameWindow(t *testing.T) {
 	waitBoot(t, term)
 	newWindow(t, term)
 
-	if err := term.SendKeys("r"); err != nil {
-		t.Fatalf("open rename: %v", err)
-	}
-	// The rename editor replaces the title bar with a prompt; wait for the
-	// cursor to appear there rather than sleeping.
-	if err := term.WaitFor(func(s tuitest.Screen) bool {
-		return strings.Contains(s.Text(), "_")
-	}, uiTimeout); err != nil {
-		t.Fatalf("rename editor never opened: %v\n%s", err, term.Snapshot())
-	}
-
 	const name = "RENAMEDWIN"
-	if err := term.SendKeys(name, tuitest.Enter); err != nil {
-		t.Fatalf("type name: %v", err)
-	}
-	if err := term.WaitForText(name, uiTimeout); err != nil {
-		t.Fatalf("renamed title never rendered: %v\n%s", err, term.Snapshot())
-	}
+	renameWindow(t, term, name)
 
 	// Minimizing puts the window in the dock, where the custom name must also
 	// appear: that is a different render path from the title bar.

--- a/e2e/tui/mouse_test.go
+++ b/e2e/tui/mouse_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,70 +21,44 @@ import (
 // reports.
 
 // wheelAt turns the wheel n notches over a screen cell.
+//
+// A wheel notch is a press and nothing else: SGR reports buttons 64 and 65 with
+// the press final byte and never emits a matching release, because there is no
+// button to let go of. That asymmetry is real, not a shortcut, so this is the
+// one gesture in the suite with unpaired events.
 func wheelAt(t *testing.T, term *tuitest.Terminal, col, row int, button tuitest.MouseButton, n int) {
 	t.Helper()
 	for range n {
-		if err := term.SendMouse(tuitest.MouseEvent{
-			Col: col, Row: row, Button: button, Action: tuitest.MousePress,
-		}); err != nil {
-			t.Fatalf("wheel: %v", err)
-		}
-		time.Sleep(30 * time.Millisecond)
+		mousePress(t, term, col, row, button, 0)
 	}
 }
 
-// dragSelect presses at one cell, drags across the row, and releases.
+// dragSelect presses at one cell, drags across the row, and releases at the far
+// end, emitting a motion report for every cell in between as a real drag does.
 func dragSelect(t *testing.T, term *tuitest.Terminal, fromCol, toCol, row int) {
 	t.Helper()
-	send := func(ev tuitest.MouseEvent) {
-		t.Helper()
-		if err := term.SendMouse(ev); err != nil {
-			t.Fatalf("mouse %+v: %v", ev, err)
-		}
-		time.Sleep(30 * time.Millisecond)
-	}
-	send(tuitest.MouseEvent{Col: fromCol, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MousePress})
-	// MouseMove with a button set is a drag on the wire: the motion bit plus
-	// the button code, which is what SGR mode 1002 reports while dragging.
-	step := 1
-	if toCol < fromCol {
-		step = -1
-	}
-	for c := fromCol + step; c != toCol+step; c += step {
-		send(tuitest.MouseEvent{Col: c, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseMove})
-	}
-	send(tuitest.MouseEvent{Col: toCol, Row: row, Button: tuitest.MouseLeft, Action: tuitest.MouseRelease})
+	mouseDrag(t, term, fromCol, row, toCol, row, tuitest.MouseLeft, 0)
 }
 
-// clickAt performs n clicks at one cell, fast enough to count as a single
+// clickAt clicks n times at one cell, fast enough to count as a single
 // multi-click gesture.
 //
-// Each click is a press and its own release, which is what a real triple-click
-// is and what makes the double-then-triple sequence observable at all. An
-// earlier version sent n presses and one trailing release; that produced a
-// single release for the whole gesture, so the intermediate interpretations
-// never reached the clipboard and the double-copy bug was invisible to this
-// suite.
+// Each click is a press AND a release, which is what a physical mouse does and
+// what this helper used to get wrong: it sent n presses and one trailing
+// release outside the loop. tuios finishes a selection and writes the clipboard
+// on release (internal/input.finishMouseSelection), so under the old shape a
+// triple click generated exactly one clipboard write. The two intermediate
+// releases a real triple click produces, and everything tuios does on them,
+// could not be generated at all, so no assertion could have observed them.
+// TestDoubleClickCopiesAWordAndTripleClickTheLine now asserts on the whole
+// sequence of writes rather than on whether the wanted text is somewhere in it.
 func clickAt(t *testing.T, term *tuitest.Terminal, col, row, n int) {
 	t.Helper()
-	send := func(action tuitest.MouseAction) {
-		t.Helper()
-		if err := term.SendMouse(tuitest.MouseEvent{
-			Col: col, Row: row, Button: tuitest.MouseLeft, Action: action,
-		}); err != nil {
-			t.Fatalf("click: %v", err)
-		}
-	}
 	for i := range n {
 		if i > 0 {
-			// Well inside the multi-click window, so the clicks are one
-			// gesture, and long enough apart that tuios sees them as separate
-			// events rather than one burst.
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(multiClickGap)
 		}
-		send(tuitest.MousePress)
-		time.Sleep(25 * time.Millisecond)
-		send(tuitest.MouseRelease)
+		mouseClick(t, term, col, row, tuitest.MouseLeft, 0)
 	}
 }
 
@@ -337,6 +312,51 @@ func TestMouseTrackingAppKeepsItsOwnWheel(t *testing.T) {
 // the pane's own tty echo: button 64, a column, a row, and the press marker.
 var sgrWheelReport = regexp.MustCompile(`64;\d+;\d+M`)
 
+// sgrBareMotionReport matches a forwarded pointer motion with no button held,
+// echoed back by the pane's tty: button code 35, which is the no-button value 3
+// plus the motion bit 32.
+var sgrBareMotionReport = regexp.MustCompile(`35;\d+;\d+M`)
+
+// TestBareMotionReachesAnEventTrackingApp is the only place in this suite where
+// a pointer motion with no button held can be observed at all, and it exists as
+// much to pin that fact as to test the forwarding.
+//
+// cmd/tuios/run.go installs tea.WithFilter(filterMouseMotion), a whitelist that
+// drops every motion event unless a drag, a resize, an overlay drag, the
+// scrollback browser or a mouse-tracking pane is active. In every other state
+// the model never sees motion, so hover behaviour is not merely untested here,
+// it is unobservable: a helper that sends motion and an assertion on its effect
+// would be asserting on an event the shipping binary discards. That includes
+// the context menu's own hover highlight, which handleMouseMotion implements
+// and the filter never lets it reach.
+//
+// A pane that has asked for any-event tracking (DECSET 1003) is the exception,
+// and with the tty's echo on, the report it receives comes straight back as
+// text. See NEGATIVE_CONTROLS.md for the full list of blind spots.
+func TestBareMotionReachesAnEventTrackingApp(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	// 1003 is any-event tracking: motion is reported whether or not a button is
+	// down. 1006 asks for the SGR encoding.
+	runInShell(t, term, `printf '\033[?1003h\033[?1006h'; echo MOTIONON`, "MOTIONON", shellTimeout)
+
+	col, row := paneCell(t, term)
+	for i := range 4 {
+		mouseHover(t, term, col+i, row)
+	}
+
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return sgrBareMotionReport.MatchString(s.Text())
+	}, uiTimeout); err != nil {
+		t.Fatalf("a bare pointer motion was not forwarded to the pane that asked for "+
+			"any-event tracking: %v\n%s", err, term.Snapshot())
+	}
+	alive(t, term, "after moving the pointer over an any-event tracking pane")
+}
+
 // osc52 matches a clipboard write on the wire. tuios's copy path is
 // tea.SetClipboard, which is OSC 52, so this is what a copy looks like to the
 // terminal the user is actually sitting in front of.
@@ -371,21 +391,62 @@ func (b *lockedBuffer) String() string {
 	return b.buf.String()
 }
 
-// waitForClipboard blocks until tuios has written the wanted text to the
-// clipboard, and reports what it did write if it never does.
-func waitForClipboard(t *testing.T, term *tuitest.Terminal, out *lockedBuffer, want string) {
+// clipboardSince returns the clipboard writes made after the first n, with
+// surrounding whitespace trimmed the way the assertions compare them.
+func clipboardSince(out *lockedBuffer, n int) []string {
+	all := clipboardWrites(out)
+	if len(all) <= n {
+		return nil
+	}
+	got := make([]string, 0, len(all)-n)
+	for _, s := range all[n:] {
+		got = append(got, strings.TrimSpace(s))
+	}
+	return got
+}
+
+// clipboardSettle is how long waitClipboardSequence waits after the wanted
+// sequence arrives to be sure nothing else follows it.
+const clipboardSettle = 700 * time.Millisecond
+
+// waitClipboardSequence blocks until the clipboard writes made after the first
+// `from` are exactly `want`, in order, and then holds still to confirm nothing
+// further arrives.
+//
+// This exists because "the wanted text is somewhere in the list of writes" is
+// the wrong assertion for a gesture whose whole risk is how many times it
+// writes. A triple click passes through a word selection on its way to a line
+// selection and copies both, in that order; a paste taken between the two gets
+// the word. Asking only whether the line was written at some point cannot see
+// that, cannot see a stray write before it, and cannot see a duplicate after
+// it. The count and the order are the property, so they are what is asserted.
+//
+// The settle window is not decoration either. Without it a gesture that writes
+// one time too many satisfies the condition on its correct prefix and the extra
+// write lands after the test has moved on.
+func waitClipboardSequence(t *testing.T, term *tuitest.Terminal, out *lockedBuffer, from int, want ...string) {
 	t.Helper()
 	deadline := time.Now().Add(uiTimeout)
-	for time.Now().Before(deadline) {
-		for _, got := range clipboardWrites(out) {
-			if strings.TrimSpace(got) == want {
-				return
-			}
+	for {
+		got := clipboardSince(out, from)
+		if slices.Equal(got, want) {
+			break
+		}
+		if len(got) > len(want) {
+			t.Fatalf("the gesture wrote the clipboard more times than it should: got %q, want %q\n%s",
+				got, want, term.Snapshot())
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("the gesture never produced the clipboard writes %q; it wrote %q\n%s",
+				want, got, term.Snapshot())
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("no clipboard write of %q. tuios wrote %q\n%s",
-		want, clipboardWrites(out), term.Snapshot())
+	time.Sleep(clipboardSettle)
+	if got := clipboardSince(out, from); !slices.Equal(got, want) {
+		t.Fatalf("the gesture kept writing the clipboard after it was done: got %q, want %q\n%s",
+			got, want, term.Snapshot())
+	}
 }
 
 // TestDragSelectionCopiesOnRelease drives a real click-drag across a line of
@@ -407,85 +468,96 @@ func TestDragSelectionCopiesOnRelease(t *testing.T) {
 
 	dragSelect(t, term, col, col+len(marker)-1, row)
 
-	waitForClipboard(t, term, out, marker)
+	// Exactly one write: a drag is one gesture and copies once at the end of it.
+	waitClipboardSequence(t, term, out, 0, marker)
 	if err := term.WaitForText("Copied", uiTimeout); err != nil {
 		t.Errorf("no copy confirmation in the dock: %v\n%s", err, term.Snapshot())
 	}
 	alive(t, term, "after a drag selection")
 }
 
-// clipboardSettleTime is how long to keep watching after the expected write
-// lands, so a second, wrong write arriving late is caught rather than missed.
-// It is several times the multi-click window that gates a deferred copy.
-const clipboardSettleTime = 1500 * time.Millisecond
-
-// TestDoubleClickCopiesTheWord covers one of the two gestures every terminal
-// has had since the nineties and tuios had neither of.
+// TestDoubleClickCopiesAWordAndTripleClickTheLine covers the two gestures every
+// terminal has had since the nineties and tuios had neither of.
 //
 // The word is a path so the assertion also pins the word-character set: a
-// double-click that stopped at every punctuation mark would select "opt" and
+// double-click that stopped at every punctuation mark would select "usr" and
 // the test would say so.
-func TestDoubleClickCopiesTheWord(t *testing.T) {
-	out := &lockedBuffer{}
-	term, _ := start(t, startOpts{out: out})
-	row, col, word, _ := setupClickTarget(t, term)
-
-	clickAt(t, term, col+6, row, 2)
-	waitForClipboard(t, term, out, word)
-
-	time.Sleep(clipboardSettleTime)
-	if got := clipboardWrites(out); len(got) != 1 {
-		t.Errorf("a double-click produced %d clipboard writes, want exactly 1: %q", len(got), got)
-	}
-	alive(t, term, "after a double-click")
-}
-
-// TestTripleClickCopiesTheLineExactlyOnce is the regression test for a
-// triple-click copying twice.
 //
-// A triple-click reaches tuios as a double-click followed by a third press, and
-// copying on each release wrote the word first and the line second. The
-// clipboard ended up correct, so an assertion on the final contents passed
-// while the bug was live; what was wrong is that the word was ever written at
-// all, because a paste landing in the gap got it. Hence "exactly one write",
-// which is only assertable because the harness keeps them all.
-func TestTripleClickCopiesTheLineExactlyOnce(t *testing.T) {
+// Every gesture asserts the whole sequence of clipboard writes it produced, not
+// just that the wanted text turns up in it. A single click copies nothing, a
+// double click copies once, and a triple click copies twice because it passes
+// through the word on its way to the line and each release is a real release.
+// Those counts are the contract: they are what a paste taken mid-gesture gets,
+// and they are what the old helper could not generate, let alone assert on.
+func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
 	out := &lockedBuffer{}
 	term, _ := start(t, startOpts{out: out})
-	row, col, word, line := setupClickTarget(t, term)
-
-	clickAt(t, term, col+6, row, 3)
-	waitForClipboard(t, term, out, line)
-
-	time.Sleep(clipboardSettleTime)
-	got := clipboardWrites(out)
-	if len(got) != 1 {
-		t.Fatalf("a triple-click produced %d clipboard writes, want exactly 1: %q", len(got), got)
-	}
-	for _, w := range got {
-		if strings.TrimSpace(w) == word {
-			t.Errorf("the word %q reached the clipboard on the way to the line; a paste "+
-				"landing between the two writes would have got it", word)
-		}
-	}
-	alive(t, term, "after a triple-click")
-}
-
-// setupClickTarget boots a pane with one line of output and returns where it is
-// on screen along with the word and the whole line, which are what the two
-// multi-click gestures should each produce.
-func setupClickTarget(t *testing.T, term *tuitest.Terminal) (row, col int, word, line string) {
-	t.Helper()
 	waitBoot(t, term)
 	newWindow(t, term)
 	enterTerminalMode(t, term)
 
-	word = "/opt/dblclick/word.txt"
-	line = "PREFIX " + word + " SUFFIX"
+	const word = "/opt/dblclick/word.txt"
+	const line = "PREFIX " + word + " SUFFIX"
 	// The word is assembled from a variable so the shell's echo of the command
 	// does not itself contain it: otherwise findText lands on the command line
 	// rather than on the output, and the test asserts about the wrong row.
 	runInShell(t, term, `P=/opt; echo "PREFIX $P/dblclick/word.txt SUFFIX"`, word, shellTimeout)
-	row, col = findText(t, term, word)
-	return row, col, word, line
+	row, col := findText(t, term, word)
+
+	// One click is not a selection. It must leave the clipboard alone, or every
+	// stray click in a pane destroys whatever the user had copied.
+	clickAt(t, term, col+6, row, 1)
+	waitClipboardSequence(t, term, out, 0)
+	time.Sleep(gestureGap)
+
+	clickAt(t, term, col+6, row, 2)
+	waitClipboardSequence(t, term, out, 0, word)
+
+	// Let the multi-click window lapse, or the first press of the triple
+	// continues the double and the counts come out shifted.
+	time.Sleep(gestureGap)
+
+	// A triple click writes the line exactly once. The clipboard is not touched
+	// on the intermediate word: the write is deferred until the multi-click
+	// window closes, and the second click's word is retired when the third
+	// arrives (see internal/app/clipboard_copy.go). This is the whole point of
+	// the deferral, and asserting the count rather than the final contents is
+	// what makes it observable, since the final contents were always the line.
+	clickAt(t, term, col+6, row, 3)
+	waitClipboardSequence(t, term, out, 1, line)
+	alive(t, term, "after multi-click selection")
+}
+
+// TestClickInPaneDoesNotFreezeOutput is the standing guard on the press/release
+// pairing this harness now enforces, and on the product behaviour that pairing
+// depends on.
+//
+// A left press inside a pane sets OS.Dragging, and app.updateTerminals returns
+// early while it is set: tuios stops polling every pane's output for the
+// duration of the gesture, deliberately, so content cannot shift under the
+// pointer. The release is what clears it.
+//
+// So a helper that presses without releasing does not leave a harmless bit set.
+// It stops the whole program reading its panes, permanently, and every later
+// assertion in that test is made against a frozen screen. Measured: sending
+// this click press-only against a correct binary leaves FREEZE-AFTER-9 off the
+// screen for the full 20s budget. Guarded: a binary that fails to clear
+// OS.Dragging on release fails here, and passes every other mouse and context
+// menu test in this package.
+func TestClickInPaneDoesNotFreezeOutput(t *testing.T) {
+	term, _ := start(t, startOpts{})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	runInShell(t, term, "echo FREEZE-BEFORE-$((1+1))", "FREEZE-BEFORE-2", shellTimeout)
+	col, row := paneCell(t, term)
+
+	// A plain click in the middle of the pane: press and release, as a mouse does.
+	mouseClick(t, term, col, row, tuitest.MouseLeft, 0)
+
+	// The shell must still be able to put something new on screen. On a program
+	// left in interaction mode it never will, however long the timeout.
+	runInShell(t, term, "echo FREEZE-AFTER-$((3*3))", "FREEZE-AFTER-9", shellTimeout)
+	alive(t, term, "after clicking inside a pane")
 }


### PR DESCRIPTION
The clipboard double-copy bug was invisible to the test suite not because the assertions were weak but because the harness could not generate the input that triggers it. This audits every helper for that failure mode and fixes the ones that hid real bugs.

## Two helpers whose simulation diverged from reality

**`clickAt` sent n presses and one trailing release.** A real mouse sends press and release per click. tuios copies on release, so a triple-click in the harness produced a single release and the intermediate word-copy never happened. Proven: with a fault that makes every release copy, the old helpers pass `TestDoubleClickCopiesAWordAndTripleClickTheLine` and `TestDragSelectionCopiesOnRelease`, and the new ones fail with `the gesture wrote the clipboard more times than it should`. The contract is now pinned as counts: single writes nothing, double writes once, triple writes the line once.

**`leftClick` and `shiftRightClick` sent a press and no release at all**, and this is the worse one. A left press sets `OS.Dragging`, and `os_render.go` skips all terminal updates while it is set. So every assertion made after a click in the old suite ran against a program that had stopped reading its panes. Proven: with a fault that drops `o.Dragging = false` from the release handler (one click freezes every pane forever), all thirteen mouse and context-menu tests pass on the old helpers, and the new `TestClickInPaneDoesNotFreezeOutput` fails.

## Other divergences, fixed, honest about which caught a bug

- `runInShell` with an empty marker returned silently. No caller used it; a loaded gun, now fails loudly.
- Rename waits could be satisfied by the editor's echo of the typed keystrokes rather than the rename taking effect. Rewritten to wait for the underscore count to rise then the editor to close. No demonstrated blind spot, since both call sites have a follow-on dock assertion; reported as hardening.
- `enableTiling` slept 500ms and could be satisfied by a stale message, the exact `TestFocusCycleWithRapidKeyRepeat` trap. Now waits for its own message after clearing any earlier one. With a dead-tiling fault the old form fails 11s later blaming the context menu, the new form fails in 0.2s naming tiling.
- `killDaemon` swallowed its error and was registered by hand. Now registered by every `startIn` and verifies no session survives. Audit result: nothing was actually leaking.
- Verified correct rather than guessed: SGR button and modifier encodings, release encoding, per-cell drag motion, and wheel-without-release, which is the one gesture a real terminal genuinely leaves unpaired.

## What the harness structurally cannot observe

A new section in `NEGATIVE_CONTROLS.md` documents the traps rather than leaving them:

- **Motion outside a drag.** `filterMouseMotion` discards every motion event unless a drag, resize, overlay drag, scrollback browser or mouse-tracking pane is active. Hover is not untested, it is ungeneratable. `mouseHover` carries a warning and is used only by `TestBareMotionReachesAnEventTrackingApp`, which drives DECSET 1003, the one state where bare motion gets through.
- **Chords the terminal eats first** (kitty and shift+click): unreproducible, and their absence is indistinguishable from tuios ignoring them.
- **Typing speed**: `SendKeys` writes a whole string in one `write(2)`, closer to a paste than typing.

## A product finding this surfaced, now fixed elsewhere

`ContextMenuHover` was unreachable in the shipping binary for exactly the motion-filter reason above. That landed separately in the context-menu fix. This branch's doc wording is time-stamped so it does not become a false claim.

## Rebase note

Rebased onto main after the multi-click fix landed. That fix changed the clipboard contract this branch pins: a triple-click now writes the line once rather than word-then-line. The assertion was updated to the new contract, which is the correct one, and the whole point of counting writes rather than checking final contents is that this kind of change fails loudly here rather than silently.

`go build`, `go vet`, `gofmt`, `go test ./...` across 19 packages, and the nested `e2e/tui` module (154s) all pass.