### PR TITLE
Per-pane agent state: model, verb, and Claude Code shim

### DIFF
--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -728,6 +728,57 @@ whether or not a TUI client is attached.`,
 			return runGetConfig(getConfigSession, args[0])
 		},
 	}
+	var setAgentStateSession string
+	var setAgentStateWindow string
+	var setAgentStateMessage string
+	setAgentStateCmd := &cobra.Command{
+		Use:   "set-agent-state <state>",
+		Short: "Report a pane's agent state to the running TUIOS session",
+		Long: `Report the semantic state of an agent running in a pane so the daemon can
+surface which panes need attention. State is one of: none, working, needs_input,
+idle, done, errored. A pane reports its own state by running this against the
+daemon socket; the reference Claude Code shim does exactly that.`,
+		Example: `  # Mark the focused pane as working
+  tuios set-agent-state working
+
+  # Mark a specific pane as needing input, with a note
+  tuios set-agent-state needs_input -w build -m "awaiting approval"
+
+  # Clear a pane's agent state
+  tuios set-agent-state none`,
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: session.AgentStateNames,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runSetAgentState(setAgentStateSession, setAgentStateWindow, args[0], setAgentStateMessage)
+		},
+	}
+	setAgentStateCmd.Flags().StringVarP(&setAgentStateSession, "session", "s", "", "Target session (default: most recently active)")
+	setAgentStateCmd.Flags().StringVarP(&setAgentStateWindow, "window", "w", "", "Target window by name or ID (default: focused)")
+	setAgentStateCmd.Flags().StringVarP(&setAgentStateMessage, "message", "m", "", "Optional short note reported with the state")
+	_ = setAgentStateCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
+
+	var getAgentStateSession string
+	var getAgentStateWindow string
+	var getAgentStateJSON bool
+	getAgentStateCmd := &cobra.Command{
+		Use:   "get-agent-state",
+		Short: "Read a pane's reported agent state",
+		Long:  `Read the agent state a pane last reported. Prints the state name, or the full result with --json.`,
+		Example: `  # Read the focused pane's state
+  tuios get-agent-state
+
+  # Read a specific pane as JSON
+  tuios get-agent-state -w build --json`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runGetAgentState(getAgentStateSession, getAgentStateWindow, getAgentStateJSON)
+		},
+	}
+	getAgentStateCmd.Flags().StringVarP(&getAgentStateSession, "session", "s", "", "Target session (default: most recently active)")
+	getAgentStateCmd.Flags().StringVarP(&getAgentStateWindow, "window", "w", "", "Target window by name or ID (default: focused)")
+	getAgentStateCmd.Flags().BoolVar(&getAgentStateJSON, "json", false, "Output result as JSON")
+	_ = getAgentStateCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
+
 	getConfigCmd.Flags().StringVarP(&getConfigSession, "session", "s", "", "Target session (default: most recently active)")
 	_ = getConfigCmd.RegisterFlagCompletionFunc("session", completeSessionNames)
 	getConfigCmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -998,6 +1049,7 @@ Name a verb to describe only that verb.`,
 	rootCmd.AddCommand(attachCmd, newCmd, lsCmd, killSessionCmd, resurrectCmd)
 	rootCmd.AddCommand(startDaemonCmd, daemonCmd, killDaemonCmd)
 	rootCmd.AddCommand(sendKeysCmd, runCommandCmd, setConfigCmd, getConfigCmd, logsCmd, capturePaneCmd)
+	rootCmd.AddCommand(setAgentStateCmd, getAgentStateCmd)
 	rootCmd.AddCommand(listWindowsCmd, getWindowCmd, sessionInfoCmd, listVerbsCmd)
 
 	// Command failures are printed here rather than by fang, which would query

--- a/cmd/tuios/remote_commands.go
+++ b/cmd/tuios/remote_commands.go
@@ -294,6 +294,56 @@ func runGetConfig(sessionName, path string) error {
 	return nil
 }
 
+// runSetAgentState reports a pane's agent state to the daemon over the verb
+// protocol. It is what the reference shim calls, and what a user runs to mark a
+// pane by hand.
+func runSetAgentState(sessionName, windowTarget, state, message string) error {
+	client, err := dialVerb()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Call("set-agent-state", map[string]any{
+		"session": sessionName,
+		"window":  windowTarget,
+		"state":   state,
+		"message": message,
+	}); err != nil {
+		return explainVerbError("set-agent-state", err)
+	}
+	return nil
+}
+
+// runGetAgentState reads a pane's reported agent state and prints it. With
+// jsonOutput it prints the full result; otherwise it prints the state name.
+func runGetAgentState(sessionName, windowTarget string, jsonOutput bool) error {
+	client, err := dialVerb()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	raw, err := client.Call("get-agent-state", map[string]any{
+		"session": sessionName,
+		"window":  windowTarget,
+	})
+	if err != nil {
+		return reportVerbError(explainVerbError("get-agent-state", err), jsonOutput)
+	}
+	if jsonOutput {
+		return printVerbResult(raw, jsonOutput)
+	}
+	var res struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	fmt.Println(res.State)
+	return nil
+}
+
 // runTapeExec executes a tape file in a running TUIOS session.
 func runTapeExec(sessionName, filePath string) error {
 	if err := requireDaemon(); err != nil {

--- a/docs/AGENT_STATE.md
+++ b/docs/AGENT_STATE.md
@@ -1,0 +1,117 @@
+# Agent state
+
+tuios tracks a semantic state for each window's pane so a session can show which
+panes need attention. A pane running a coding agent reports what it is doing;
+tuios stores that state per window, syncs it to every attached client, and draws
+an indicator for it.
+
+## Table of Contents
+
+- [States](#states)
+- [Reporting state](#reporting-state)
+- [The stall heuristic](#the-stall-heuristic)
+- [Indicator](#indicator)
+- [Claude Code integration](#claude-code-integration)
+- [Environment](#environment)
+
+## States
+
+| State         | Meaning                                          |
+| ------------- | ------------------------------------------------ |
+| `none`        | Not running an agent, or not reporting (default) |
+| `working`     | Actively working on a task                       |
+| `needs_input` | Blocked waiting for the user                     |
+| `idle`        | Not working and not blocked                      |
+| `done`        | Finished its task                                |
+| `errored`     | Stopped because of an error                      |
+
+State is daemon-owned per-window state. It rides the same versioned state sync
+every other window property uses, so it survives detach/reattach and reaches all
+clients. `none` is the zero value and is never persisted, so older sessions and
+older clients simply read every pane as `none`.
+
+## Reporting state
+
+A pane reports its own state through the `set-agent-state` verb, the same way it
+would call `send-keys` or `capture-pane`:
+
+```sh
+# From inside a pane
+tuios set-agent-state working
+tuios set-agent-state needs_input -m "awaiting approval"
+tuios set-agent-state done
+tuios set-agent-state none          # clear it
+```
+
+Read it back with `get-agent-state`:
+
+```sh
+tuios get-agent-state               # prints the state name
+tuios get-agent-state -w build --json
+```
+
+Both are ordinary control-protocol verbs, so they appear in `tuios list-verbs`
+and can be called over the daemon socket directly. `list-windows --json` also
+reports each window's `agent_state`, so a cross-session view can read every
+pane's state in one call.
+
+Targeting follows the same rules as the other window verbs: `-s`/`--session`
+selects the session (default: most recently active), `-w`/`--window` selects the
+window by id or name (default: the focused window).
+
+## The stall heuristic
+
+Agents that do not report get a conservative fallback. If a pane reported
+`working` but then produces no output for a while, the daemon demotes it to
+`idle`, on the assumption that a genuinely busy agent produces output. The
+fallback is strictly secondary to explicit reporting:
+
+- It only ever moves a pane out of `working`, and only ever into `idle`. Any
+  other state (`needs_input`, `done`, `errored`) is never touched, so an explicit
+  report is never overridden.
+- The silence clock is the later of the pane's last output and the time its
+  `working` state was set, so a working report is given the full window before it
+  can be demoted, and output keeps a pane looking busy.
+- It never promotes a pane into `working`; only an explicit report does that.
+
+The silence window defaults to 30 seconds. Override it with the
+`TUIOS_AGENT_STALL_SECONDS` environment variable when starting the daemon; set it
+to `0` (or a negative value) to disable the heuristic entirely.
+
+## Indicator
+
+tuios draws a one-cell glyph in each window's title:
+
+| State         | Indicator |
+| ------------- | --------- |
+| `working`     | `●`       |
+| `needs_input` | `▲`       |
+| `idle`        | `○`       |
+| `done`        | `■`       |
+| `errored`     | `×`       |
+| `none`        | (nothing) |
+
+The glyphs are distinct shapes rather than the same shape in different colors, so
+the state reads at a glance and survives a monochrome capture. The indicator
+shows even for a window with no name.
+
+## Claude Code integration
+
+A reference shim maps Claude Code's lifecycle hooks to these states. See
+[integrations/claude-code](../integrations/claude-code/README.md) for the script
+and how to wire it.
+
+## Environment
+
+When tuios spawns a pane it exports the environment a state-reporting shim needs:
+
+| Variable          | Meaning                                          |
+| ----------------- | ------------------------------------------------ |
+| `TUIOS_ENV`       | `1` when running under tuios                      |
+| `TUIOS_SOCKET`    | Daemon socket path                               |
+| `TUIOS_PANE_ID`   | The pane's window id                             |
+| `TUIOS_WINDOW_ID` | The pane's window id (alias of `TUIOS_PANE_ID`)  |
+| `TUIOS_SESSION`   | The session name                                 |
+
+A shim guards on these and no-ops when they are unset, so it is safe to leave
+wired up outside tuios.

--- a/e2e/tui/NEGATIVE_CONTROLS.md
+++ b/e2e/tui/NEGATIVE_CONTROLS.md
@@ -46,6 +46,7 @@ a working negative control look like a broken one for half an hour.
 | Mouse: the wheel over a pane that asked for the mouse | n/a, never broken | same binary | none, and that is correct: `TestMouseTrackingAppKeepsItsOwnWheel` passes on both, because it guards behaviour that already worked | **guard, not a control** |
 | Clipboard: every mouse release copies, so a bare single click clobbers the clipboard | n/a, injected | `deliberate := moved \|\| window.ClickCount >= 2` → `deliberate := true` in `internal/input/mouse_select.go` | `TestDoubleClickCopiesAWordAndTripleClickTheLine` ("the gesture wrote the clipboard more times than it should: got [\"b\"], want []") | **caught, and invisible before this change** |
 | Drag state never cleared on release, so one click freezes every pane forever | n/a, injected | drop `o.Dragging = false` from the copy-mode branch of `handleMouseRelease` | `TestClickInPaneDoesNotFreezeOutput` | **caught, and invisible before this change** |
+| Agent-state feature absent (no verb, no indicator) | whole feature | build `origin/main` and point `TUIOS_E2E_BIN` at it | `TestAgentStateIndicatorRenders` (fails at the set step: `Unknown command "set-agent-state"`) | **caught** |
 
 ### The mouse row is a whole-change control, not a single-hunk one
 

--- a/e2e/tui/agent_state_test.go
+++ b/e2e/tui/agent_state_test.go
@@ -1,0 +1,72 @@
+package tuie2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuitest"
+)
+
+// needsInputGlyph is the indicator tuios draws for the needs_input agent state.
+// It is the whole assertion: the client must render it once the state is set.
+const needsInputGlyph = "▲"
+
+// TestAgentStateIndicatorRenders drives a real daemon: it sets a window's agent
+// state through the set-agent-state verb (via the tuios CLI, exactly as a pane's
+// state-reporting shim would) and asserts the attached client renders the
+// matching indicator in the window title.
+//
+// It is the end-to-end proof that the state model, the verb, the state sync, and
+// the renderer are wired together: nothing in this test touches tuios internals,
+// only the CLI a shim uses and the screen a user sees.
+//
+// Negative control: against a binary without the feature, `tuios set-agent-state`
+// is an unknown subcommand (the CLI errors and this fails at the set step), and
+// even if the call were a no-op no indicator would ever render, so the final wait
+// would time out. Verified per NEGATIVE_CONTROLS.md by pointing TUIOS_E2E_BIN at
+// a pre-feature build.
+func TestAgentStateIndicatorRenders(t *testing.T) {
+	term, base := start(t, startOpts{cols: 120, rows: 40, args: []string{"new", "e2e"}})
+	killDaemon(t, base)
+
+	waitBoot(t, term)
+	newWindow(t, term)
+	waitWindowCount(t, term, 1, "first window")
+
+	// A named window guarantees a title is drawn, so the indicator has a place to
+	// appear regardless of the default title position.
+	renameWindow(t, term, "AGENTPANE")
+
+	// The indicator must not already be on screen, or the assertion below would
+	// prove nothing.
+	if strings.Contains(term.Screen().Text(), needsInputGlyph) {
+		t.Fatalf("the needs_input indicator was on screen before the state was set\n%s", term.Snapshot())
+	}
+
+	// Report the state the way a pane reports its own, over the daemon socket.
+	if out, err := tuiosCLI(t, base, "set-agent-state", "needs_input", "-s", "e2e", "-w", "AGENTPANE"); err != nil {
+		t.Fatalf("set-agent-state failed: %v\n%s", err, out)
+	}
+
+	// The daemon pushes the new state to the attached client, which redraws the
+	// title with the indicator.
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		text := s.Text()
+		return strings.Contains(text, needsInputGlyph) && strings.Contains(text, "AGENTPANE")
+	}, uiTimeout); err != nil {
+		t.Fatalf("the needs_input indicator never rendered on the window title: %v\n%s",
+			err, term.Snapshot())
+	}
+
+	// And it clears when the state is cleared, so the indicator tracks the state
+	// rather than merely appearing once.
+	if out, err := tuiosCLI(t, base, "set-agent-state", "none", "-s", "e2e", "-w", "AGENTPANE"); err != nil {
+		t.Fatalf("set-agent-state none failed: %v\n%s", err, out)
+	}
+	if err := term.WaitFor(func(s tuitest.Screen) bool {
+		return !strings.Contains(s.Text(), needsInputGlyph)
+	}, uiTimeout); err != nil {
+		t.Fatalf("the indicator never cleared after the state was reset to none: %v\n%s",
+			err, term.Snapshot())
+	}
+}

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,109 @@
+# Claude Code agent-state integration
+
+This shim reports Claude Code's per-turn state into tuios so a session can show,
+at a glance, which panes need attention. It is the reference integration for the
+tuios agent-state model; the same pattern works for any agent that can run a
+command on a lifecycle event.
+
+## What it does
+
+`tuios-agent-state.sh` maps Claude Code lifecycle hooks to tuios agent states:
+
+| Claude Code event               | tuios state   |
+| ------------------------------- | ------------- |
+| `SessionStart`                  | `working`     |
+| `UserPromptSubmit`              | `working`     |
+| `Notification`                  | `needs_input` |
+| `Stop`                          | `done`        |
+
+Subagent events (`SubagentStop`, and any event carrying an `agent_id`) are
+ignored, so a Task-tool subagent finishing cannot reset the pane's displayed
+state while the main turn is still running.
+
+The state is set with `tuios set-agent-state`, the same verb any process can call
+to report its own state. tuios draws a per-window indicator for it:
+
+| State         | Indicator |
+| ------------- | --------- |
+| `working`     | `●`       |
+| `needs_input` | `▲`       |
+| `idle`        | `○`       |
+| `done`        | `■`       |
+| `errored`     | `×`       |
+| `none`        | (nothing) |
+
+An agent that reports nothing still gets a conservative fallback: a pane that
+reported `working` but then produces no output for a while is demoted to `idle`
+by the daemon. That fallback never overrides an explicit report. See
+[Agent state](../../docs/AGENT_STATE.md).
+
+## How it finds tuios
+
+When tuios spawns a pane it exports the environment the shim guards on:
+
+- `TUIOS_ENV=1` marks the process as running under tuios.
+- `TUIOS_SOCKET` is the daemon socket path.
+- `TUIOS_PANE_ID` is the pane's window id (also exported as `TUIOS_WINDOW_ID`).
+- `TUIOS_SESSION` is the session name.
+
+If any of these is missing the shim exits 0 without doing anything, so it is safe
+to leave wired up when you run Claude Code outside tuios.
+
+## Requirements
+
+- `tuios` on `PATH` (the shim reports through the `tuios set-agent-state` verb).
+- `python3` on `PATH` (used to parse the hook payload and filter subagents).
+
+Both are checked; a missing one is a clean no-op, not an error.
+
+## Wiring
+
+1. Copy the shim somewhere stable, for example:
+
+   ```sh
+   mkdir -p ~/.config/tuios/integrations
+   cp integrations/claude-code/tuios-agent-state.sh ~/.config/tuios/integrations/
+   chmod +x ~/.config/tuios/integrations/tuios-agent-state.sh
+   ```
+
+2. Point Claude Code's hooks at it. In your Claude Code settings
+   (`~/.claude/settings.json`), add the shim to the `SessionStart`,
+   `UserPromptSubmit`, `Notification`, and `Stop` hooks. The shim reads the event
+   from the hook payload on stdin, so the same command serves every event:
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         { "hooks": [{ "type": "command", "command": "~/.config/tuios/integrations/tuios-agent-state.sh" }] }
+       ],
+       "UserPromptSubmit": [
+         { "hooks": [{ "type": "command", "command": "~/.config/tuios/integrations/tuios-agent-state.sh" }] }
+       ],
+       "Notification": [
+         { "hooks": [{ "type": "command", "command": "~/.config/tuios/integrations/tuios-agent-state.sh" }] }
+       ],
+       "Stop": [
+         { "hooks": [{ "type": "command", "command": "~/.config/tuios/integrations/tuios-agent-state.sh" }] }
+       ]
+     }
+   }
+   ```
+
+   This is tuios's own shim. It is separately named and does not read, write, or
+   depend on any other tool's integration; add it alongside whatever else you
+   already have wired up.
+
+3. Run Claude Code inside a tuios pane. The pane's title indicator tracks the
+   agent as it works, blocks for input, and finishes.
+
+## Verifying by hand
+
+You do not need Claude Code to check the wiring. From inside a tuios pane:
+
+```sh
+tuios set-agent-state working
+tuios get-agent-state           # prints: working
+tuios set-agent-state needs_input -m "awaiting approval"
+tuios set-agent-state none      # clears it
+```

--- a/integrations/claude-code/tuios-agent-state.sh
+++ b/integrations/claude-code/tuios-agent-state.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# tuios Claude Code agent-state shim.
+#
+# Maps Claude Code lifecycle hooks to tuios per-pane agent state so a session can
+# show which panes need attention. It reports:
+#
+#   SessionStart, UserPromptSubmit -> working
+#   Notification                   -> needs_input
+#   Stop                           -> done
+#
+# It no-ops cleanly when not running under tuios: it exits 0 the moment any of the
+# environment tuios sets on a pane (TUIOS_ENV, TUIOS_SOCKET, TUIOS_PANE_ID) is
+# missing, so it is safe to leave wired up outside tuios. Subagent events are
+# ignored so a Task-tool subagent cannot clobber the pane's displayed state.
+#
+# Wiring is documented in the README beside this file. This is tuios's own shim;
+# it is separate from any other integration and does not touch them.
+
+set -eu
+
+# Guard on tuios's pane environment. Any one missing means we are not inside a
+# tuios pane (or an older tuios), so there is nothing to report to.
+[ "${TUIOS_ENV:-}" = "1" ] || exit 0
+[ -n "${TUIOS_SOCKET:-}" ] || exit 0
+[ -n "${TUIOS_PANE_ID:-}" ] || exit 0
+
+# The reporter and the JSON parser are both required; a missing one is a clean
+# no-op rather than an error, matching how the guards above behave.
+command -v tuios >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+hook_input="$(cat 2>/dev/null || true)"
+
+# Derive the state from the hook event, filtering out subagent turns. Prints an
+# empty line (and the script then exits) for any event that does not map.
+state="$(printf '%s' "$hook_input" | python3 - <<'PY'
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    data = {}
+
+event = str(data.get("hook_event_name") or "")
+
+# A subagent turn must never drive the pane's state: agent_id marks a subagent
+# event, and SubagentStop is a subagent completion.
+if data.get("agent_id") or event == "SubagentStop":
+    sys.exit(0)
+
+mapping = {
+    "SessionStart": "working",
+    "UserPromptSubmit": "working",
+    "Notification": "needs_input",
+    "Stop": "done",
+}
+state = mapping.get(event, "")
+if state:
+    print(state)
+PY
+)"
+
+[ -n "$state" ] || exit 0
+
+# A Notification carries a short message describing what it wants; pass it along
+# so the pane's indicator can say why it is blocked.
+message=""
+if [ "$state" = "needs_input" ]; then
+	message="$(printf '%s' "$hook_input" | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+print(str(d.get("message") or ""))' 2>/dev/null || true)"
+fi
+
+# Report best-effort: a failed report must never fail the hook and interrupt the
+# agent. The window is the pane id tuios exported; the session scopes the lookup.
+if [ -n "$message" ]; then
+	tuios set-agent-state "$state" -s "${TUIOS_SESSION:-}" -w "$TUIOS_PANE_ID" -m "$message" >/dev/null 2>&1 || true
+else
+	tuios set-agent-state "$state" -s "${TUIOS_SESSION:-}" -w "$TUIOS_PANE_ID" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/internal/app/render_helpers.go
+++ b/internal/app/render_helpers.go
@@ -8,10 +8,34 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
 	"github.com/Gaurav-Gosain/tuios/internal/pool"
+	"github.com/Gaurav-Gosain/tuios/internal/session"
 	"github.com/Gaurav-Gosain/tuios/internal/terminal"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )
+
+// agentStateIndicator returns the one-cell glyph that marks a pane's agent state
+// in its window title, or the empty string for none/unset. The glyphs are
+// deliberately distinct shapes rather than the same shape in different colors, so
+// the state reads at a glance and survives a monochrome capture: a filled circle
+// working, a triangle needs-input, a hollow circle idle, a filled square done,
+// and a cross errored.
+func agentStateIndicator(state string) string {
+	switch session.AgentState(state) {
+	case session.AgentStateWorking:
+		return "●"
+	case session.AgentStateNeedsInput:
+		return "▲"
+	case session.AgentStateIdle:
+		return "○"
+	case session.AgentStateDone:
+		return "■"
+	case session.AgentStateErrored:
+		return "×"
+	default:
+		return ""
+	}
+}
 
 var (
 	baseButtonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
@@ -80,8 +104,21 @@ func getWindowTitle(window *terminal.Window, position int, isRenaming bool, rena
 		windowName = config.FormatWindowTitle(windowName, position, window.CWD())
 	}
 
+	// The agent-state indicator shows even for a window with no name, so a pane
+	// running an agent is always marked. It is not shown while renaming, so it
+	// never sits in front of the text the user is typing.
+	indicator := ""
+	if !isRenaming {
+		indicator = agentStateIndicator(window.AgentState)
+	}
+
 	if windowName == "" {
-		return ""
+		return indicator
+	}
+
+	// Reserve room for the indicator and its trailing space before truncating.
+	if indicator != "" {
+		maxWidth = max(maxWidth-2, 0)
 	}
 
 	maxNameLen := max(maxWidth-6, 0)
@@ -97,8 +134,11 @@ func getWindowTitle(window *terminal.Window, position int, isRenaming bool, rena
 			}
 			windowName = truncated + "..."
 		} else {
-			return ""
+			return indicator
 		}
+	}
+	if indicator != "" {
+		return indicator + " " + windowName
 	}
 	return windowName
 }

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -620,6 +620,8 @@ func (m *OS) updateWindowFromState(w *terminal.Window, ws *session.WindowState) 
 	w.PreMinimizeWidth = ws.PreMinimizeW
 	w.PreMinimizeHeight = ws.PreMinimizeH
 	w.SetAltScreen(ws.IsAltScreen)
+	w.AgentState = string(ws.AgentState)
+	w.AgentMessage = ws.AgentMessage
 
 	if renderTraceEnabled && !sizeChanged {
 		traceSync(w, ws.IsAltScreen, false, w.Width, w.Height, "SetAltScreen; no resize")
@@ -717,6 +719,8 @@ func (m *OS) createWindowFromSync(ws *session.WindowState) *terminal.Window {
 	window.PreMinimizeWidth = ws.PreMinimizeW
 	window.PreMinimizeHeight = ws.PreMinimizeH
 	window.SetAltScreen(ws.IsAltScreen)
+	window.AgentState = string(ws.AgentState)
+	window.AgentMessage = ws.AgentMessage
 
 	m.setupKittyPassthrough(window)
 	m.setupSixelPassthrough(window)

--- a/internal/session/agent_state.go
+++ b/internal/session/agent_state.go
@@ -1,0 +1,157 @@
+package session
+
+import "time"
+
+// AgentState is the semantic state of an agent (a coding-agent CLI or any other
+// long-running process) running in a window's pane. It is daemon-owned per-window
+// state: a pane reports its own state through the set-agent-state verb, and the
+// daemon syncs it to attached clients alongside the rest of the window state.
+//
+// The zero value is AgentStateNone, which is also what a pane not running an
+// agent reports. Storing none as the empty string keeps it out of serialized
+// state entirely (omitempty), so older on-disk state and older clients that never
+// heard of agent state read back as none, which is exactly the pre-existing
+// behavior.
+type AgentState string
+
+const (
+	// AgentStateNone is the default: the pane is not running an agent, or is not
+	// reporting. It serializes as the empty string so it is omitted from state.
+	AgentStateNone AgentState = ""
+	// AgentStateWorking means the agent is actively working on a task.
+	AgentStateWorking AgentState = "working"
+	// AgentStateNeedsInput means the agent is blocked waiting for the user.
+	AgentStateNeedsInput AgentState = "needs_input"
+	// AgentStateIdle means the agent is not working and not blocked; it is the
+	// state the output-stall heuristic assigns to a pane that went quiet.
+	AgentStateIdle AgentState = "idle"
+	// AgentStateDone means the agent finished its task.
+	AgentStateDone AgentState = "done"
+	// AgentStateErrored means the agent stopped because of an error.
+	AgentStateErrored AgentState = "errored"
+)
+
+// agentStateByName maps every accepted wire value to its AgentState. "none" is
+// the explicit spelling a caller uses to clear the state; it maps to the empty
+// AgentStateNone.
+var agentStateByName = map[string]AgentState{
+	"none":        AgentStateNone,
+	"working":     AgentStateWorking,
+	"needs_input": AgentStateNeedsInput,
+	"idle":        AgentStateIdle,
+	"done":        AgentStateDone,
+	"errored":     AgentStateErrored,
+}
+
+// AgentStateNames lists the accepted wire values in a stable order, for the
+// verb's accepted-value schema and for input validation. It is part of the
+// public protocol surface; keep the values stable.
+var AgentStateNames = []string{"none", "working", "needs_input", "idle", "done", "errored"}
+
+// ParseAgentState resolves a wire value to an AgentState, reporting whether the
+// value was one of the accepted names. An empty input is not accepted here: the
+// verb requires the caller to name a state, and "none" is the spelling that
+// clears it.
+func ParseAgentState(s string) (AgentState, bool) {
+	if s == "" {
+		return AgentStateNone, false
+	}
+	v, ok := agentStateByName[s]
+	return v, ok
+}
+
+// Name returns the wire spelling of the state, mapping the empty AgentStateNone
+// back to "none" so a reader always gets an explicit value.
+func (a AgentState) Name() string {
+	if a == AgentStateNone {
+		return "none"
+	}
+	return string(a)
+}
+
+// SetDaemonWindowAgentState records the agent state (and an optional short
+// message) on the window matching target, stamping the time it was set. It runs
+// through mutateState, so it bumps the session version and reaches attached
+// clients through the same state-push every other daemon-side mutation uses.
+//
+// This is an explicit report. The output-stall heuristic never overrides it: the
+// heuristic only ever moves a window out of AgentStateWorking, and only after the
+// pane has been silent for the configured window, so any state set here other
+// than working is left untouched, and a fresh working report resets the silence
+// clock.
+func (s *Session) SetDaemonWindowAgentState(target string, state AgentState, message string) error {
+	return s.mutateState(func(st *SessionState) error {
+		idx, err := findWindowStateIndex(st.Windows, target)
+		if err != nil {
+			return err
+		}
+		st.Windows[idx].AgentState = state
+		st.Windows[idx].AgentMessage = message
+		st.Windows[idx].AgentStateAt = time.Now().UnixNano()
+		return nil
+	})
+}
+
+// applyStallHeuristic moves any window that has been silently working for at
+// least stall into AgentStateIdle, and reports how many it moved. It is the
+// fallback for agents that do not report their own state: a pane that reported
+// working but has produced no output for the stall window has most likely gone
+// idle or is waiting on the user, so it is demoted to idle rather than left
+// looking busy forever.
+//
+// It is deliberately conservative and strictly secondary to explicit reporting:
+//
+//   - It only ever reads AgentStateWorking and only ever writes AgentStateIdle.
+//     Any window in any other state is untouched, so an explicit needs_input,
+//     done, or errored report is never overridden.
+//   - The silence clock is the later of the window's last output and the time
+//     its working state was set, so an agent that is genuinely working (and thus
+//     producing output) is never demoted, and a working report just made is given
+//     the full stall window before it can be demoted.
+//   - It never promotes a pane into working; only an explicit report does that.
+//
+// now and stall are passed in, and lastOutput returns the unix-nano time of a
+// PTY's most recent output (0 when unknown), so the whole rule is deterministic
+// and unit-testable without real timers. A stall <= 0 disables the heuristic.
+func (s *Session) applyStallHeuristic(now time.Time, stall time.Duration, lastOutput func(ptyID string) int64) int {
+	if stall <= 0 {
+		return 0
+	}
+	cutoff := now.Add(-stall).UnixNano()
+	flipped := 0
+	_ = s.mutateState(func(st *SessionState) error {
+		for i := range st.Windows {
+			w := &st.Windows[i]
+			if w.AgentState != AgentStateWorking {
+				continue
+			}
+			lastActivity := w.AgentStateAt
+			if w.PTYID != "" {
+				if out := lastOutput(w.PTYID); out > lastActivity {
+					lastActivity = out
+				}
+			}
+			if lastActivity <= cutoff {
+				w.AgentState = AgentStateIdle
+				w.AgentStateAt = now.UnixNano()
+				flipped++
+			}
+		}
+		if flipped == 0 {
+			// Returning an error makes mutateState skip the version bump and the
+			// client push, so a quiet tick that changed nothing is free.
+			return errNoStallChange
+		}
+		return nil
+	})
+	return flipped
+}
+
+// errNoStallChange is a sentinel used by applyStallHeuristic to tell mutateState
+// that a tick changed nothing, so it neither bumps the version nor pushes state.
+// It never leaves the package.
+var errNoStallChange = stallNoChange{}
+
+type stallNoChange struct{}
+
+func (stallNoChange) Error() string { return "no agent-state change" }

--- a/internal/session/agent_state_test.go
+++ b/internal/session/agent_state_test.go
@@ -1,0 +1,277 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseAgentState checks the wire-name mapping, including that "none" clears
+// to the empty AgentStateNone and that an unknown or empty name is rejected.
+func TestParseAgentState(t *testing.T) {
+	cases := map[string]struct {
+		want AgentState
+		ok   bool
+	}{
+		"none":        {AgentStateNone, true},
+		"working":     {AgentStateWorking, true},
+		"needs_input": {AgentStateNeedsInput, true},
+		"idle":        {AgentStateIdle, true},
+		"done":        {AgentStateDone, true},
+		"errored":     {AgentStateErrored, true},
+		"bogus":       {AgentStateNone, false},
+		"":            {AgentStateNone, false},
+	}
+	for in, want := range cases {
+		got, ok := ParseAgentState(in)
+		if got != want.want || ok != want.ok {
+			t.Errorf("ParseAgentState(%q) = (%q, %v), want (%q, %v)", in, got, ok, want.want, want.ok)
+		}
+	}
+	if AgentStateNone.Name() != "none" {
+		t.Errorf("AgentStateNone.Name() = %q, want none", AgentStateNone.Name())
+	}
+	if AgentStateWorking.Name() != "working" {
+		t.Errorf("AgentStateWorking.Name() = %q, want working", AgentStateWorking.Name())
+	}
+}
+
+// TestSetAgentStateVerbRoundTrip drives the set-agent-state and get-agent-state
+// verbs over the real socket: a set followed by a get returns the same state and
+// message, and the mutation bumps the session version.
+func TestSetAgentStateVerbRoundTrip(t *testing.T) {
+	d, sp := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "work")
+	before := sess.GetState().Version
+
+	c := dialVerb(t, sp)
+
+	res := result(t, c.call(t, `{"id":1,"verb":"set-agent-state","params":{"session":"work","window":"Window","state":"needs_input","message":"awaiting approval"}}`))
+	if res["state"] != "needs_input" {
+		t.Fatalf("set-agent-state returned state %v, want needs_input", res["state"])
+	}
+
+	after := sess.GetState().Version
+	if after <= before {
+		t.Fatalf("version did not bump: before=%d after=%d", before, after)
+	}
+
+	got := result(t, c.call(t, `{"id":2,"verb":"get-agent-state","params":{"session":"work","window":"Window"}}`))
+	if got["state"] != "needs_input" {
+		t.Fatalf("get-agent-state returned state %v, want needs_input", got["state"])
+	}
+	if got["message"] != "awaiting approval" {
+		t.Fatalf("get-agent-state returned message %v, want %q", got["message"], "awaiting approval")
+	}
+
+	// Clearing with none round-trips back to none.
+	_ = result(t, c.call(t, `{"id":3,"verb":"set-agent-state","params":{"session":"work","window":"Window","state":"none"}}`))
+	cleared := result(t, c.call(t, `{"id":4,"verb":"get-agent-state","params":{"session":"work","window":"Window"}}`))
+	if cleared["state"] != "none" {
+		t.Fatalf("after clearing, get-agent-state returned %v, want none", cleared["state"])
+	}
+}
+
+// TestSetAgentStateRejectsBadState checks the verb validates the state name.
+func TestSetAgentStateRejectsBadState(t *testing.T) {
+	_, sp := startTestDaemon(t)
+	c := dialVerb(t, sp)
+	// A session with a window so the failure is the state, not the target.
+	// (startTestDaemon holds no sessions; create one over the manager is not
+	// reachable here, so a bogus state must fail before session resolution.)
+	code := errCode(t, c.call(t, `{"id":1,"verb":"set-agent-state","params":{"session":"work","state":"bogus"}}`))
+	if code != ErrVerbInvalidParams {
+		t.Fatalf("bad state gave code %q, want %q", code, ErrVerbInvalidParams)
+	}
+
+	missing := errCode(t, c.call(t, `{"id":2,"verb":"set-agent-state","params":{"session":"work"}}`))
+	if missing != ErrVerbInvalidParams {
+		t.Fatalf("missing state gave code %q, want %q", missing, ErrVerbInvalidParams)
+	}
+}
+
+// TestSetAgentStateVerbListed confirms the verbs appear in the self-describing
+// list-verbs output, so a caller can discover them.
+func TestSetAgentStateVerbListed(t *testing.T) {
+	if _, ok := verbRegistry["set-agent-state"]; !ok {
+		t.Error("set-agent-state missing from verb registry")
+	}
+	if _, ok := verbRegistry["get-agent-state"]; !ok {
+		t.Error("get-agent-state missing from verb registry")
+	}
+	names := knownVerbNames()
+	found := false
+	for _, n := range names {
+		if n == "set-agent-state" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("set-agent-state missing from knownVerbNames (list-verbs output)")
+	}
+}
+
+// bareSessionWithWindow builds a session with one window but no daemon socket, so
+// the stall heuristic can be exercised directly without any network.
+func bareSessionWithWindow(t *testing.T) (*Session, string) {
+	t.Helper()
+	t.Cleanup(useResurrectionDir(t.TempDir()))
+	sess, err := NewSession("stall", &SessionConfig{}, 80, 24)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	win, err := sess.AddDaemonWindow("Window", nil)
+	if err != nil {
+		t.Fatalf("AddDaemonWindow: %v", err)
+	}
+	t.Cleanup(sess.Stop)
+	return sess, win.ID
+}
+
+func agentStateOf(t *testing.T, sess *Session, windowID string) AgentState {
+	t.Helper()
+	for _, w := range sess.GetState().Windows {
+		if w.ID == windowID {
+			return w.AgentState
+		}
+	}
+	t.Fatalf("window %s not found", windowID)
+	return AgentStateNone
+}
+
+// TestStallHeuristicDemotesQuietWorking checks a pane that reported working but
+// has gone quiet is demoted to idle only after the silence window elapses.
+func TestStallHeuristicDemotesQuietWorking(t *testing.T) {
+	sess, id := bareSessionWithWindow(t)
+	if err := sess.SetDaemonWindowAgentState(id, AgentStateWorking, ""); err != nil {
+		t.Fatalf("SetDaemonWindowAgentState: %v", err)
+	}
+	quiet := func(string) int64 { return 0 } // no output ever
+
+	const stall = 30 * time.Second
+
+	// Well within the window: no demotion.
+	now := time.Now()
+	if n := sess.applyStallHeuristic(now.Add(10*time.Second), stall, quiet); n != 0 {
+		t.Fatalf("demoted %d windows inside the stall window, want 0", n)
+	}
+	if got := agentStateOf(t, sess, id); got != AgentStateWorking {
+		t.Fatalf("state inside window = %q, want working", got)
+	}
+
+	// Past the window: demoted to idle.
+	if n := sess.applyStallHeuristic(now.Add(stall+time.Second), stall, quiet); n != 1 {
+		t.Fatalf("demoted %d windows past the stall window, want 1", n)
+	}
+	if got := agentStateOf(t, sess, id); got != AgentStateIdle {
+		t.Fatalf("state past window = %q, want idle", got)
+	}
+}
+
+// TestStallHeuristicRespectsRecentOutput checks a working pane that keeps
+// producing output is never demoted, however long it works.
+func TestStallHeuristicRespectsRecentOutput(t *testing.T) {
+	sess, id := bareSessionWithWindow(t)
+	if err := sess.SetDaemonWindowAgentState(id, AgentStateWorking, ""); err != nil {
+		t.Fatalf("SetDaemonWindowAgentState: %v", err)
+	}
+	const stall = 30 * time.Second
+	// Evaluate well past the original working report, but with output that arrived
+	// only a second before this evaluation: a busy pane keeps emitting, so its
+	// last output stays fresh relative to now even though it has worked a while.
+	evalAt := time.Now().Add(5 * stall)
+	recent := func(string) int64 { return evalAt.Add(-time.Second).UnixNano() }
+	if n := sess.applyStallHeuristic(evalAt, stall, recent); n != 0 {
+		t.Fatalf("demoted %d windows with recent output, want 0", n)
+	}
+	if got := agentStateOf(t, sess, id); got != AgentStateWorking {
+		t.Fatalf("state with recent output = %q, want working", got)
+	}
+}
+
+// TestStallHeuristicNeverOverridesExplicit checks the heuristic only ever moves a
+// pane out of working: an explicit needs_input (or any non-working state) is left
+// alone no matter how long it sits.
+func TestStallHeuristicNeverOverridesExplicit(t *testing.T) {
+	sess, id := bareSessionWithWindow(t)
+	quiet := func(string) int64 { return 0 }
+	const stall = 30 * time.Second
+	long := time.Now().Add(time.Hour)
+
+	for _, state := range []AgentState{AgentStateNeedsInput, AgentStateDone, AgentStateErrored, AgentStateIdle} {
+		if err := sess.SetDaemonWindowAgentState(id, state, ""); err != nil {
+			t.Fatalf("SetDaemonWindowAgentState(%q): %v", state, err)
+		}
+		if n := sess.applyStallHeuristic(long, stall, quiet); n != 0 {
+			t.Fatalf("heuristic changed %d windows in state %q, want 0", n, state)
+		}
+		if got := agentStateOf(t, sess, id); got != state {
+			t.Fatalf("state %q was overridden to %q by the heuristic", state, got)
+		}
+	}
+}
+
+// TestStallHeuristicDisabled checks a non-positive stall disables the heuristic.
+func TestStallHeuristicDisabled(t *testing.T) {
+	sess, id := bareSessionWithWindow(t)
+	if err := sess.SetDaemonWindowAgentState(id, AgentStateWorking, ""); err != nil {
+		t.Fatalf("SetDaemonWindowAgentState: %v", err)
+	}
+	quiet := func(string) int64 { return 0 }
+	if n := sess.applyStallHeuristic(time.Now().Add(time.Hour), 0, quiet); n != 0 {
+		t.Fatalf("disabled heuristic demoted %d windows, want 0", n)
+	}
+	if got := agentStateOf(t, sess, id); got != AgentStateWorking {
+		t.Fatalf("state with heuristic disabled = %q, want working", got)
+	}
+}
+
+// TestResolveAgentStallTimeout checks the config/env/default precedence.
+func TestResolveAgentStallTimeout(t *testing.T) {
+	t.Setenv("TUIOS_AGENT_STALL_SECONDS", "")
+	if got := resolveAgentStallTimeout(5 * time.Second); got != 5*time.Second {
+		t.Errorf("explicit config: got %v, want 5s", got)
+	}
+	if got := resolveAgentStallTimeout(-1); got != 0 {
+		t.Errorf("negative config should disable: got %v, want 0", got)
+	}
+	if got := resolveAgentStallTimeout(0); got != defaultAgentStallTimeout {
+		t.Errorf("zero config with no env: got %v, want default %v", got, defaultAgentStallTimeout)
+	}
+	t.Setenv("TUIOS_AGENT_STALL_SECONDS", "12")
+	if got := resolveAgentStallTimeout(0); got != 12*time.Second {
+		t.Errorf("env override: got %v, want 12s", got)
+	}
+	t.Setenv("TUIOS_AGENT_STALL_SECONDS", "0")
+	if got := resolveAgentStallTimeout(0); got != 0 {
+		t.Errorf("env 0 should disable: got %v, want 0", got)
+	}
+}
+
+// TestAgentStateRetainedAcrossClientSync checks a client state sync that omits
+// agent fields does not wipe them: the daemon carries them over by window id.
+func TestAgentStateRetainedAcrossClientSync(t *testing.T) {
+	sess, id := bareSessionWithWindow(t)
+	if err := sess.SetDaemonWindowAgentState(id, AgentStateWorking, "building"); err != nil {
+		t.Fatalf("SetDaemonWindowAgentState: %v", err)
+	}
+
+	// A client sync built from the daemon state but with the agent fields cleared,
+	// exactly as a client (which never sets them) would send.
+	incoming := sess.GetState()
+	incoming.BaseVersion = incoming.Version
+	for i := range incoming.Windows {
+		incoming.Windows[i].AgentState = AgentStateNone
+		incoming.Windows[i].AgentMessage = ""
+		incoming.Windows[i].AgentStateAt = 0
+	}
+	sess.UpdateState(incoming)
+
+	if got := agentStateOf(t, sess, id); got != AgentStateWorking {
+		t.Fatalf("agent state after client sync = %q, want working (should be retained)", got)
+	}
+	for _, w := range sess.GetState().Windows {
+		if w.ID == id && w.AgentMessage != "building" {
+			t.Fatalf("agent message after client sync = %q, want building", w.AgentMessage)
+		}
+	}
+}

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -49,7 +50,20 @@ type Daemon struct {
 	// sessions on daemon start. Sessions can still be brought back on demand
 	// with the resurrect verb.
 	disableAutoRestore bool
+
+	// agentStallTimeout is how long a pane may report working while producing no
+	// output before the stall heuristic demotes it to idle. Zero disables the
+	// heuristic. It is resolved once in NewDaemon from config or the
+	// TUIOS_AGENT_STALL_SECONDS environment override.
+	agentStallTimeout time.Duration
 }
+
+// defaultAgentStallTimeout is the conservative default silence window before a
+// pane that reported working but never reported anything after is assumed idle.
+// It is long on purpose: the heuristic is a fallback for agents that do not
+// report, and demoting a genuinely-busy-but-quiet pane too eagerly is worse than
+// leaving it looking busy a little longer.
+const defaultAgentStallTimeout = 30 * time.Second
 
 // pendingRequest tracks a routed command awaiting its result, with the time it
 // was created so cleanupLoop can expire stale entries.
@@ -123,6 +137,11 @@ type DaemonConfig struct {
 	LogFile    string
 	// DisableAutoRestore skips restoring saved sessions on daemon start.
 	DisableAutoRestore bool
+	// AgentStallTimeout overrides how long a pane may report working with no
+	// output before the stall heuristic demotes it to idle. Zero falls back to
+	// the TUIOS_AGENT_STALL_SECONDS environment override, then to the default; a
+	// negative value disables the heuristic.
+	AgentStallTimeout time.Duration
 }
 
 // NewDaemon creates a new daemon instance.
@@ -138,6 +157,7 @@ func NewDaemon(cfg *DaemonConfig) *Daemon {
 		events:             newEventHub(),
 		version:            cfg.Version,
 		disableAutoRestore: cfg.DisableAutoRestore,
+		agentStallTimeout:  resolveAgentStallTimeout(cfg.AgentStallTimeout),
 	}
 
 	if cfg.SocketPath != "" {
@@ -237,6 +257,7 @@ func (d *Daemon) Start() error {
 	go d.handleSignals()
 	go d.acceptLoop()
 	go d.cleanupLoop()
+	go d.stallMonitor()
 
 	return nil
 }
@@ -574,6 +595,69 @@ func (d *Daemon) cleanupLoop() {
 				}
 			}
 			d.pendingRequestsMu.Unlock()
+		}
+	}
+}
+
+// resolveAgentStallTimeout picks the stall heuristic's silence window: an
+// explicit positive config wins, a negative config disables the heuristic, and a
+// zero config falls back to the TUIOS_AGENT_STALL_SECONDS environment override
+// (0 or less there disables it) and finally to the default.
+func resolveAgentStallTimeout(cfg time.Duration) time.Duration {
+	if cfg > 0 {
+		return cfg
+	}
+	if cfg < 0 {
+		return 0
+	}
+	if s := os.Getenv("TUIOS_AGENT_STALL_SECONDS"); s != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil {
+			if n <= 0 {
+				return 0
+			}
+			return time.Duration(n) * time.Second
+		}
+	}
+	return defaultAgentStallTimeout
+}
+
+// stallMonitor periodically applies the agent-state output-stall heuristic to
+// every live session, demoting panes that reported working but have gone quiet
+// to idle. It is the fallback for agents that never report their own state and is
+// strictly secondary to explicit reports (see Session.applyStallHeuristic). It
+// exits when the daemon context is cancelled, and does nothing at all when the
+// heuristic is disabled.
+func (d *Daemon) stallMonitor() {
+	if d.agentStallTimeout <= 0 {
+		return
+	}
+	// Tick often enough to demote within a fraction of the timeout, but never
+	// spin: at least once a second, at most once every ten.
+	interval := d.agentStallTimeout / 4
+	if interval < time.Second {
+		interval = time.Second
+	}
+	if interval > 10*time.Second {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			for _, sess := range d.manager.AllSessions() {
+				sess := sess
+				sess.applyStallHeuristic(now, d.agentStallTimeout, func(ptyID string) int64 {
+					if pty := sess.GetPTY(ptyID); pty != nil {
+						return pty.LastOutput()
+					}
+					return 0
+				})
+			}
 		}
 	}
 }

--- a/internal/session/daemon_native.go
+++ b/internal/session/daemon_native.go
@@ -398,6 +398,15 @@ func windowStateToData(state *SessionState, idx int) map[string]any {
 	if w.CustomName != "" {
 		info["custom_name"] = w.CustomName
 	}
+	// Always report the agent state (as "none" when unset) so a consumer building
+	// an attention view can read every pane's state in one list-windows call.
+	info["agent_state"] = w.AgentState.Name()
+	if w.AgentMessage != "" {
+		info["agent_message"] = w.AgentMessage
+	}
+	if w.AgentStateAt != 0 {
+		info["agent_state_at"] = w.AgentStateAt
+	}
 	return info
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -71,6 +71,15 @@ func (m *Manager) CreateSession(name string, cfg *SessionConfig, width, height i
 		}
 	}
 
+	// Stamp the daemon socket path so shells spawned in this session can find the
+	// daemon (exported as TUIOS_SOCKET) without every caller having to know it.
+	if cfg == nil {
+		cfg = &SessionConfig{}
+	}
+	if cfg.SocketPath == "" {
+		cfg.SocketPath = m.SocketPath()
+	}
+
 	// Create the session
 	session, err := NewSession(name, cfg, width, height)
 	if err != nil {
@@ -171,6 +180,19 @@ func (m *Manager) ListSessions() []SessionInfo {
 	})
 
 	return infos
+}
+
+// AllSessions returns every live session. It backs the daemon's agent-state
+// stall monitor, which needs the session objects themselves rather than the
+// SessionInfo summaries ListSessions returns.
+func (m *Manager) AllSessions() []*Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		out = append(out, s)
+	}
+	return out
 }
 
 // SessionCount returns the number of active sessions.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -66,6 +67,20 @@ type WindowState struct {
 	// resurrection state written before this existed) reads as placed, which is
 	// exactly the pre-existing behavior of trusting the geometry as sent.
 	Unplaced bool `json:"unplaced,omitempty"`
+	// AgentState is the semantic state of an agent running in this pane
+	// (working, needs_input, idle, done, errored). It is daemon-owned: a pane
+	// reports it through the set-agent-state verb and clients never set it, so it
+	// is retained across a client sync the same way Cwd and Options are. The zero
+	// value (empty) is AgentStateNone and is omitted from serialized state, so
+	// older state and older clients read back as "no agent", the pre-existing
+	// behavior.
+	AgentState AgentState `json:"agent_state,omitempty"`
+	// AgentMessage is an optional short note the pane reported alongside its
+	// state, e.g. what it is waiting for. Daemon-owned, like AgentState.
+	AgentMessage string `json:"agent_message,omitempty"`
+	// AgentStateAt is the unix-nano time AgentState was last set. It is stamped
+	// daemon-side and drives the output-stall heuristic (see applyStallHeuristic).
+	AgentStateAt int64 `json:"agent_state_at,omitempty"`
 }
 
 // SerializedBSPNode represents a BSP tree node for serialization
@@ -203,6 +218,18 @@ type PTY struct {
 	// change, process exit) already tagged with this PTY's window and PTY ID. It
 	// is a no-op when the session has no event sink installed.
 	emit func(SessionEvent)
+
+	// lastOutput is the unix-nano time this PTY most recently produced output. It
+	// is written on the PTY read goroutine and read by the daemon's output-stall
+	// heuristic, so it is an atomic rather than guarded by a lock.
+	lastOutput atomic.Int64
+}
+
+// LastOutput returns the unix-nano time this PTY most recently produced output,
+// or 0 if it has produced none. It backs the daemon's agent-state stall
+// heuristic, which demotes a pane that reported working but has gone quiet.
+func (p *PTY) LastOutput() int64 {
+	return p.lastOutput.Load()
 }
 
 // Session represents a persistent TUIOS session.
@@ -286,6 +313,10 @@ type SessionConfig struct {
 	Term      string
 	ColorTerm string
 	Shell     string
+	// SocketPath is the daemon socket a shell spawned in this session reports to.
+	// The manager stamps it from the daemon's own socket when a session is
+	// created, so it is exported into every pane's environment as TUIOS_SOCKET.
+	SocketPath string
 }
 
 // NewSession creates a new persistent session.
@@ -854,6 +885,17 @@ func (s *Session) buildEnv(windowID string, restored bool) []string {
 	env = append(env, "TUIOS_SESSION="+s.Name)
 	if windowID != "" {
 		env = append(env, "TUIOS_WINDOW_ID="+windowID)
+		// TUIOS_PANE_ID is an alias a state-reporting shim guards on, mirroring
+		// the pane-id contract other multiplexers' agent integrations use.
+		env = append(env, "TUIOS_PANE_ID="+windowID)
+	}
+	// TUIOS_ENV marks a process as running under tuios, and TUIOS_SOCKET tells a
+	// shim which daemon socket to report to. Together with the pane id above they
+	// are the whole contract the agent-state shim needs; a shim finds nothing to
+	// report to when they are unset and no-ops.
+	env = append(env, "TUIOS_ENV=1")
+	if s.config != nil && s.config.SocketPath != "" {
+		env = append(env, "TUIOS_SOCKET="+s.config.SocketPath)
 	}
 	// Mark restored shells so the user's shell rc (and scripts) can react, and
 	// so the restore is observable without relying on the visual banner.
@@ -1272,6 +1314,11 @@ func (p *PTY) readOutput() {
 
 			// Broadcast to subscribers
 			p.broadcast(data)
+
+			// Record the activity time for the agent-state stall heuristic before
+			// anything that can block, so a demotion decision is made against when
+			// output actually arrived.
+			p.lastOutput.Store(time.Now().UnixNano())
 
 			// Raise a control-plane output-activity event. This is a lightweight
 			// signal (byte count only, no content) that drives wait-for-output and

--- a/internal/session/state_merge.go
+++ b/internal/session/state_merge.go
@@ -30,14 +30,33 @@ func retainDaemonExclusive(incoming, canonical *SessionState) {
 	}
 
 	cwds := make(map[string]string, len(canonical.Windows))
+	// Agent state is daemon-owned and clients never set it, so it is carried over
+	// by window id exactly as Cwd is; without this a client sync (which omits it)
+	// would wipe every pane's reported state.
+	type agent struct {
+		state   AgentState
+		message string
+		at      int64
+	}
+	agents := make(map[string]agent, len(canonical.Windows))
 	for i := range canonical.Windows {
-		if cwd := canonical.Windows[i].Cwd; cwd != "" {
-			cwds[canonical.Windows[i].ID] = cwd
+		w := &canonical.Windows[i]
+		if cwd := w.Cwd; cwd != "" {
+			cwds[w.ID] = cwd
+		}
+		if w.AgentState != AgentStateNone || w.AgentMessage != "" || w.AgentStateAt != 0 {
+			agents[w.ID] = agent{w.AgentState, w.AgentMessage, w.AgentStateAt}
 		}
 	}
 	for i := range incoming.Windows {
-		if incoming.Windows[i].Cwd == "" {
-			incoming.Windows[i].Cwd = cwds[incoming.Windows[i].ID]
+		w := &incoming.Windows[i]
+		if w.Cwd == "" {
+			w.Cwd = cwds[w.ID]
+		}
+		if a, ok := agents[w.ID]; ok && w.AgentState == AgentStateNone && w.AgentMessage == "" && w.AgentStateAt == 0 {
+			w.AgentState = a.state
+			w.AgentMessage = a.message
+			w.AgentStateAt = a.at
 		}
 	}
 }

--- a/internal/session/verb_handlers.go
+++ b/internal/session/verb_handlers.go
@@ -468,6 +468,81 @@ func (d *Daemon) verbGetOption(_ *connState, params json.RawMessage) (any, *verb
 	return map[string]any{"type": "option", "key": p.Key, "value": value}, nil
 }
 
+func (d *Daemon) verbSetAgentState(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p struct {
+		Session string `json:"session"`
+		Window  string `json:"window"`
+		State   string `json:"state"`
+		Message string `json:"message"`
+	}
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	if p.State == "" {
+		return nil, invalidParam("state", "state is required, one of: "+strings.Join(AgentStateNames, ", "))
+	}
+	state, ok := ParseAgentState(p.State)
+	if !ok {
+		return nil, hintedVerbError(ErrVerbInvalidParams, "unknown agent state "+echoName(p.State), &VerbHint{
+			Param:      "state",
+			DidYouMean: closestMatch(p.State, AgentStateNames),
+			Available:  AgentStateNames,
+			Detail:     "state names the pane's semantic agent state; use none to clear it.",
+		})
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	target := p.Window
+	if target == "" {
+		id, err := focusedWindowID(sess.GetState())
+		if err != nil {
+			return nil, mapResolveErr(err, sess)
+		}
+		target = id
+	}
+
+	if err := sess.SetDaemonWindowAgentState(target, state, p.Message); err != nil {
+		return nil, mapResolveErr(err, sess)
+	}
+	return map[string]any{"type": "agent_state_set", "state": state.Name(), "message": p.Message}, nil
+}
+
+func (d *Daemon) verbGetAgentState(_ *connState, params json.RawMessage) (any, *verbError) {
+	var p commonParams
+	if verr := decodeParams(params, &p); verr != nil {
+		return nil, verr
+	}
+	sess, verr := d.resolveVerbSession(p.Session)
+	if verr != nil {
+		return nil, verr
+	}
+
+	state := sess.GetState()
+	target := p.Window
+	if target == "" {
+		id, err := focusedWindowID(state)
+		if err != nil {
+			return nil, mapResolveErr(err, sess)
+		}
+		target = id
+	}
+	idx, err := findWindowStateIndex(state.Windows, target)
+	if err != nil {
+		return nil, mapResolveErr(err, sess)
+	}
+	w := state.Windows[idx]
+	return map[string]any{
+		"type":           "agent_state",
+		"window_id":      w.ID,
+		"state":          w.AgentState.Name(),
+		"message":        w.AgentMessage,
+		"agent_state_at": w.AgentStateAt,
+	}, nil
+}
+
 // sliceCaptureLines applies the optional region/lines selection to captured
 // content. start/end are 1-based inclusive line numbers; when both are zero the
 // region is ignored. lines, when > 0 and no region is given, keeps only the last

--- a/internal/session/verb_protocol.go
+++ b/internal/session/verb_protocol.go
@@ -292,6 +292,25 @@ func init() {
 			examples:    []string{`{"id":1,"verb":"unsubscribe"}`},
 			handler:     (*Daemon).verbUnsubscribe,
 		},
+		"set-agent-state": {
+			description: "Set the agent state a window's pane reports (working, needs_input, idle, done, errored, or none to clear). A pane reports its own state by calling this against the daemon socket.",
+			params: []verbParam{
+				sessionParam,
+				windowParam,
+				{Name: "state", Type: "string", Required: true, Description: "The agent state to record.", Accepted: AgentStateNames},
+				{Name: "message", Type: "string", Description: "Optional short note reported with the state, e.g. what the agent is waiting for."},
+			},
+			examples: []string{
+				`{"id":1,"verb":"set-agent-state","params":{"session":"work","state":"needs_input","message":"awaiting approval"}}`,
+			},
+			handler: (*Daemon).verbSetAgentState,
+		},
+		"get-agent-state": {
+			description: "Read the agent state a window's pane last reported, with its optional message and the time it was set.",
+			params:      []verbParam{sessionParam, windowParam},
+			examples:    []string{`{"id":1,"verb":"get-agent-state","params":{"session":"work","window":"build"}}`},
+			handler:     (*Daemon).verbGetAgentState,
+		},
 		"wait-for": {
 			description: "Block until a condition matches, or fail with the timeout code.",
 			params: []verbParam{

--- a/internal/terminal/window.go
+++ b/internal/terminal/window.go
@@ -311,6 +311,14 @@ type Window struct {
 
 	Tiled bool // True when window is in shared-border tiling mode (no individual borders)
 
+	// AgentState is the semantic agent state the daemon reports for this pane
+	// (working, needs_input, idle, done, errored, or empty for none). It is set
+	// from the daemon state sync and read by the renderer to draw the per-window
+	// state indicator; it is written and read on the UI goroutine, like CustomName.
+	AgentState string
+	// AgentMessage is the optional short note reported with AgentState.
+	AgentMessage string
+
 	KittyPassthroughFunc func(cmd *vt.KittyCommand, rawData []byte)
 	SixelPassthroughFunc func(cmd *vt.SixelCommand, cursorX, cursorY, absLine int)
 


### PR DESCRIPTION
The first piece of making tuios a better herdr, from the analysis in tuios-vs-herdr-analysis.md. herdr's one differentiator is that it tracks each pane's semantic agent state and surfaces which agents need attention. tuios had no such concept; everything else it needs (a daemon owning versioned per-window state, a self-describing verb protocol, state sync to clients) already existed. This rides those rails rather than inventing a parallel system.

## State model

`AgentState`: `none`, `working`, `needs_input`, `idle`, `done`, `errored`. Three `omitempty` fields on `WindowState`, so it syncs through the existing versioned mechanism and older clients read `none`. `SetDaemonWindowAgentState` mutates through the existing `mutateState`, bumping the version and pushing to clients like any other daemon mutation. Client syncs never set the fields; they are retained by window id the same way `Cwd` and `Options` are.

## Verb

`set-agent-state` and `get-agent-state` (params: session, window, state, message), following the existing verbs' shape and validation, both in the self-describing `list-verbs` output. Bad or missing state returns `invalid_params` with a did-you-mean hint. `list-windows --json` now reports each window's `agent_state`. CLI: `tuios set-agent-state <state>` / `tuios get-agent-state`.

## Stall fallback

A daemon goroutine demotes a pane that reported `working` but produced no output for the timeout to `idle`. It only ever moves a pane OUT of `working` and only INTO `idle`, so an explicit report is never overridden and it never promotes into `working`. Default 30s, configurable via `TUIOS_AGENT_STALL_SECONDS` (0 disables). Secondary to explicit reporting by construction.

## Indicator

A per-state glyph in the window title: working, needs_input, idle, done, errored each distinct; nothing for none. Chose glyphs over colour so they survive a monochrome capture and avoid embedding ANSI in the title badge; per-state colour is a clean follow-on. Placed on the window rather than the dock, since the dock only shows minimized panes.

## Reference shim

`integrations/claude-code/tuios-agent-state.sh` maps Claude Code hooks to states (SessionStart / UserPromptSubmit to working, Notification to needs_input, Stop to done), filters subagent events, and no-ops when `TUIOS_ENV` / `TUIOS_SOCKET` / `TUIOS_PANE_ID` are unset. Panes now export those. It does not touch the existing herdr hook. Docs in docs/AGENT_STATE.md.

## Verification

Unit tests cover the verb round-trip and version bump, validation, list-verbs inclusion, and the stall heuristic (fires only after N, respects recent output, never overrides an explicit non-working state, disabled at 0, config precedence, retention across sync). The e2e test drives a real daemon, sets state via the CLI verb, and asserts the client renders the indicator and clears it on `none`. Negative control confirmed: against origin/main the e2e test fails with `Unknown command "set-agent-state"`.

`go build`, `go vet`, `gofmt`, `go test ./...`, and the nested e2e module all green.

## Decisions open to change
State names used verbatim; 30s stall default; glyphs not colour; Stop maps to `done` not `idle` so a finished turn reads as attention-worthy. This is the state model only; the attention inbox and remote observer are later pieces that will consume it.