### PR TITLE
Make kitty-graphics browsers interactive in a pane: pixel mouse and resize hold

### DIFF
--- a/internal/app/kitty_passthrough.go
+++ b/internal/app/kitty_passthrough.go
@@ -91,6 +91,12 @@ type KittyPassthrough struct {
 	// Screen dimensions (updated by RefreshAllPlacements)
 	screenWidth  int
 	screenHeight int
+
+	// resizeFreezeSize records, per window, the size a placement was last laid
+	// out at while that window is being manipulated. It exists to suppress the
+	// per-tick re-placement churn during an interactive resize; see
+	// RefreshAllPlacements.
+	resizeFreezeSize map[string][2]int
 }
 
 // pendingDirectTransmit holds accumulated data for chunked direct transmissions
@@ -234,6 +240,7 @@ func NewKittyPassthroughWithOptions(opts KittyPassthroughOptions) *KittyPassthro
 		nextHostID:        1,
 		pendingDirectData: make(map[string]*pendingDirectTransmit),
 		asyncFrameCh:      make(chan []byte, 1),
+		resizeFreezeSize:  make(map[string][2]int),
 	}
 	go kp.asyncFrameWriter()
 	return kp

--- a/internal/app/kitty_passthrough_placement.go
+++ b/internal/app/kitty_passthrough_placement.go
@@ -75,10 +75,39 @@ func (kp *KittyPassthrough) RefreshAllPlacements(getAllWindows func() map[string
 				}
 			}
 			delete(kp.placements, windowID)
+			delete(kp.resizeFreezeSize, windowID)
 			continue
 		}
 
 		kittyPassthroughLog("RefreshAllPlacements: windowID=%s, IsAltScreen=%v, visible=%v", windowID[:min(8, len(windowID))], info.IsAltScreen, info.Visible)
+
+		// Coalesce an interactive resize.
+		//
+		// A drag-resize changes the window size every render tick, and the guest
+		// has not redrawn at the new size yet (the PTY resize is deferred until
+		// the gesture settles, see resize_deferral.go). Re-clipping and re-placing
+		// the same stale image against each intermediate viewport size makes it
+		// visibly crop and jitter many times a second: the flicker. So while a
+		// window is being manipulated AND its size differs from the size the
+		// placement was last laid out at, the existing placement is left exactly
+		// where it is - kitty keeps the last a=p on screen - and no delete or
+		// re-place is emitted for it.
+		//
+		// resizeFreezeSize records that last laid-out size. It is refreshed on
+		// every pass that is NOT frozen, so a plain window move (manipulated but
+		// unchanged size) still re-places and follows the pointer, and the instant
+		// the gesture ends the settled size is recorded and the image re-places
+		// once at the final geometry. The deferred PTY resize then delivers a
+		// fresh frame; nothing is left stale.
+		if prev, seen := kp.resizeFreezeSize[windowID]; info.IsBeingManipulated && seen &&
+			(prev[0] != info.Width || prev[1] != info.Height) {
+			// Frozen: hold this window's placement untouched for this tick.
+			// resizeFreezeSize is deliberately not updated, so every later tick of
+			// the same gesture keeps differing from it and stays frozen until the
+			// size settles.
+			continue
+		}
+		kp.resizeFreezeSize[windowID] = [2]int{info.Width, info.Height}
 
 		// During window manipulation (drag/resize), let images reposition
 		// with the window. The change detection below (posChanged check)

--- a/internal/app/kitty_passthrough_resize_test.go
+++ b/internal/app/kitty_passthrough_resize_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// placementHarness wires a real VT emulator to a native kitty passthrough for a
+// single full-screen pane and streams a browser-style direct frame (a=T, i=1)
+// into it. It returns the passthrough, the emulator, a mutable window-info the
+// caller drives, and a refresh function that returns everything forwarded to the
+// host on that refresh.
+func placementHarness(t *testing.T, screenW, screenH, border int) (*KittyPassthrough, *vt.Emulator, *WindowPositionInfo, func() string) {
+	t.Helper()
+	clientCapabilities = &HostCapabilities{
+		TerminalName: "kitty", KittyGraphics: true, KittyFileTransfer: true,
+		TrueColor: true, CellWidth: 10, CellHeight: 20,
+	}
+	t.Cleanup(func() { clientCapabilities = nil })
+
+	hostFile, err := os.CreateTemp(t.TempDir(), "hostout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kp := NewKittyPassthroughWithOptions(KittyPassthroughOptions{Output: hostFile})
+	if kp.inlineGraphics {
+		t.Fatal("expected native mode")
+	}
+
+	winID := "win"
+	em := vt.NewEmulator(screenW-2*border, screenH-2*border)
+	t.Cleanup(func() { _ = em.Close() })
+	em.SetKittyPassthroughFunc(func(cmd *vt.KittyCommand, rawData []byte) {
+		cur := em.CursorPosition()
+		kp.ForwardCommand(cmd, rawData, winID, 0, 0, screenW, screenH, border, border,
+			cur.X, cur.Y, em.ScrollbackLen(), em.IsAltScreen(), func([]byte) {})
+	})
+	// Alt screen + a frame that fills the pane exactly (contentW*cellW x
+	// contentH*cellH), the way a full-window graphics app draws.
+	_, _ = em.Write([]byte("\x1b[?1049h\x1b[H"))
+	imgW := (screenW - 2*border) * 10
+	imgH := (screenH - 2*border) * 20
+	streamBrowserFrame(em, 1, imgW, imgH)
+
+	info := &WindowPositionInfo{
+		WindowX: 0, WindowY: 0, ContentOffsetX: border, ContentOffsetY: border,
+		Width: screenW, Height: screenH, Visible: true,
+		ScreenWidth: screenW, ScreenHeight: screenH,
+		IsAltScreen: em.IsAltScreen(), ScrollbackLen: em.ScrollbackLen(),
+	}
+	refresh := func() string {
+		kp.RefreshAllPlacements(func() map[string]*WindowPositionInfo {
+			return map[string]*WindowPositionInfo{winID: info}
+		})
+		return string(kp.FlushPending())
+	}
+	return kp, em, info, refresh
+}
+
+// streamBrowserFrame writes one direct transmit+place (a=T, reused id) frame, as
+// terminal-browser emits every rendered frame.
+func streamBrowserFrame(em *vt.Emulator, id, w, h int) {
+	var b strings.Builder
+	b.WriteString("\x1b_Ga=T,f=32,s=")
+	b.WriteString(strconv.Itoa(w))
+	b.WriteString(",v=")
+	b.WriteString(strconv.Itoa(h))
+	b.WriteString(",t=d,i=")
+	b.WriteString(strconv.Itoa(id))
+	b.WriteString(",p=1,C=1,q=2;AAAA\x1b\\")
+	_, _ = em.Write([]byte(b.String()))
+}
+
+func countCmd(s, needle string) int { return strings.Count(s, needle) }
+
+func lastPlacement(s string) string {
+	i := strings.LastIndex(s, "a=p")
+	if i < 0 {
+		return ""
+	}
+	if j := strings.Index(s[i:], "\x1b\\"); j >= 0 {
+		return s[i : i+j]
+	}
+	return s[i:]
+}
+
+// TestResizeCoalescesPlacementChurn is the objective anti-flicker proof. During
+// an interactive resize the pane size changes every render tick while the guest
+// image is still the old size (its PTY resize is deferred). The passthrough must
+// NOT re-clip and re-place the stale image on every tick - that churn is the
+// flicker. It must hold the last placement and re-place once when the size
+// settles.
+//
+// Fails on main, where every size-changing tick emits a fresh a=p.
+func TestResizeCoalescesPlacementChurn(t *testing.T) {
+	_, _, info, refresh := placementHarness(t, 120, 40, 1)
+
+	// Prime: one refresh places the image at the starting size.
+	_ = refresh()
+
+	// Drag-resize: the window shrinks each tick, IsBeingManipulated set.
+	info.IsBeingManipulated = true
+	sizes := [][2]int{{110, 38}, {100, 36}, {90, 34}, {80, 32}, {70, 30}}
+	churn := 0
+	for _, s := range sizes {
+		info.Width, info.Height = s[0], s[1]
+		out := refresh()
+		churn += countCmd(out, "a=p") + countCmd(out, "a=d")
+	}
+	if churn > 0 {
+		t.Fatalf("resize emitted %d placement commands over %d size-changing ticks; "+
+			"must hold the frame during an interactive resize (flicker)", churn, len(sizes))
+	}
+
+	// Settle: gesture ends, the pane keeps its final size. Exactly one re-place
+	// must bring the image to the settled geometry - no leftover stale image.
+	info.IsBeingManipulated = false
+	settle := refresh()
+	if countCmd(settle, "a=p") != 1 {
+		t.Fatalf("after resize settled, expected exactly one a=p, got %d (%q)",
+			countCmd(settle, "a=p"), settle)
+	}
+}
+
+// TestPlacementIdempotentOnUnrelatedRefresh proves that refreshing repeatedly
+// while the browser pane's geometry is unchanged - which is what happens when a
+// SIBLING pane redraws or scrolls and re-invokes the render loop - emits nothing
+// after the first placement. The visible region must be byte-stable: no stretch,
+// no ratcheting shrink to invisible, no delete+place churn.
+func TestPlacementIdempotentOnUnrelatedRefresh(t *testing.T) {
+	_, _, _, refresh := placementHarness(t, 120, 40, 0)
+
+	first := refresh()
+	if countCmd(first, "a=p") != 1 {
+		t.Fatalf("first refresh should place once, got %d a=p", countCmd(first, "a=p"))
+	}
+
+	// Many unrelated renders (sibling pane activity). The browser geometry never
+	// changes, so nothing may be forwarded.
+	for i := range 8 {
+		out := refresh()
+		if out != "" {
+			t.Fatalf("unrelated refresh %d churned the placement (%q); a sibling redraw "+
+				"must not re-place or resize the browser image", i, out)
+		}
+	}
+}
+
+// TestPlacementStableAcrossStreamedFrames proves the visible region is a pure
+// function of the pane rect: streaming identical frames at a fixed pane size
+// yields byte-identical placements frame after frame (the #116 edge clamp is
+// idempotent, never accumulating into a shrinking region).
+func TestPlacementStableAcrossStreamedFrames(t *testing.T) {
+	_, em, _, refresh := placementHarness(t, 120, 40, 0)
+
+	var want string
+	for frame := range 6 {
+		streamBrowserFrame(em, 1, 1200, 800)
+		got := lastPlacement(refresh())
+		if got == "" {
+			t.Fatalf("frame %d produced no placement", frame)
+		}
+		if frame == 0 {
+			want = got
+			continue
+		}
+		if got != want {
+			t.Fatalf("frame %d placement changed with no geometry change:\n got=%q\nwant=%q",
+				frame, got, want)
+		}
+	}
+}

--- a/internal/input/mouse_forward_graphics_test.go
+++ b/internal/input/mouse_forward_graphics_test.go
@@ -1,0 +1,89 @@
+package input
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// mouseModeGraphicsWindow builds a focused, full-content window whose emulator
+// has enabled the same mouse modes terminal-browser uses (any-motion + SGR +
+// SGR-pixel), sized so cell (5,3) maps to a known host pixel.
+func mouseModeGraphicsWindow(t *testing.T) (*app.OS, *vt.Emulator) {
+	t.Helper()
+	em := vt.NewEmulator(80, 24)
+	t.Cleanup(func() { _ = em.Close() })
+	_, _ = em.Write([]byte("\x1b[?1003h\x1b[?1006h\x1b[?1016h"))
+	em.SetCellSize(10, 20)
+
+	win := &terminal.Window{Terminal: em, X: 0, Y: 0, Width: 82, Height: 26}
+	o := &app.OS{
+		Mode:          app.TerminalMode,
+		FocusedWindow: 0,
+		Windows:       []*terminal.Window{win},
+	}
+	return o, em
+}
+
+// TestWheelForwardedToMouseModeGraphicsPane proves a wheel event over a
+// mouse-tracking pane reaches that pane's emulator instead of being swallowed by
+// tuios scrollback / copy mode (the natural-scroll routing is only for panes
+// WITHOUT mouse mode). With 1016 on it must carry pixel coordinates.
+func TestWheelForwardedToMouseModeGraphicsPane(t *testing.T) {
+	o, em := mouseModeGraphicsWindow(t)
+
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 128)
+		n, _ := em.Read(buf)
+		got <- string(buf[:n])
+	}()
+
+	// Wheel-up at screen cell (5,3); content offset is 1 (border), so pane cell
+	// is (4,2) -> pixel centre (4*10+5, 2*20+10) = (45, 50) -> SGR 1-based 46;51.
+	handleMouseWheel(tea.MouseWheelMsg(tea.Mouse{X: 5, Y: 3, Button: tea.MouseWheelUp}), o)
+
+	select {
+	case s := <-got:
+		if s != "\x1b[<64;46;51M" {
+			t.Fatalf("wheel report = %q, want %q (pixel coords for mouse-mode graphics pane)", s, "\x1b[<64;46;51M")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wheel was not forwarded to the mouse-mode pane (consumed by scrollback/copy mode?)")
+	}
+
+	// The wheel must not have entered copy mode on a mouse-mode pane.
+	if o.Windows[0].InCopyMode() {
+		t.Fatal("wheel over a mouse-mode pane wrongly entered copy mode")
+	}
+}
+
+// TestMotionForwardedToMouseModeGraphicsPane proves hover (motion) reaches a
+// mouse-mode pane with pixel coordinates when 1016 is on.
+func TestMotionForwardedToMouseModeGraphicsPane(t *testing.T) {
+	o, em := mouseModeGraphicsWindow(t)
+
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 128)
+		n, _ := em.Read(buf)
+		got <- string(buf[:n])
+	}()
+
+	// Motion at screen cell (5,3) -> pane cell (4,2) -> pixel 46;51, button 35
+	// is the SGR "motion, no button" code (32 + 3 for the motion bit path).
+	handleMouseMotion(tea.MouseMotionMsg(tea.Mouse{X: 5, Y: 3, Button: tea.MouseNone}), o)
+
+	select {
+	case s := <-got:
+		if s != "\x1b[<35;46;51M" {
+			t.Fatalf("motion report = %q, want %q (pixel hover for mouse-mode graphics pane)", s, "\x1b[<35;46;51M")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("motion (hover) was not forwarded to the mouse-mode pane")
+	}
+}

--- a/internal/vt/emulator.go
+++ b/internal/vt/emulator.go
@@ -670,13 +670,7 @@ func (e *Emulator) EncodeMouseEvent(m Mouse) string {
 		mouse.Mod.Contains(ModAlt),
 		mouse.Mod.Contains(ModCtrl))
 
-	switch enc {
-	case nil: // X10 mouse encoding
-		return ansi.MouseX10(b, mouse.X, mouse.Y)
-	case ansi.ModeMouseExtSgr: // SGR mouse encoding
-		return ansi.MouseSgr(b, mouse.X, mouse.Y, isRelease)
-	}
-	return ""
+	return e.encodeMouseReport(enc, b, mouse.X, mouse.Y, isRelease)
 }
 
 // Resize resizes the terminal.

--- a/internal/vt/mouse.go
+++ b/internal/vt/mouse.go
@@ -105,7 +105,6 @@ func (e *Emulator) SendMouse(m Mouse) {
 		// ansi.Utf8ExtMouseMode,
 		ansi.ModeMouseExtSgr,
 		// ansi.UrxvtExtMouseMode,
-		// ansi.SgrPixelExtMouseMode,
 	} {
 		if e.isModeSet(mm) {
 			enc = mm
@@ -121,13 +120,44 @@ func (e *Emulator) SendMouse(m Mouse) {
 		mouse.Mod.Contains(ModAlt),
 		mouse.Mod.Contains(ModCtrl))
 
-	switch enc {
-	// XXX: Support [ansi.HighlightMouseMode].
-	// XXX: Support [ansi.Utf8ExtMouseMode], [ansi.UrxvtExtMouseMode], and
-	// [ansi.SgrPixelExtMouseMode].
-	case nil: // X10 mouse encoding
-		_, _ = io.WriteString(e.pipe, ansi.MouseX10(b, mouse.X, mouse.Y))
-	case ansi.ModeMouseExtSgr: // SGR mouse encoding
-		_, _ = io.WriteString(e.pipe, ansi.MouseSgr(b, mouse.X, mouse.Y, isRelease))
+	_, _ = io.WriteString(e.pipe, e.encodeMouseReport(enc, b, mouse.X, mouse.Y, isRelease))
+}
+
+// encodeMouseReport turns a pane-relative cell position into the wire form the
+// guest asked for.
+//
+// SGR-pixel (DEC mode 1016) takes precedence over every other encoding when the
+// guest enabled it: a web page rendered by a kitty-graphics app (terminal-browser,
+// awrit) probes 1016 and, once it sees it enabled, reads every mouse report as
+// pixels. Reporting cell indices at that point places the pointer a cell-count of
+// pixels from the origin, which is why hover and clicks land in the top-left. So
+// when 1016 is set the cell position is scaled to host pixels; otherwise the
+// existing SGR-cell (1006) or X10 encoding is used unchanged.
+//
+// The pixel is the cell centre, matching the cell->pixel convention a terminal
+// app uses itself when it has only a cell report to work from. Sub-cell
+// precision is not available: the mouse position tuios receives from its own host
+// is already quantised to cells, so a cell centre is the most accurate pixel it
+// can report.
+func (e *Emulator) encodeMouseReport(enc ansi.Mode, b byte, cellX, cellY int, isRelease bool) string {
+	if e.isModeSet(ansi.ModeMouseExtSgrPixel) {
+		px, py := e.cellToPixel(cellX, cellY)
+		return ansi.MouseSgr(b, px, py, isRelease)
 	}
+	switch enc {
+	// XXX: Support [ansi.HighlightMouseMode] and [ansi.Utf8ExtMouseMode],
+	// [ansi.UrxvtExtMouseMode].
+	case ansi.ModeMouseExtSgr: // SGR mouse encoding
+		return ansi.MouseSgr(b, cellX, cellY, isRelease)
+	default: // X10 mouse encoding
+		return ansi.MouseX10(b, cellX, cellY)
+	}
+}
+
+// cellToPixel maps a pane-relative cell position to the host pixel position at
+// that cell's centre, for SGR-pixel (mode 1016) reporting. The cell dimensions
+// are the host terminal's, set via SetCellSize from the detected capabilities.
+func (e *Emulator) cellToPixel(cellX, cellY int) (int, int) {
+	cw, ch := e.CellSize()
+	return cellX*cw + cw/2, cellY*ch + ch/2
 }

--- a/internal/vt/mouse_pixel_test.go
+++ b/internal/vt/mouse_pixel_test.go
@@ -1,0 +1,92 @@
+package vt
+
+import (
+	"testing"
+	"time"
+)
+
+// A kitty-graphics web browser (terminal-browser, awrit) enables SGR-pixel mouse
+// (DEC mode 1016) and, once it sees it enabled, reads every mouse report as
+// pixels. tuios must then report the pointer in host pixels, not cells; reporting
+// cells while 1016 is on places every event a cell-count of pixels from the
+// origin, which is why hover and clicks land in the top-left corner.
+//
+// These tests pin the encoding for both mouse paths: EncodeMouseEvent (daemon,
+// over the PTY) and SendMouse (native, over the response pipe). Cell size is
+// 10x20, so a click at cell (3,4) is pixel (3*10+5, 4*20+10) = (35, 90) at the
+// cell centre, and MouseSgr reports it 1-based as 36;91.
+
+func enablePixelMouse(e *Emulator) {
+	// 1003 (any-motion) + 1006 (SGR) + 1016 (SGR-pixel): exactly what
+	// terminal-browser turns on at startup.
+	_, _ = e.Write([]byte("\x1b[?1003h\x1b[?1006h\x1b[?1016h"))
+	e.SetCellSize(10, 20)
+}
+
+func enableCellMouse(e *Emulator) {
+	_, _ = e.Write([]byte("\x1b[?1003h\x1b[?1006h"))
+	e.SetCellSize(10, 20)
+}
+
+func TestEncodeMousePixelMode(t *testing.T) {
+	e := NewEmulator(80, 24)
+	defer func() { _ = e.Close() }()
+	enablePixelMouse(e)
+
+	got := e.EncodeMouseEvent(MouseClick{X: 3, Y: 4, Button: MouseLeft})
+	want := "\x1b[<0;36;91M"
+	if got != want {
+		t.Fatalf("pixel-mode click = %q, want %q", got, want)
+	}
+
+	// Motion (any-motion mode is on) must also report pixels so hover works.
+	gotMotion := e.EncodeMouseEvent(MouseMotion{X: 3, Y: 4, Button: MouseNone})
+	if gotMotion != "\x1b[<35;36;91M" {
+		t.Fatalf("pixel-mode motion = %q, want %q", gotMotion, "\x1b[<35;36;91M")
+	}
+
+	// Wheel-up over the page must report pixels too.
+	gotWheel := e.EncodeMouseEvent(MouseWheel{X: 3, Y: 4, Button: MouseWheelUp})
+	if gotWheel != "\x1b[<64;36;91M" {
+		t.Fatalf("pixel-mode wheel = %q, want %q", gotWheel, "\x1b[<64;36;91M")
+	}
+}
+
+func TestEncodeMouseCellModeUnchanged(t *testing.T) {
+	e := NewEmulator(80, 24)
+	defer func() { _ = e.Close() }()
+	enableCellMouse(e)
+
+	// Without 1016, the existing SGR-cell (1006) encoding is used: cell (3,4)
+	// reported 1-based as 4;5, no pixel scaling.
+	got := e.EncodeMouseEvent(MouseClick{X: 3, Y: 4, Button: MouseLeft})
+	if got != "\x1b[<0;4;5M" {
+		t.Fatalf("cell-mode click = %q, want %q", got, "\x1b[<0;4;5M")
+	}
+}
+
+// TestSendMousePixelMode covers the native path, which writes to the emulator's
+// response pipe rather than returning a string.
+func TestSendMousePixelMode(t *testing.T) {
+	e := NewEmulator(80, 24)
+	defer func() { _ = e.Close() }()
+	enablePixelMouse(e)
+
+	out := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, _ := e.Read(buf)
+		out <- string(buf[:n])
+	}()
+
+	e.SendMouse(MouseClick{X: 3, Y: 4, Button: MouseLeft})
+
+	select {
+	case got := <-out:
+		if got != "\x1b[<0;36;91M" {
+			t.Fatalf("native pixel-mode click = %q, want %q", got, "\x1b[<0;36;91M")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for native mouse report")
+	}
+}


### PR DESCRIPTION
terminal-browser and awrit render in a tuios pane (PR #116) but hover did not work, clicks were imprecise, and resizing flickered. Fixes the tuios-side causes and documents which remaining limitations are terminal-browser's, not tuios's.

## The core bug: 1016 advertised but cells encoded

terminal-browser enables SGR-pixel mouse (mode 1016) and, if the terminal reflects it as enabled, reads every mouse report as pixels (engine/crates/pixel-core/src/terminal.rs). tuios reflected 1016 as enabled (the guest set it) via DECRQM but still encoded coordinates in cells, so the browser read a cell count as a pixel count and landed hover and clicks in the top-left corner. That single mismatch explains both broken hover and imprecise clicks.

Fix (internal/vt/mouse.go, emulator.go): when the guest has 1016 set, encode press/release/motion/wheel in host pixels (cell center times host cell size, which the emulator already knows from capabilities), through one shared encoder used by both the native (SendMouse) and daemon (EncodeMouseEvent) paths. Without 1016 the existing 1006/X10 encodings are untouched.

## Resize flicker

RefreshAllPlacements re-placed the image against each intermediate size every tick during a drag (the PTY resize is deferred), cropping and jittering. Now, while a window is being manipulated and its size differs from the size the placement was last laid out at, the placement is held (kitty keeps the last a=p), and it re-places exactly once at the settled geometry on gesture end. A plain move still follows the pointer; no stale leftover.

## Forwarding

Verified, no change needed: wheel and motion already reach a mouse-mode graphics pane rather than being taken by copy mode or scrollback. The only thing wrong was the coordinate encoding, above.

## What is NOT tuios's to fix

terminal-browser's smooth/trackpad scroll, pointer-follow hover between motion reports, and pinch-zoom come from an OS input helper that is X11-only (native/x11.rs, no Wayland backend). On this Niri/Wayland machine those degrade even in bare kitty, so they are out of scope here.

## Verification

Each fix fails on origin/main and passes here (run against a clean origin/main worktree):
- internal/vt/mouse_pixel_test.go: main sends `0;4;5`, want `0;36;91`.
- internal/app/kitty_passthrough_resize_test.go TestResizeCoalescesPlacementChurn: main emits 5 placement commands over 5 resize ticks; branch emits 0 during the resize and 1 on settle. Objective anti-flicker proof.
- internal/input/mouse_forward_graphics_test.go: wheel and motion reach the pane with pixel coords.

go build, go vet, gofmt, go test ./..., and the nested e2e module all green.

## Two honest caveats

- The user also reported the browser image stretching or shrinking to invisible when an ADJACENT pane scrolls or outputs. I could not reproduce it headlessly, and proved the placement layer is idempotent under repeated and streamed refreshes (TestPlacementIdempotentOnUnrelatedRefresh, TestPlacementStableAcrossStreamedFrames both pass on main). The likely real trigger is a transient frame/pane size mismatch right after a resize, which the freeze fix should cover. Needs a visual confirmation; if it persists it is a separate follow-up.
- Minor, not fixed to limit scope: forwardTransmit hardcodes a -2 border, so tiled/borderless images render 2 cells short. Stable, not the ratchet.