### PR TITLE
Treat incoming terminal paste as passthrough, not a clipboard event

### DIFF
--- a/e2e/tui/incoming_paste_test.go
+++ b/e2e/tui/incoming_paste_test.go
@@ -1,0 +1,119 @@
+package tuie2e
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// A bracketed-paste burst arriving from the OUTER terminal (ESC[200~ ... ESC[201~)
+// is passthrough input, not a clipboard operation. fcitx5 and other IMEs commit
+// text wrapped exactly this way, and the burst a real PTY delivers is byte for
+// byte what tuios receives here. It must reach the focused pane and must NOT
+// raise the "Pasted N characters" notification that a real clipboard paste does.
+// This is the regression from issue #113.
+//
+// The payload is multi-byte CJK on purpose: nothing in the paste path may assume
+// one byte per character.
+func TestIncomingBracketedPasteReachesPaneSilently(t *testing.T) {
+	term, _ := start(t, startOpts{cols: 120, rows: 40})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	// The inner /bin/sh does not enable bracketed paste, so tuios forwards the
+	// text raw and the shell echoes it at the prompt. Sending the outer markers
+	// is what a real terminal (or fcitx5) does; tuios's input parser turns them
+	// into a single paste event.
+	if err := term.Type("\x1b[200~中文\x1b[201~"); err != nil {
+		t.Fatalf("send bracketed paste burst: %v", err)
+	}
+
+	if err := term.WaitForText("中文", shellTimeout); err != nil {
+		t.Fatalf("the pasted CJK text never reached the pane: %v\n%s", err, term.Snapshot())
+	}
+	if got := dockRow(term.Screen()); strings.Contains(got, "Pasted") {
+		t.Fatalf("an incoming terminal paste raised a %q notification; IME/terminal "+
+			"paste must be silent (issue #113)\ndock row: %q\n%s", "Pasted", got, term.Snapshot())
+	}
+	alive(t, term, "after an incoming bracketed paste")
+}
+
+// osc52Responder mirrors the PTY output stream and, once armed, answers the
+// first OSC 52 clipboard read query with a fixed payload, exactly as a real
+// terminal with a populated clipboard would. This is what lets the harness
+// exercise tuios's OWN clipboard paste end to end: Ctrl+Shift+V emits the query,
+// the terminal answers, and tuios pastes the answer.
+type osc52Responder struct {
+	mu      sync.Mutex
+	buf     []byte
+	term    *tuitest.Terminal
+	replyB  string
+	armed   bool
+	replied bool
+}
+
+func (r *osc52Responder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buf = append(r.buf, p...)
+	// An OSC 52 read query is ESC ] 52 ; <selection> ; ? <terminator>. Matching
+	// the "]52;" introducer and a trailing "?" is enough to recognize it without
+	// depending on the selection byte or terminator.
+	if r.armed && !r.replied && r.term != nil &&
+		bytes.Contains(r.buf, []byte("]52;")) && bytes.Contains(r.buf, []byte("?")) {
+		r.replied = true
+		term, reply := r.term, r.replyB
+		// Answer off the reader goroutine so this Write does not block.
+		go func() { _ = term.Type("\x1b]52;c;" + reply + "\x07") }()
+	}
+	return len(p), nil
+}
+
+func (r *osc52Responder) arm(term *tuitest.Terminal) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.term = term
+	r.buf = r.buf[:0]
+	r.armed = true
+}
+
+// TUIOS's own clipboard paste (Ctrl+Shift+V, which reads the clipboard over
+// OSC 52) is a genuine clipboard operation: it pastes the clipboard content AND
+// notifies. This is the other side of issue #113 and must keep working, so the
+// two paths are proven distinct: incoming terminal paste is silent, clipboard
+// paste notifies.
+func TestClipboardPasteStillPastesAndNotifies(t *testing.T) {
+	const clip = "CLIPPASTEXYZ"
+	resp := &osc52Responder{replyB: base64.StdEncoding.EncodeToString([]byte(clip))}
+
+	term, _ := start(t, startOpts{cols: 120, rows: 40, out: resp})
+	waitBoot(t, term)
+	newWindow(t, term)
+	enterTerminalMode(t, term)
+
+	resp.arm(term)
+
+	// Ctrl+Shift+V in the Kitty CSI u encoding: 'v' is 118, modifier 6 is
+	// ctrl+shift. tuios reads this as a clipboard-paste request and emits the
+	// OSC 52 query the responder answers.
+	if err := term.SendKeys(tuitest.Key("\x1b[118;6u")); err != nil {
+		t.Fatalf("send ctrl+shift+v: %v", err)
+	}
+
+	if err := term.WaitForText(clip, shellTimeout); err != nil {
+		t.Fatalf("the clipboard content never reached the pane: %v\n%s", err, term.Snapshot())
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return strings.Contains(dockRow(s), "Pasted")
+	}, uiTimeout); err != nil {
+		t.Fatalf("a real clipboard paste did not raise the \"Pasted\" notification; the "+
+			"clipboard path must stay distinct from the silent incoming-paste path: %v\n%s",
+			err, term.Snapshot())
+	}
+	alive(t, term, "after a real clipboard paste")
+}

--- a/internal/input/handler.go
+++ b/internal/input/handler.go
@@ -54,11 +54,13 @@ func HandleInput(msg tea.Msg, o *app.OS) (tea.Model, tea.Cmd) {
 			result, cmd = handleMouseWheel(msg, o)
 		}
 	case tea.PasteMsg:
-		// Handle bracketed paste from terminal (when pasting via Cmd+V in Ghostty, etc.)
-		// Only handle paste in terminal mode
+		// Incoming bracketed paste from the outer terminal (ESC[200~ ... ESC[201~).
+		// This is passthrough input, not a clipboard operation: the outer terminal
+		// pasted on the user's behalf, or an IME such as fcitx5 wrapped a commit in
+		// paste markers. Forward it to the focused window's PTY without touching the
+		// stored clipboard and without a "Pasted" notification (matching tmux/VTM).
 		if o.Mode == app.TerminalMode {
-			o.ClipboardContent = msg.Content
-			handleClipboardPaste(o)
+			forwardPasteToFocused(o, msg.Content)
 		}
 		return o, nil
 	case tea.ClipboardMsg:

--- a/internal/input/incoming_paste_test.go
+++ b/internal/input/incoming_paste_test.go
@@ -1,0 +1,128 @@
+package input
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// pasteHarness builds a focused pane in terminal mode whose PTY writes are
+// captured instead of touching a real kernel PTY. The window runs in daemon
+// mode so SendInput routes through DaemonWriteFunc, which is the path a real
+// daemon session uses. sent accumulates everything delivered to the PTY.
+func pasteHarness(t *testing.T, bracketed bool) (*app.OS, *strings.Builder) {
+	t.Helper()
+
+	em := vt.NewEmulator(40, 20)
+	t.Cleanup(func() { _ = em.Close() })
+	if bracketed {
+		// ?2004h: the inner app turns on bracketed paste mode.
+		if _, err := em.Write([]byte("\x1b[?2004h")); err != nil {
+			t.Fatalf("enable bracketed paste: %v", err)
+		}
+	}
+
+	var sent strings.Builder
+	win := &terminal.Window{
+		Terminal:   em,
+		X:          0,
+		Y:          0,
+		Width:      42,
+		Height:     22,
+		DaemonMode: true,
+		DaemonWriteFunc: func(b []byte) error {
+			sent.Write(b)
+			return nil
+		},
+	}
+	o := &app.OS{
+		Mode:          app.TerminalMode,
+		FocusedWindow: 0,
+		Windows:       []*terminal.Window{win},
+		Width:         80,
+		Height:        30,
+	}
+	return o, &sent
+}
+
+func hasPastedNotification(o *app.OS) bool {
+	for _, n := range o.Notifications {
+		if strings.Contains(n.Message, "Pasted") {
+			return true
+		}
+	}
+	return false
+}
+
+// An incoming tea.PasteMsg is passthrough input from the outer terminal (for
+// example an fcitx5 IME commit that arrives wrapped in bracketed-paste
+// markers). It must reach the pane's PTY verbatim, must not overwrite the
+// user's stored clipboard, and must not raise a "Pasted N characters"
+// notification. This is the regression from issue #113.
+func TestIncomingPasteIsPassthroughNotClipboard(t *testing.T) {
+	o, sent := pasteHarness(t, false)
+
+	const sentinel = "user-clipboard-do-not-touch"
+	o.ClipboardContent = sentinel
+
+	_, _ = HandleInput(tea.PasteMsg{Content: "中文"}, o)
+
+	if o.ClipboardContent != sentinel {
+		t.Errorf("ClipboardContent = %q, want it left as %q: an incoming terminal paste "+
+			"must not clobber the user's real clipboard", o.ClipboardContent, sentinel)
+	}
+	if hasPastedNotification(o) {
+		t.Errorf("incoming paste raised a %q notification; IME/terminal paste must be silent",
+			"Pasted")
+	}
+	if got := sent.String(); got != "中文" {
+		t.Errorf("PTY received %q, want the CJK text %q delivered raw (inner app has no "+
+			"bracketed paste)", got, "中文")
+	}
+}
+
+// When the inner app has bracketed paste enabled, the incoming paste must be
+// re-wrapped so the app still sees a paste, and the multi-byte UTF-8 payload
+// must survive the wrapping intact.
+func TestIncomingPasteRewrapsWhenBracketedPasteEnabled(t *testing.T) {
+	o, sent := pasteHarness(t, true)
+	o.ClipboardContent = "keep-me"
+
+	_, _ = HandleInput(tea.PasteMsg{Content: "中文"}, o)
+
+	want := "\x1b[200~中文\x1b[201~"
+	if got := sent.String(); got != want {
+		t.Errorf("PTY received %q, want bracketed %q", got, want)
+	}
+	if o.ClipboardContent != "keep-me" {
+		t.Errorf("ClipboardContent = %q, want it untouched", o.ClipboardContent)
+	}
+	if hasPastedNotification(o) {
+		t.Error("bracketed incoming paste must still be silent")
+	}
+}
+
+// TUIOS's own clipboard paste (the OSC 52 read response, tea.ClipboardMsg) is a
+// real clipboard operation. It stores the content and notifies. This path must
+// keep working so the two are provably distinct.
+func TestClipboardMsgStillPastesAndNotifies(t *testing.T) {
+	o, sent := pasteHarness(t, false)
+
+	_, _ = HandleInput(tea.ClipboardMsg{Content: "hello"}, o)
+
+	if o.ClipboardContent != "hello" {
+		t.Errorf("ClipboardContent = %q, want %q stored from the clipboard read",
+			o.ClipboardContent, "hello")
+	}
+	if !hasPastedNotification(o) {
+		t.Error("a real clipboard paste must still show the \"Pasted\" notification")
+	}
+	if got := sent.String(); got != "hello" {
+		t.Errorf("PTY received %q, want %q", got, "hello")
+	}
+}

--- a/internal/input/selection.go
+++ b/internal/input/selection.go
@@ -146,14 +146,39 @@ func extractSelectedText(window *terminal.Window, _ *app.OS) string {
 	return strings.TrimSpace(selectedText.String())
 }
 
-// handleClipboardPaste processes clipboard content and sends it to the focused terminal
-func handleClipboardPaste(o *app.OS) {
-	if o.FocusedWindow < 0 || o.FocusedWindow >= len(o.Windows) {
-		return
-	}
-
+// forwardPasteToFocused sends paste text to the focused window's PTY, wrapping it in
+// bracketed-paste markers when the inner app has that mode enabled and sending it raw
+// otherwise. It never touches o.ClipboardContent and never shows a notification.
+//
+// It is used both by TUIOS's own clipboard paste (which layers notifications on top)
+// and by the incoming-terminal-paste path, where a tea.PasteMsg is passthrough input
+// (for example an fcitx5 IME commit) and must be delivered silently.
+//
+// SendInput() is used instead of Terminal.Paste() because in daemon mode
+// Terminal.Paste() writes to an internal pipe that gets drained by
+// StartDaemonResponseReader(), so the data never reaches the PTY. SendInput()
+// properly routes through DaemonWriteFunc in daemon mode. Returns false when there
+// is no focused window or the write fails.
+func forwardPasteToFocused(o *app.OS, text string) bool {
 	focusedWindow := o.GetFocusedWindow()
 	if focusedWindow == nil {
+		return false
+	}
+
+	pasteContent := text
+	if focusedWindow.Terminal != nil && focusedWindow.Terminal.BracketedPasteEnabled() {
+		pasteContent = "\x1b[200~" + pasteContent + "\x1b[201~"
+	}
+
+	return focusedWindow.SendInput([]byte(pasteContent)) == nil
+}
+
+// handleClipboardPaste processes stored clipboard content and sends it to the focused
+// terminal, notifying the user of the result. This is the path for TUIOS's own paste
+// actions (Cmd/Ctrl+V and the OSC 52 clipboard read response), not for incoming
+// terminal paste.
+func handleClipboardPaste(o *app.OS) {
+	if o.GetFocusedWindow() == nil {
 		return
 	}
 
@@ -162,17 +187,7 @@ func handleClipboardPaste(o *app.OS) {
 		return
 	}
 
-	// Build paste content with bracketed paste sequences if the app has enabled it.
-	// We use SendInput() instead of Terminal.Paste() because in daemon mode,
-	// Terminal.Paste() writes to an internal pipe that gets drained by
-	// StartDaemonResponseReader() - the data never reaches the PTY.
-	// SendInput() properly routes through DaemonWriteFunc in daemon mode.
-	pasteContent := o.ClipboardContent
-	if focusedWindow.Terminal != nil && focusedWindow.Terminal.BracketedPasteEnabled() {
-		pasteContent = "\x1b[200~" + pasteContent + "\x1b[201~"
-	}
-
-	if err := focusedWindow.SendInput([]byte(pasteContent)); err != nil {
+	if !forwardPasteToFocused(o, o.ClipboardContent) {
 		o.ShowNotification("Paste failed", "error", config.NotificationDuration)
 		return
 	}


### PR DESCRIPTION
Fixes #113. Chinese text committed through fcitx5 was reported as `Pasted N characters` and handled as a paste rather than as input.

## Cause

Alacritty with fcitx5 wraps an IME commit in bracketed-paste markers (`ESC[200~ ... ESC[201~`). The input parser only enters paste mode on a real marker, so the commit reaches tuios as a `tea.PasteMsg`. The handler treated any incoming `PasteMsg` as a clipboard operation:

```go
case tea.PasteMsg:
    if o.Mode == app.TerminalMode {
        o.ClipboardContent = msg.Content   // clobbers the user's clipboard
        handleClipboardPaste(o)            // shows "Pasted N characters"
    }
```

Two wrongs: it overwrote the stored clipboard with the incoming text, and it notified. tmux and VTM forward terminal-originated bracketed paste to the inner program transparently and do neither, which is the behaviour the reporter observed as correct.

## Fix

Incoming paste from the outer terminal is passthrough input, not a clipboard action. New `forwardPasteToFocused` forwards the text to the focused window's PTY, re-wrapping in `ESC[200~`/`ESC[201~` when the inner app has bracketed paste enabled and sending raw otherwise, via `SendInput` so daemon mode works. It does not touch `o.ClipboardContent` and shows no notification.

`handleClipboardPaste` now layers the stored-clipboard read, the empty-clipboard warning, and the `Pasted N characters` success notification on top of that same forward, so tuios's own paste actions (Ctrl+Shift+V, OSC 52 read) keep the clipboard and the notification. The `tea.ClipboardMsg` case is a genuine OSC 52 read response and is untouched.

No notification at all on the incoming-paste path, by design: a user typing via IME is not pasting, and a large terminal-side paste showing nothing also matches tmux.

## Reproducible without an IME

`ESC[200~<text>ESC[201~` through a PTY is byte-identical to what fcitx5 sends.

- Unit `internal/input/incoming_paste_test.go`: a `tea.PasteMsg{Content: "中文"}` in terminal mode must leave `o.ClipboardContent` unchanged, queue no notification, and reach the focused window. Both assertions fail on main, confirmed by running the test against `origin/main`.
- e2e `e2e/tui/incoming_paste_test.go`: `TestIncomingBracketedPasteReachesPaneSilently` sends the marker burst and asserts `中文` reaches the pane with no `Pasted` in the dock. Against the unfixed binary it fails with `Pasted 6 characters` (6 = the UTF-8 byte length of 中文, the exact byte-count symptom in the report). A companion test drives a real Ctrl+Shift+V, answers the OSC 52 query, and asserts the paste content and the `Pasted` notification, proving the two paths stay distinct.

CJK confirmed multi-byte-safe on both the raw and re-wrapped paths.

`go build`, `go vet`, `gofmt`, `go test ./...`, and the nested `e2e/tui` module all pass.