### PR TITLE
Tell a mishandled triple-click from an undelivered one

### DIFF
--- a/e2e/tui/harness_test.go
+++ b/e2e/tui/harness_test.go
@@ -611,10 +611,30 @@ const (
 	// a time with human-scale gaps between them, and tuios coalesces motion to
 	// a frame budget, so back-to-back writes are not the input a user produces.
 	mouseGap = 30 * time.Millisecond
-	// multiClickGap separates the clicks of one multi-click gesture. It has to
-	// stay well under internal/input.multiClickInterval (500ms) or the clicks
-	// stop counting as one gesture.
-	multiClickGap = 40 * time.Millisecond
+	// multiClickHold is how long a button of a multi-click gesture stays down,
+	// and multiClickGap is the pause before the next one goes down. Together
+	// they set the press-to-press interval, which is the figure that has to stay
+	// inside internal/input.multiClickInterval for tuios to read the clicks as
+	// one gesture: 40ms against a 300ms window.
+	//
+	// They are shorter than mouseGap, and deliberately so. mouseGap is spaced
+	// for motion, which tuios coalesces to a frame budget; presses and releases
+	// pass through untouched (cmd/tuios/run.go filters motion and nothing else),
+	// and the harness was measured sending all six reports of a triple click
+	// with no pause at all and having every one of them counted, 10 times out of
+	// 10. So the pause between the clicks of one gesture buys no fidelity, and
+	// what it costs is margin: tuios measures the interval when it processes the
+	// press, not when the byte arrives, so every millisecond of nominal spacing
+	// is a millisecond less stall it takes to push the third click outside the
+	// window and turn the gesture into a double click plus a single one.
+	//
+	// Measured on this machine: with the interval widened deliberately, the
+	// gesture was still read as three clicks at 295ms and never at 300ms, so
+	// there is no fixed overhead to leave room for, only the stall. What is left
+	// is a hold short enough to be cheap and long enough to be a real button
+	// press.
+	multiClickHold = 15 * time.Millisecond
+	multiClickGap  = 25 * time.Millisecond
 	// gestureGap is long enough to guarantee the next press starts a fresh
 	// gesture rather than continuing the previous one.
 	gestureGap = 800 * time.Millisecond
@@ -624,10 +644,17 @@ const (
 // sequence of separate events rather than one burst.
 func sendMouse(t *testing.T, term *tuitest.Terminal, what string, ev tuitest.MouseEvent) {
 	t.Helper()
+	sendMouseThenWait(t, term, what, ev, mouseGap)
+}
+
+// sendMouseThenWait is sendMouse with the pause named by the caller, for the
+// one gesture whose whole meaning is how fast its reports arrive.
+func sendMouseThenWait(t *testing.T, term *tuitest.Terminal, what string, ev tuitest.MouseEvent, pause time.Duration) {
+	t.Helper()
 	if err := term.SendMouse(ev); err != nil {
 		t.Fatalf("%s at (%d,%d): %v", what, ev.Col, ev.Row, err)
 	}
-	time.Sleep(mouseGap)
+	time.Sleep(pause)
 }
 
 // mousePress sends a button-down. Every mousePress in a test must be matched by

--- a/e2e/tui/mouse_test.go
+++ b/e2e/tui/mouse_test.go
@@ -52,13 +52,22 @@ func dragSelect(t *testing.T, term *tuitest.Terminal, fromCol, toCol, row int) {
 // could not be generated at all, so no assertion could have observed them.
 // TestDoubleClickCopiesAWordAndTripleClickTheLine now asserts on the whole
 // sequence of writes rather than on whether the wanted text is somewhere in it.
+//
+// The clicks are paced by multiClickHold and multiClickGap rather than by the
+// harness's ordinary mouseGap, because for this one gesture the spacing is not
+// presentation, it is the input: tuios decides how many clicks it received by
+// how far apart it processed them.
 func clickAt(t *testing.T, term *tuitest.Terminal, col, row, n int) {
 	t.Helper()
 	for i := range n {
 		if i > 0 {
 			time.Sleep(multiClickGap)
 		}
-		mouseClick(t, term, col, row, tuitest.MouseLeft, 0)
+		ev := tuitest.MouseEvent{Col: col, Row: row, Button: tuitest.MouseLeft}
+		ev.Action = tuitest.MousePress
+		sendMouseThenWait(t, term, "press", ev, multiClickHold)
+		ev.Action = tuitest.MouseRelease
+		sendMouseThenWait(t, term, "release", ev, 0)
 	}
 }
 
@@ -449,6 +458,117 @@ func waitClipboardSequence(t *testing.T, term *tuitest.Terminal, out *lockedBuff
 	}
 }
 
+// selectionSpan reports which columns of a row tuios is painting as selected,
+// as a half-open [start, end), and (-1, -1) when it is painting none.
+//
+// The highlight is the only thing on a row of ordinary pane output that carries
+// a background colour: shell output is drawn on the terminal's default
+// background and internal/app.visualSelectionStyle sets one. So "this cell has
+// a background at all" identifies the selection without the test having to know
+// which colour the style resolved to on this terminal, which depends on the
+// colour profile the child detects.
+func selectionSpan(s tuitest.Screen, row int) (start, end int) {
+	cols, _ := s.Size()
+	start, end = -1, -1
+	for c := range cols {
+		if s.Cell(c, row).Bg.Kind == tuitest.ColorDefault {
+			continue
+		}
+		if start < 0 {
+			start = c
+		}
+		end = c + 1
+	}
+	return start, end
+}
+
+// describeSpan renders what selectionSpan returned for a failure message.
+func describeSpan(start, end int) string {
+	if start < 0 {
+		return "nothing"
+	}
+	return fmt.Sprintf("columns [%d,%d)", start, end)
+}
+
+// multiClickAttempts is how many times one multi-click gesture is re-sent when
+// tuios did not read it as a multi-click at all. Three is enough that losing
+// the race every time is not a plausible accident, and small enough that a
+// product that has genuinely stopped selecting still fails quickly.
+const multiClickAttempts = 3
+
+// selectByMultiClick clicks n times at one cell and returns once tuios has
+// highlighted exactly the columns that many clicks should select. It reports
+// how many clipboard writes had already been made when the gesture that
+// succeeded began, which is the baseline the caller's waitClipboardSequence
+// needs.
+//
+// This exists because a test that sends three clicks is not thereby a test of
+// what tuios does with a triple click. A click joins the gesture in progress
+// only if it arrives within internal/input.multiClickInterval of the last one,
+// measured in tuios at the moment it processes the press. The harness cannot
+// control that: it can only put the bytes in the pty and hope tuios is not
+// busy. When it is, the third press lands outside the window, tuios reads a
+// double click followed by a single one, and everything it does afterwards is
+// correct for the input it actually received. Asserting on the clipboard
+// without checking that first conflates "the product mishandled a triple
+// click", which must fail, with "the harness failed to deliver one", which
+// means nothing.
+//
+// The highlight is what makes the difference visible, and it is a sound witness
+// for the gesture because it is painted on the press: it is set before, and
+// independently of, the clipboard write being asserted on, so reading it does
+// not assume the answer. What it shows when a click falls outside the window is
+// a shorter gesture. Losing the third press leaves nothing highlighted, because
+// the stray single click starts a one-cell selection its own release finds
+// empty and drops the implicit copy-mode session with it. Losing the second
+// leaves the word highlighted, because the last two clicks are then a double
+// click of their own. Both of those were observed while measuring this.
+//
+// One outcome cannot be told from a lost race by looking at a single gesture: a
+// tuios that selected the word on three clicks would paint exactly what a lost
+// second press paints. Repetition separates them, and that is all the retry is
+// for. A lost race is a coin flip that comes up differently on the next throw;
+// a product that selects the wrong thing does it every time and fails on the
+// last attempt with the span it painted in the message. So the retry is driven
+// by a measured property of the gesture, never by a failed assertion, and it is
+// bounded.
+//
+// Measured on a 16-core machine oversubscribed with 256 busy loops, which is
+// the only way the race was made to happen at all: at the pacing this harness
+// sends, 4 to 9 of every 100 triple clicks came out short. Idle, and with the
+// machine merely busy rather than swamped, none of several hundred did.
+func selectByMultiClick(t *testing.T, term *tuitest.Terminal, out *lockedBuffer, col, row, n, wantStart, wantEnd int) int {
+	t.Helper()
+	for attempt := 1; ; attempt++ {
+		from := len(clipboardWrites(out))
+		clickAt(t, term, col, row, n)
+
+		err := term.WaitFor(func(s tuitest.Screen) bool {
+			start, end := selectionSpan(s, row)
+			return start == wantStart && end == wantEnd
+		}, uiTimeout)
+		if err == nil {
+			return from
+		}
+
+		got := describeSpan(selectionSpan(term.Screen(), row))
+		want := describeSpan(wantStart, wantEnd)
+		if attempt == multiClickAttempts {
+			t.Fatalf("%d clicks at (%d,%d) selected %s on all %d attempts, and %d clicks select "+
+				"%s; a gesture that comes out short every time is not the machine losing a "+
+				"race, it is multi-click selection selecting the wrong thing\n%s",
+				n, col, row, got, attempt, n, want, term.Snapshot())
+		}
+		t.Logf("attempt %d: %d clicks at (%d,%d) selected %s rather than %s, so tuios read them "+
+			"as a shorter gesture; the harness lost the race against "+
+			"internal/input.multiClickInterval, re-sending", attempt, n, col, row, got, want)
+		// Long enough that the retry's first press cannot join the gesture that
+		// just ended, and that any deferred write the short gesture did produce
+		// has landed before the next baseline is taken.
+		time.Sleep(gestureGap)
+	}
+}
+
 // TestDragSelectionCopiesOnRelease drives a real click-drag across a line of
 // output and asserts the text left the process on the clipboard.
 //
@@ -489,6 +609,11 @@ func TestDragSelectionCopiesOnRelease(t *testing.T) {
 // through the word on its way to the line and each release is a real release.
 // Those counts are the contract: they are what a paste taken mid-gesture gets,
 // and they are what the old helper could not generate, let alone assert on.
+//
+// Each multi-click also asserts the highlight it painted, which is both a
+// stronger claim about the gesture and the thing that lets the test tell a
+// mishandled triple click apart from one the harness never managed to deliver;
+// see selectByMultiClick.
 func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
 	out := &lockedBuffer{}
 	term, _ := start(t, startOpts{out: out})
@@ -504,14 +629,28 @@ func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
 	runInShell(t, term, `P=/opt; echo "PREFIX $P/dblclick/word.txt SUFFIX"`, word, shellTimeout)
 	row, col := findText(t, term, word)
 
+	// Where each gesture's highlight has to land. A double click selects the
+	// word and nothing either side of it, which is the same claim about the
+	// word-character set that the clipboard assertion makes, in the other place
+	// the user can see it. A triple click selects the whole line: it starts
+	// seven columns earlier, at the P of PREFIX, and ends seven later, after the
+	// X of SUFFIX.
+	const affix = len("PREFIX ")
+	wordStart, wordEnd := col, col+len(word)
+	lineStart, lineEnd := col-affix, col+len(word)+affix
+
 	// One click is not a selection. It must leave the clipboard alone, or every
 	// stray click in a pane destroys whatever the user had copied.
 	clickAt(t, term, col+6, row, 1)
 	waitClipboardSequence(t, term, out, 0)
+	if start, end := selectionSpan(term.Screen(), row); start >= 0 {
+		t.Fatalf("a single click selected columns [%d,%d); it must select nothing\n%s",
+			start, end, term.Snapshot())
+	}
 	time.Sleep(gestureGap)
 
-	clickAt(t, term, col+6, row, 2)
-	waitClipboardSequence(t, term, out, 0, word)
+	from := selectByMultiClick(t, term, out, col+6, row, 2, wordStart, wordEnd)
+	waitClipboardSequence(t, term, out, from, word)
 
 	// Let the multi-click window lapse, or the first press of the triple
 	// continues the double and the counts come out shifted.
@@ -523,8 +662,8 @@ func TestDoubleClickCopiesAWordAndTripleClickTheLine(t *testing.T) {
 	// arrives (see internal/app/clipboard_copy.go). This is the whole point of
 	// the deferral, and asserting the count rather than the final contents is
 	// what makes it observable, since the final contents were always the line.
-	clickAt(t, term, col+6, row, 3)
-	waitClipboardSequence(t, term, out, 1, line)
+	from = selectByMultiClick(t, term, out, col+6, row, 3, lineStart, lineEnd)
+	waitClipboardSequence(t, term, out, from, line)
 	alive(t, term, "after multi-click selection")
 }
 

--- a/internal/input/mouse_multiclick_test.go
+++ b/internal/input/mouse_multiclick_test.go
@@ -169,14 +169,20 @@ func TestDragFromTheSecondClickCopiesTheDraggedRange(t *testing.T) {
 // the line rather than copying the word because the timer expired mid-gesture.
 func TestASlowTripleClickStillResolvesToTheLine(t *testing.T) {
 	const line = "alpha bravo charlie"
-	o, _ := selectPane(t, line)
+	o, win := selectPane(t, line)
 
 	pressAt(o, 6, 0)
 	pressAt(o, 6, 0)
 	wordCopy := release(o, 6, 0)
 
-	// Late, but still inside the window.
-	time.Sleep(multiClickInterval * 2 / 3)
+	// Late, but still inside the window. The delay is put on the clock rather
+	// than slept through: sleeping two thirds of the window and then requiring
+	// the press to land inside the remaining third is a race against whatever
+	// else the machine is doing, and this test would lose it by reporting that
+	// tuios mishandled a slow triple-click when all that happened is that the
+	// test was descheduled. Backdating asserts the same thing, and the interval
+	// tuios reads is then the one the test asked for.
+	win.LastClickTime = time.Now().Add(-multiClickInterval * 2 / 3)
 
 	pressAt(o, 6, 0)
 	if got := o.PendingCopyText(); got != "" {


### PR DESCRIPTION
`TestDoubleClickCopiesAWordAndTripleClickTheLine` fails about one run in twelve under load and passes in isolation every time. It conflated two outcomes that deserve different treatment: **the product mishandled a triple-click**, which must fail, and **the harness failed to deliver one**, which must not.

## Measured rather than assumed

`multiClickInterval` is 300 ms. The harness was producing a **100 ms** press-to-press interval, not the 80 to 120 ms previously estimated: `clickAt` paid `mouseGap` after the press, `mouseGap` again after the release, then `multiClickGap`.

Widening the interval deliberately showed the gesture still read as three clicks at 295 ms nominal and never at 300 ms, so harness-to-tuios overhead at rest is under 5 ms and a failure needs a genuine ~200 ms stall of the update loop. CPU saturation at 16, 24 and 48 busy loops on a 16-core machine never produced one: **32 full-suite runs, 0 failures**. It took 256 busy loops. That is precisely why passing a few times proves nothing here.

## A second degradation mode, which changes the fix

Losing the **second** press rather than the third leaves the last two clicks forming a double-click of their own, so the **word** stays highlighted. A fix that treated a wrong highlight as a hard failure would have converted that race into a hard failure. The naive version of this fix would have been wrong.

## The fix

Each multi-click now asserts **the span of the highlight it painted** (word = exactly the word's columns; line = seven columns wider each side). That is the product's own interpretation of the gesture, painted on the press, before and independently of the clipboard write being asserted. It is a strictly stronger assertion than the test had.

The gesture is re-sent **only when the painted span shows tuios never saw a multi-click**, bounded at three attempts and ending in a failure that names the span. This is not a blind retry: it never retries a failed assertion, only a gesture the product demonstrably never received.

The one genuinely ambiguous outcome, a product that wrongly selects the word on three clicks painting the same thing as a lost second press, is separated by repetition rather than ignored: a race throws differently next time, a broken product does it every time and fails.

Clicks within one gesture are also paced for the gesture (15 ms hold, 25 ms gap, so 40 ms press-to-press instead of 100 ms), justified by measurement: a triple-click sent with **no pause at all** was counted as three clicks 10 times out of 10, because `cmd/tuios/run.go` filters motion and nothing else. A stale comment claiming the window is 500 ms is corrected.

## Results

All under 256 busy loops on 16 cores, the only condition that reproduced it.

| | before | after |
| --- | --- | --- |
| targeted runs | **7 / 60 failed (11.7%)** | **0 / 60**, short gesture detected and re-sent in 5 |
| full-suite runs | **1 / 12 failed (8.3%)** | **0 / 12** |
| per-gesture degradation | 4 to 9 per 100 triple-clicks | unchanged rate, now recognised |

The old failure signatures match the mechanism exactly: 4 wrote `[]` (both gaps lost), 3 wrote `[word]` (third press lost), and 1 failed in the **double**-click phase, so the double-click was fragile too. The fix covers that as well.

## It still fails on a real regression

- Copying immediately instead of deferring: **FAIL**, `got ["/opt/dblclick/word.txt" "PREFIX ... SUFFIX"]`.
- Triple-click selecting the word instead of the line: **FAIL** after the bounded retries, `selected columns [38,60) on all 3 attempts, and 3 clicks select columns [31,67); a gesture that comes out short every time is not the machine losing a race`.

## One more with the same shape

`TestASlowTripleClickStillResolvesToTheLine` slept two thirds of the window and then required the press to land in the remaining third. It now backdates `LastClickTime` instead of sleeping, and still fails if the window is narrowed. It never actually failed in 100 loaded runs, but the exposure was real and removing it was free.

`clickAt` is the only multi-click sender in the suite, and `registerClick` is reached only by a left press in pane content, so the context-menu and wheel tests never touch the window.

## Unrelated, not touched

Under 256 busy loops the five `TestProjectTape*` tests fail in essentially every run. That is a different load sensitivity; they never failed at 24 burners.

No product code changed. `go build`, `go vet`, `gofmt` across both modules, `go test ./...`, and the nested `e2e/tui` module all pass.