### PR TITLE
Fix daemon-mode shared-border splits and stale separators

### DIFF
--- a/e2e/tui/daemon_shared_borders_test.go
+++ b/e2e/tui/daemon_shared_borders_test.go
@@ -1,0 +1,191 @@
+package tuie2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// countTallVerticalBorders returns how many interior columns are a vertical
+// box-drawing border for most of the usable height. The splash screen's own
+// centered welcome box contributes its two side borders, so the test compares
+// this count against a fresh-splash baseline rather than expecting zero: a
+// leftover separator adds a column the clean splash never had.
+func countTallVerticalBorders(s tuitest.Screen) int {
+	cols, rows := s.Size()
+	if cols < 8 || rows < 6 {
+		return 0
+	}
+	isVert := func(r rune) bool {
+		switch r {
+		case '│', '┃', '║', '|', '┆', '┇', '┊', '┋':
+			return true
+		}
+		return false
+	}
+	n := 0
+	for c := 3; c < cols-3; c++ {
+		run := 0
+		for r := 1; r < rows-2; r++ {
+			line := []rune(s.Line(r))
+			if c < len(line) && isVert(line[c]) {
+				run++
+			}
+		}
+		if run >= (rows-3)/2 {
+			n++
+		}
+	}
+	return n
+}
+
+// countWideHorizontalBorders is the horizontal analogue: interior rows that are
+// a horizontal border for most of the usable width. The welcome box's top and
+// bottom borders contribute here, so the same baseline comparison applies.
+func countWideHorizontalBorders(s tuitest.Screen) int {
+	cols, rows := s.Size()
+	if cols < 8 || rows < 8 {
+		return 0
+	}
+	isHoriz := func(r rune) bool {
+		switch r {
+		case '─', '━', '═', '┄', '┅', '┈', '┉':
+			return true
+		}
+		return false
+	}
+	n := 0
+	for r := 2; r < rows-3; r++ {
+		line := []rune(s.Line(r))
+		run := 0
+		for c := 2; c < cols-2; c++ {
+			if c < len(line) && isHoriz(line[c]) {
+				run++
+			}
+		}
+		if run >= (cols-4)/2 {
+			n++
+		}
+	}
+	return n
+}
+
+// closeFocusedWindow closes the focused window through the 'w' window-management
+// binding and waits for the dock count to drop by one. In a daemon session the
+// close is a round trip: the client asks the daemon, the daemon kills the pane
+// and pushes state back, and only then does the count move.
+func closeFocusedWindow(t *testing.T, term *tuitest.Terminal, want int) {
+	t.Helper()
+	if err := term.SendKeys("w"); err != nil {
+		t.Fatalf("send 'w': %v", err)
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return countWindows(s) == want
+	}, uiTimeout); err != nil {
+		t.Fatalf("window count never fell to %d after close (last %d): %v\n%s",
+			want, countWindows(term.Screen()), err, term.Snapshot())
+	}
+}
+
+// TestDaemonSharedBordersSeparatorClearsOnClose reproduces the reported bug:
+// with shared borders on in a daemon session, three tiled windows draw interior
+// separators, and after every window is closed the separators must be gone. On
+// the broken build the client rebuilds nothing when the last window leaves, so
+// the BSP tree keeps the closed windows and CollectSplits still draws their
+// dividers over the splash screen.
+func TestDaemonSharedBordersSeparatorClearsOnClose(t *testing.T) {
+	term, base := start(t, startOpts{cols: 120, rows: 40, args: []string{"--shared-borders", "new", "sb"}})
+	killDaemon(t, base)
+	waitBoot(t, term)
+
+	// Baseline: the clean splash already draws its own centered welcome box, whose
+	// side, top and bottom borders count as full-length interior borders. A
+	// leftover separator is anything drawn on top of this, so the after-close
+	// screen must not exceed these counts.
+	baseV := countTallVerticalBorders(term.Screen())
+	baseH := countWideHorizontalBorders(term.Screen())
+
+	// Tiling on while empty, then three windows into the tiled session.
+	enableTiling(t, term)
+	for i := 1; i <= 3; i++ {
+		newWindow(t, term)
+		waitWindowCount(t, term, i, fmt.Sprintf("after new window #%d", i))
+	}
+
+	// Sanity: three tiled panes under shared borders show an interior vertical
+	// divider. If they never do, the rest of the test proves nothing.
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return hasInteriorVerticalSplit(s)
+	}, uiTimeout); err != nil {
+		t.Fatalf("three tiled windows never drew an interior separator: %v\n%s", err, term.Snapshot())
+	}
+
+	// Close every window.
+	for remaining := 2; remaining >= 0; remaining-- {
+		closeFocusedWindow(t, term, remaining)
+	}
+	waitWindowCount(t, term, 0, "after closing all windows")
+
+	// The splash screen is back. Give the final close round trip a beat to land
+	// and settle, then require that no separator survives beyond the splash box.
+	if err := term.WaitForText(welcomeText, uiTimeout); err != nil {
+		t.Fatalf("splash never returned after closing all windows: %v\n%s", err, term.Snapshot())
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		s := term.Screen()
+		if countTallVerticalBorders(s) <= baseV && countWideHorizontalBorders(s) <= baseH {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	s := term.Screen()
+	t.Fatalf("separators still drawn after all windows closed "+
+		"(vertical %d>%d or horizontal %d>%d beyond the clean splash):\n%s",
+		countTallVerticalBorders(s), baseV, countWideHorizontalBorders(s), baseH, term.Snapshot())
+}
+
+// TestDaemonForcedVerticalSplitStaysVertical reproduces the second bug: in a
+// daemon session, ctrl+b | (and the bare '|' window-management binding it shares
+// SplitFocusedVertical with) must force a vertical split every time. On the
+// broken build the forced direction is dropped on the daemon path, so the new
+// window is placed by the default spiral scheme and the splits alternate
+// vertical/horizontal by depth. Three forced vertical splits must leave four
+// panes all spanning the full usable height, i.e. sharing one Y and one Height.
+func TestDaemonForcedVerticalSplitStaysVertical(t *testing.T) {
+	term, base := start(t, startOpts{cols: 160, rows: 40, args: []string{"new", "vs"}})
+	killDaemon(t, base)
+	waitBoot(t, term)
+
+	enableTiling(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "first window")
+
+	// Force a vertical split three times via the window-management '|' binding,
+	// which calls the same SplitFocusedVertical as ctrl+b |.
+	for i := 2; i <= 4; i++ {
+		if err := term.SendKeys("|"); err != nil {
+			t.Fatalf("send '|' #%d: %v", i, err)
+		}
+		waitWindowCount(t, term, i, fmt.Sprintf("after forced vertical split #%d", i))
+	}
+
+	rects := waitForSettledGeometry(t, base, 4)
+	for _, r := range rects {
+		t.Logf("window %s: (%d,%d) %dx%d", r.ID, r.X, r.Y, r.Width, r.Height)
+	}
+
+	// Under pure vertical splits every pane spans the full height: same Y, same
+	// Height. Any horizontal split leaves at least one pane at a different Y or a
+	// reduced Height, which is the signature of the alternating-direction bug.
+	y0, h0 := rects[0].Y, rects[0].Height
+	for _, r := range rects {
+		if r.Y != y0 || r.Height != h0 {
+			t.Errorf("window %s is (%d,%d) %dx%d: not full-height like %dx@Y=%d, "+
+				"so a forced vertical split was turned horizontal",
+				r.ID, r.X, r.Y, r.Width, r.Height, h0, y0)
+		}
+	}
+}

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -146,40 +146,47 @@ type OS struct {
 	AutoTiling         bool                       // Automatic tiling mode enabled
 	MasterRatio        float64                    // Master window width ratio for tiling (0.3-0.7)
 	// BSP tiling state
-	WorkspaceTrees        map[int]*layout.BSPTree // BSP tree per workspace
-	PreselectionDir       layout.PreselectionDir  // Pending preselection direction (0 = none)
-	TilingScheme          layout.AutoScheme       // Default auto-insertion scheme
-	SplitTargetWindowID   string                  // Window ID to split (set before AddWindow for splits)
-	WindowToBSPID         map[string]int          // Maps window UUID to stable BSP integer ID
-	BSPIDToWindowID       map[int]string          // Reverse of WindowToBSPID: BSP integer ID to window UUID (speed-up for getWindowByIntID)
-	NextBSPWindowID       int                     // Next BSP window ID to assign (starts at 1)
-	RenamingWindow        bool                    // True when renaming a window
-	RenameBuffer          string                  // Buffer for new window name
-	PrefixActive          bool                    // True when prefix key was pressed (tmux-style)
-	WorkspacePrefixActive bool                    // True when Ctrl+B, w was pressed (workspace sub-prefix)
-	MinimizePrefixActive  bool                    // True when Ctrl+B, m was pressed (minimize sub-prefix)
-	TilingPrefixActive    bool                    // True when Ctrl+B, t was pressed (tiling/window sub-prefix)
-	DebugPrefixActive     bool                    // True when Ctrl+B, D was pressed (debug sub-prefix)
-	LastPrefixTime        time.Time               // Time when prefix was activated
-	HelpScrollOffset      int                     // Scroll offset for help menu
-	HelpCategory          int                     // Current help category index (for left/right navigation)
-	HelpSearchMode        bool                    // True when help search is active
-	HelpSearchQuery       string                  // Current search query in help menu
-	CurrentWorkspace      int                     // Current active workspace (1-9)
-	NumWorkspaces         int                     // Total number of workspaces
-	WorkspaceFocus        map[int]int             // Remembers focused window per workspace
-	WorkspaceLayouts      map[int][]WindowLayout  // Stores custom layouts per workspace
-	WorkspaceHasCustom    map[int]bool            // Tracks if workspace has custom layout
-	WorkspaceMasterRatio  map[int]float64         // Stores master ratio per workspace
-	ShowLogs              bool                    // True when showing log overlay
-	LogMessages           []LogMessage            // Store log messages
-	LogScrollOffset       int                     // Scroll offset for log viewer
-	Notifications         []Notification          // Active notifications
-	SelectionMode         bool                    // True when in text selection mode
-	ClipboardContent      string                  // Store clipboard content from tea.ClipboardMsg
-	ShowCacheStats        bool                    // True when showing style cache statistics overlay
-	ShowQuitConfirm       bool                    // True when showing quit confirmation dialog
-	QuitConfirmSelection  int                     // 0 = Yes (left), 1 = No (right)
+	WorkspaceTrees      map[int]*layout.BSPTree // BSP tree per workspace
+	PreselectionDir     layout.PreselectionDir  // Pending preselection direction (0 = none)
+	TilingScheme        layout.AutoScheme       // Default auto-insertion scheme
+	SplitTargetWindowID string                  // Window ID to split (set before AddWindow for splits)
+	// pendingSplitDir/pendingSplitTarget carry a forced-direction split (ctrl+b |
+	// / -) across the daemon round trip. The daemon owns window creation, so the
+	// new pane is not built locally; it arrives later through a state sync. These
+	// remember which side of which pane the split was meant for so the sync path
+	// can honor the direction instead of falling back to the spiral scheme.
+	pendingSplitDir       layout.PreselectionDir
+	pendingSplitTarget    string
+	WindowToBSPID         map[string]int         // Maps window UUID to stable BSP integer ID
+	BSPIDToWindowID       map[int]string         // Reverse of WindowToBSPID: BSP integer ID to window UUID (speed-up for getWindowByIntID)
+	NextBSPWindowID       int                    // Next BSP window ID to assign (starts at 1)
+	RenamingWindow        bool                   // True when renaming a window
+	RenameBuffer          string                 // Buffer for new window name
+	PrefixActive          bool                   // True when prefix key was pressed (tmux-style)
+	WorkspacePrefixActive bool                   // True when Ctrl+B, w was pressed (workspace sub-prefix)
+	MinimizePrefixActive  bool                   // True when Ctrl+B, m was pressed (minimize sub-prefix)
+	TilingPrefixActive    bool                   // True when Ctrl+B, t was pressed (tiling/window sub-prefix)
+	DebugPrefixActive     bool                   // True when Ctrl+B, D was pressed (debug sub-prefix)
+	LastPrefixTime        time.Time              // Time when prefix was activated
+	HelpScrollOffset      int                    // Scroll offset for help menu
+	HelpCategory          int                    // Current help category index (for left/right navigation)
+	HelpSearchMode        bool                   // True when help search is active
+	HelpSearchQuery       string                 // Current search query in help menu
+	CurrentWorkspace      int                    // Current active workspace (1-9)
+	NumWorkspaces         int                    // Total number of workspaces
+	WorkspaceFocus        map[int]int            // Remembers focused window per workspace
+	WorkspaceLayouts      map[int][]WindowLayout // Stores custom layouts per workspace
+	WorkspaceHasCustom    map[int]bool           // Tracks if workspace has custom layout
+	WorkspaceMasterRatio  map[int]float64        // Stores master ratio per workspace
+	ShowLogs              bool                   // True when showing log overlay
+	LogMessages           []LogMessage           // Store log messages
+	LogScrollOffset       int                    // Scroll offset for log viewer
+	Notifications         []Notification         // Active notifications
+	SelectionMode         bool                   // True when in text selection mode
+	ClipboardContent      string                 // Store clipboard content from tea.ClipboardMsg
+	ShowCacheStats        bool                   // True when showing style cache statistics overlay
+	ShowQuitConfirm       bool                   // True when showing quit confirmation dialog
+	QuitConfirmSelection  int                    // 0 = Yes (left), 1 = No (right)
 	// Pending resize tracking for debouncing PTY resize during mouse drag
 	PendingResizes map[string][2]int // windowID -> [width, height] of pending PTY resize
 	// pendingCopy is text a settled multi-click selection will put on the

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -440,6 +440,18 @@ func (m *OS) ApplyStateSync(state *session.SessionState) error {
 		}
 	}
 
+	// The BSP tree, the window->int-ID map and the split scheme are computed by
+	// clients, never by the daemon's own mutations (AddDaemonWindow and friends do
+	// not touch them). The daemon only stores what a client last synced and echoes
+	// it back, so a sync that is not strictly newer than the one this client
+	// already applied carries this client's own tiling state, often lagging a
+	// mutation this client has since made. Adopting that echo wipes the fresh tree
+	// and reassigns int IDs, which rebuilds the whole layout from scratch and drops
+	// a forced split direction (ctrl+b | / -). Version counts daemon-side
+	// mutations only, so it is exactly the right gate: adopt tiling topology only
+	// when the daemon has advanced past what this client last saw.
+	newerState := state.Version > m.DaemonStateVersion
+
 	// Update global state
 	m.SessionName = state.Name
 	m.DaemonStateVersion = state.Version
@@ -477,10 +489,28 @@ func (m *OS) ApplyStateSync(state *session.SessionState) error {
 		}
 	}
 
-	// Update BSP state
-	if state.WindowToBSPID != nil {
-		m.WindowToBSPID = make(map[string]int)
-		maps.Copy(m.WindowToBSPID, state.WindowToBSPID)
+	// Update BSP state. Adopt the daemon's window->int-ID map only from a strictly
+	// newer sync, and even then merge rather than replace: a window this client has
+	// already mapped keeps its int ID, so a stale echo that omits it (or an already
+	// applied one) cannot strip the mapping and force getWindowIntID to hand out a
+	// fresh number. A churned int ID orphans the window's node in the tree, which
+	// TileAllWindows then rebuilds from scratch with the spiral scheme, discarding
+	// any forced split direction.
+	if newerState && state.WindowToBSPID != nil {
+		if m.WindowToBSPID == nil {
+			m.WindowToBSPID = make(map[string]int, len(state.WindowToBSPID))
+		}
+		for id, intID := range state.WindowToBSPID {
+			if _, ok := m.WindowToBSPID[id]; !ok {
+				m.WindowToBSPID[id] = intID
+			}
+		}
+		// Keep the reverse map consistent with the merge; getWindowByIntID trusts
+		// it as a fast path before falling back to a linear scan.
+		m.BSPIDToWindowID = make(map[int]string, len(m.WindowToBSPID))
+		for id, intID := range m.WindowToBSPID {
+			m.BSPIDToWindowID[intID] = id
+		}
 	}
 	// Never rewind the BSP ID allocator. The counter only has to be unique
 	// locally, and taking a lower value from a sync hands the next window an int
@@ -491,8 +521,9 @@ func (m *OS) ApplyStateSync(state *session.SessionState) error {
 	m.TilingScheme = layout.AutoScheme(state.TilingScheme)
 	m.ApplyLayoutModeName(state.LayoutMode)
 
-	// Update BSP trees
-	if state.WorkspaceTrees != nil && state.AutoTiling {
+	// Update BSP trees, again only from a strictly newer sync so a lagging echo
+	// cannot clobber the tree this client just computed (see newerState above).
+	if newerState && state.WorkspaceTrees != nil && state.AutoTiling {
 		m.WorkspaceTrees = make(map[int]*layout.BSPTree)
 		for ws, serialized := range state.WorkspaceTrees {
 			if serialized != nil {
@@ -860,10 +891,46 @@ func (m *OS) adoptSyncedWindows(created []*terminal.Window, removed []int, place
 				m.ScrollingOnWindowAdded(w)
 			}
 		}
+	} else if m.pendingSplitDir != layout.PreselectionNone {
+		// A forced-direction split (ctrl+b | / -) asked the daemon for this pane
+		// and stashed the direction for exactly this moment. Insert it on the
+		// chosen side of its target before TileAllWindows runs, otherwise the
+		// spiral scheme places it and the direction is lost. Only the single-window
+		// case is a split; anything else clears the request and falls back.
+		if len(created) == 1 {
+			m.applyPendingForcedSplit(created[0])
+		} else if len(created) > 1 {
+			m.pendingSplitDir = layout.PreselectionNone
+			m.pendingSplitTarget = ""
+		}
 	}
 
 	m.TileAllWindows()
 	m.SyncStateToDaemon()
+}
+
+// applyPendingForcedSplit inserts a daemon-created pane into the BSP tree on the
+// side recorded by a forced-direction split, so ctrl+b | / - keep their meaning
+// across the round trip that created the window. The pending request is cleared
+// whether or not it applies. TileAllWindows runs afterwards and, finding every
+// window already in the tree, only re-applies the layout.
+func (m *OS) applyPendingForcedSplit(win *terminal.Window) {
+	dir := m.pendingSplitDir
+	targetID := m.pendingSplitTarget
+	m.pendingSplitDir = layout.PreselectionNone
+	m.pendingSplitTarget = ""
+
+	if dir == layout.PreselectionNone || win == nil {
+		return
+	}
+
+	tree := m.GetOrCreateBSPTree()
+	windowIntID := m.getWindowIntID(win.ID)
+	if tree.HasWindow(windowIntID) {
+		return // already in the tree; nothing to force
+	}
+	targetIntID := m.getWindowIntID(targetID)
+	tree.InsertWindowWithPreselection(windowIntID, targetIntID, dir, m.GetBSPBounds())
 }
 
 // convertSessionBSPNode converts session.SerializedBSPNode to layout.SerializedNode

--- a/internal/app/tiling.go
+++ b/internal/app/tiling.go
@@ -55,6 +55,15 @@ func (m *OS) TileAllWindows() {
 	}
 
 	if len(visibleWindows) == 0 {
+		// No visible windows means no tiling structure, so a tree left behind here
+		// still feeds CollectSplits and paints stale separators over the splash
+		// after the last pane closes. The local close path nils the tree when it
+		// empties (DeleteWindow); the daemon close path arrives through here
+		// instead, where the early return used to skip the cleanup, so clear the
+		// current workspace's tree to keep the two paths in step.
+		if m.WorkspaceTrees != nil {
+			m.WorkspaceTrees[m.CurrentWorkspace] = nil
+		}
 		return
 	}
 

--- a/internal/app/tiling_bsp.go
+++ b/internal/app/tiling_bsp.go
@@ -381,6 +381,17 @@ func (m *OS) SplitFocusedHorizontal() {
 		return
 	}
 
+	// In a daemon session the new pane is created daemon-side and arrives through
+	// a later state sync, so the preselection set here would never be consumed
+	// (AddWindow only asks the daemon and returns). Record the forced direction so
+	// the sync path applies it; see adoptSyncedWindows.
+	if m.IsDaemonSession && m.DaemonClient != nil {
+		m.pendingSplitDir = layout.PreselectionDown
+		m.pendingSplitTarget = focusedWin.ID
+		m.AddWindow("")
+		return
+	}
+
 	// Store the target window ID BEFORE creating new window (which will change focus)
 	m.SplitTargetWindowID = focusedWin.ID
 
@@ -402,6 +413,15 @@ func (m *OS) SplitFocusedVertical() {
 
 	focusedWin := m.GetFocusedWindow()
 	if focusedWin == nil {
+		return
+	}
+
+	// See SplitFocusedHorizontal: on the daemon path the forced direction has to
+	// outlive the round trip that creates the pane.
+	if m.IsDaemonSession && m.DaemonClient != nil {
+		m.pendingSplitDir = layout.PreselectionRight
+		m.pendingSplitTarget = focusedWin.ID
+		m.AddWindow("")
 		return
 	}
 


### PR DESCRIPTION
Two shared-border bugs in daemon mode, both rooted in how the client adopts synced state.

## Separators linger after the last window closes

`TileAllWindows` returned early when no windows were visible without touching the BSP tree. The local close path nils an emptied tree in `DeleteWindow`, but a daemon close arrives as a state sync and lands in `TileAllWindows` instead, so the tree kept the closed windows and `renderSeparatorOverlay` kept drawing their dividers over the splash. Fix: clear the current workspace's tree when no windows are visible.

## `ctrl+b |` and `ctrl+b -` ignored, splits alternate by depth

The daemon owns window creation, so `SplitFocusedVertical`/`Horizontal` set a preselection then call `AddWindow`, which in daemon mode only sends a `NewWindow` intent and returns. The preselection was never consumed; the pane arrived later via a state sync and was placed by the spiral scheme.

The deeper reason a naive fix did not hold: `ApplyStateSync` rebuilt the window-to-int-ID map and BSP tree from every daemon push, including lagging same-version echoes of the client's own state (the daemon never authors these; version only bumps on daemon-side mutations). Instrumentation showed the created pane's int ID churning `[1] to [1,3] to [1,3,5]` as each stale echo stripped the fresh mapping, orphaning the tree node and forcing a spiral rebuild.

Fix: `SplitFocused{Vertical,Horizontal}` record the forced direction and target across the round trip; `adoptSyncedWindows` applies the pending forced split; and `ApplyStateSync` adopts client-owned tiling topology only from a strictly newer push, merging the id map so an existing window keeps its id.

## Verification

`TestDaemonForcedVerticalSplitStaysVertical` asserts all four panes share one Y and Height; `TestDaemonSharedBordersSeparatorClearsOnClose` asserts no full-length interior borders remain after the last close, against a clean-splash baseline. Both fail on the prior binary, pass on the fix. Full suite green including the nested e2e module.

One tradeoff: gating tiling-topology adoption on a strictly-newer version means a second attached client would not pick up another client's live split-resize (which propagates without a version bump). That path was already racy under the old clobber-every-push behaviour and is untested; single-client daemon use is now deterministic.