### PR TITLE
Render kitty graphics over ssh, and harden the ssh server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/internal/app/capabilities.go
+++ b/internal/app/capabilities.go
@@ -54,6 +54,21 @@ func GetHostCapabilities() *HostCapabilities {
 	return cachedCapabilities
 }
 
+// SetClientCapabilities installs capabilities detected from a remote client so
+// GetHostCapabilities reports the client's terminal rather than the server's
+// local one. The SSH and web servers use this: the terminal that must render
+// graphics is the one the user connected from, reached over the session, not
+// the (often headless) machine running the server.
+//
+// This is a process-global. A server handling several simultaneous clients with
+// different terminals shares the last-installed value for the live consumers
+// (image cell math, cell size); the per-connection graphics-enable decision is
+// snapshotted at construction and is not affected. Single-client connections,
+// the common case, are fully correct.
+func SetClientCapabilities(caps *HostCapabilities) {
+	clientCapabilities = caps
+}
+
 func DetectHostCapabilities() *HostCapabilities {
 	caps := &HostCapabilities{}
 

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"os"
+	"io"
 
 	"github.com/Gaurav-Gosain/tuios/internal/config"
 	"github.com/Gaurav-Gosain/tuios/internal/hooks"
@@ -58,9 +58,16 @@ type OSOptions struct {
 
 	// GraphicsOutput is the writer that kitty/sixel APC sequences are written
 	// to. If nil, the passthroughs fall back to /dev/tty / os.Stdout (the
-	// native TTY path). Web mode must supply the sip session's PTY slave so
-	// graphics bytes flow through the same pipe as bubbletea's text output.
-	GraphicsOutput *os.File
+	// native TTY path). Web mode supplies the sip session's PTY slave and SSH
+	// mode supplies the ssh.Session so graphics bytes flow through the same
+	// pipe as bubbletea's text output and reach the client's terminal.
+	GraphicsOutput io.Writer
+
+	// GraphicsRemoteClient marks the graphics host as a network client (SSH)
+	// that does not share the server's filesystem, so file-medium kitty
+	// transmissions are re-encoded as direct data. See
+	// KittyPassthroughOptions.RemoteClient.
+	GraphicsRemoteClient bool
 }
 
 // NewOS creates a new OS instance with the given options.
@@ -115,8 +122,9 @@ func NewOS(opts OSOptions) *OS {
 	// Initialize graphics passthrough if enabled
 	if opts.EnableGraphicsPassthrough {
 		os.KittyPassthrough = NewKittyPassthroughWithOptions(KittyPassthroughOptions{
-			ForceEnable: opts.ForceGraphicsEnabled,
-			Output:      opts.GraphicsOutput,
+			ForceEnable:  opts.ForceGraphicsEnabled,
+			Output:       opts.GraphicsOutput,
+			RemoteClient: opts.GraphicsRemoteClient,
 		})
 		os.SixelPassthrough = NewSixelPassthroughWithOptions(SixelPassthroughOptions{
 			ForceEnable: opts.ForceGraphicsEnabled,

--- a/internal/app/kitty_passthrough.go
+++ b/internal/app/kitty_passthrough.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -69,8 +70,12 @@ type KittyPassthrough struct {
 	// transmissions (t=f, t=s) are read server-side and re-encoded as
 	// direct (t=d) chunks because the browser cannot read local files.
 	inlineGraphics bool
-	hostOut        *os.File
-	hostMu         sync.Mutex // serializes writes to hostOut across render + async paths
+	// remoteClient is set when the host terminal is reached over the network
+	// (SSH) and does not share the server's filesystem. See
+	// KittyPassthroughOptions.RemoteClient.
+	remoteClient bool
+	hostOut      io.Writer
+	hostMu       sync.Mutex // serializes writes to hostOut across render + async paths
 
 	placements    map[string]map[uint32]*PassthroughPlacement
 	imageIDMap    map[string]map[uint32]uint32 // maps (windowID, guestImageID) -> hostImageID
@@ -213,8 +218,16 @@ type KittyPassthroughOptions struct {
 	// Output is the writer for kitty graphics APC sequences. If nil, the
 	// passthrough opens /dev/tty (or falls back to os.Stdout). Web mode
 	// should pass the sip session's PtySlave so graphics bytes flow through
-	// the same PTY as bubbletea's text output to the browser.
-	Output *os.File
+	// the same PTY as bubbletea's text output to the browser. SSH mode passes
+	// the ssh.Session so APC sequences reach the client's terminal.
+	Output io.Writer
+	// RemoteClient marks the host terminal as one reached over a network
+	// (SSH), so it does not share the server's filesystem. File-medium kitty
+	// transmissions (t=f/t=t/t=s) name a server-local path the client cannot
+	// read, so they are re-encoded as direct (t=d) data. Unlike the browser's
+	// inline-graphics mode this keeps native placement, clipping, and delete
+	// behavior, which a real remote terminal still needs.
+	RemoteClient bool
 }
 
 // NewKittyPassthroughWithOptions creates a passthrough with custom options.
@@ -234,6 +247,7 @@ func NewKittyPassthroughWithOptions(opts KittyPassthroughOptions) *KittyPassthro
 	kp := &KittyPassthrough{
 		enabled:           enabled,
 		inlineGraphics:    opts.ForceEnable,
+		remoteClient:      opts.RemoteClient,
 		hostOut:           hostOut,
 		placements:        make(map[string]map[uint32]*PassthroughPlacement),
 		imageIDMap:        make(map[string]map[uint32]uint32),

--- a/internal/app/kitty_passthrough_forward.go
+++ b/internal/app/kitty_passthrough_forward.go
@@ -209,7 +209,7 @@ func isFileMedium(medium vt.KittyGraphicsMedium) bool {
 // will actually resolve there. False for a browser client, whose only view of
 // an image is the bytes we send it.
 func (kp *KittyPassthrough) hostReadsFiles() bool {
-	if kp.inlineGraphics {
+	if kp.inlineGraphics || kp.remoteClient {
 		return false
 	}
 	return GetHostCapabilities().KittyFileTransfer

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -587,5 +587,16 @@ func (m *OS) SwitchToSession(targetSession string) error {
 func (m *OS) Cleanup() {
 	if m.DaemonClient != nil {
 		_ = m.DaemonClient.Close()
+		return
+	}
+
+	// Ephemeral mode: the windows own local PTYs (child shells). When the whole
+	// process is exiting these would be reaped anyway, but an ephemeral SSH
+	// session is a goroutine inside a long-lived server: without closing them
+	// here every disconnect would leak a shell process, its PTY, and the
+	// window's I/O goroutines. Window.Close is idempotent, so this is safe even
+	// when the local binary also calls Cleanup after the program exits.
+	for _, w := range m.Windows {
+		w.Close()
 	}
 }

--- a/internal/app/sixel_passthrough.go
+++ b/internal/app/sixel_passthrough.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -28,7 +29,7 @@ func sixelPassthroughLog(format string, args ...any) {
 type SixelPassthrough struct {
 	mu      sync.Mutex
 	enabled bool
-	hostOut *os.File
+	hostOut io.Writer
 
 	// Placements per window
 	placements map[string][]*SixelPassthroughPlacement
@@ -83,8 +84,9 @@ type SixelPassthroughPlacement struct {
 type SixelPassthroughOptions struct {
 	// ForceEnable skips capability detection (for web mode).
 	ForceEnable bool
-	// Output is the writer for sixel output. If nil, uses os.Stdout.
-	Output *os.File
+	// Output is the writer for sixel output. If nil, uses os.Stdout. Web mode
+	// passes the sip PtySlave; SSH mode passes the ssh.Session.
+	Output io.Writer
 }
 
 // NewSixelPassthroughWithOptions creates a new SixelPassthrough with custom

--- a/internal/app/ssh_graphics_routing_test.go
+++ b/internal/app/ssh_graphics_routing_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// withClientCaps installs client capabilities for the duration of a test and
+// restores whatever was there before. GetHostCapabilities prefers these.
+func withClientCaps(t *testing.T, caps *HostCapabilities) {
+	t.Helper()
+	prev := clientCapabilities
+	clientCapabilities = caps
+	t.Cleanup(func() { clientCapabilities = prev })
+}
+
+// TestKittyPassthrough_EnabledForKittyClient mirrors the SSH daemon/ephemeral
+// wiring: the client's detected capabilities are installed as the host caps and
+// graphics output is routed to a session writer. A kitty-capable client must
+// enable the passthrough and have its APC bytes land on that writer, not the
+// server's stdout.
+func TestKittyPassthrough_EnabledForKittyClient(t *testing.T) {
+	withClientCaps(t, &HostCapabilities{KittyGraphics: true, TerminalName: "kitty"})
+
+	var out bytes.Buffer
+	kp := NewKittyPassthroughWithOptions(KittyPassthroughOptions{
+		Output:       &out,
+		RemoteClient: true,
+	})
+	if !kp.IsEnabled() {
+		t.Fatal("expected kitty passthrough enabled for a kitty client")
+	}
+
+	kp.WriteToHost([]byte("PAYLOAD"))
+	if !strings.Contains(out.String(), "PAYLOAD") {
+		t.Fatalf("expected graphics written to the routed output, got %q", out.String())
+	}
+}
+
+// TestKittyPassthrough_DisabledForPlainClient is the negative case: a client
+// with no kitty support must leave the passthrough disabled so no APC bytes are
+// ever forwarded to a terminal that cannot render them.
+func TestKittyPassthrough_DisabledForPlainClient(t *testing.T) {
+	withClientCaps(t, &HostCapabilities{KittyGraphics: false, TerminalName: "xterm"})
+
+	var out bytes.Buffer
+	kp := NewKittyPassthroughWithOptions(KittyPassthroughOptions{
+		Output:       &out,
+		RemoteClient: true,
+	})
+	if kp.IsEnabled() {
+		t.Fatal("expected kitty passthrough disabled for a plain client")
+	}
+}
+
+// TestKittyPassthrough_RemoteClientNeverReadsFiles verifies that a remote
+// (SSH) client never resolves server-local file transmissions, even when the
+// host capabilities claim file-transfer support. Over SSH the file lives on the
+// server; the client can only render bytes we send it.
+func TestKittyPassthrough_RemoteClientNeverReadsFiles(t *testing.T) {
+	withClientCaps(t, &HostCapabilities{KittyGraphics: true, KittyFileTransfer: true, TerminalName: "kitty"})
+
+	remote := NewKittyPassthroughWithOptions(KittyPassthroughOptions{
+		Output:       &bytes.Buffer{},
+		RemoteClient: true,
+	})
+	if remote.hostReadsFiles() {
+		t.Error("expected a remote client to re-encode file transmissions as direct data")
+	}
+
+	// A local passthrough with the same host caps should still honor file
+	// transfer, proving the difference is the RemoteClient flag, not the caps.
+	local := NewKittyPassthroughWithOptions(KittyPassthroughOptions{
+		Output: &bytes.Buffer{},
+	})
+	if !local.hostReadsFiles() {
+		t.Error("expected a local file-transfer-capable host to read files")
+	}
+}
+
+// TestSixelPassthrough_EnabledForSixelClient checks the sixel side of the same
+// routing: a sixel-capable client enables the passthrough against the routed
+// writer.
+func TestSixelPassthrough_EnabledForSixelClient(t *testing.T) {
+	withClientCaps(t, &HostCapabilities{SixelGraphics: true, TerminalName: "foot"})
+
+	var out bytes.Buffer
+	sp := NewSixelPassthroughWithOptions(SixelPassthroughOptions{Output: &out})
+	if !sp.IsEnabled() {
+		t.Fatal("expected sixel passthrough enabled for a sixel client")
+	}
+}

--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -126,23 +126,38 @@ func teaHandler(sshSession ssh.Session) (tea.Model, []tea.ProgramOption) {
 		cfg = &SSHServerConfig{Ephemeral: true}
 	}
 
+	// Detect the CLIENT terminal's graphics capabilities. The terminal that
+	// must render forwarded images is the one the user connected from, reached
+	// over this session, not the (often headless) server. Install them as the
+	// process host capabilities so the image cell math and cell-size lookups
+	// that read GetHostCapabilities report the client, not the server.
+	clientCaps := detectClientGraphics(sshSession)
+	app.SetClientCapabilities(clientToHostCapabilities(clientCaps))
+
 	// Determine session name from SSH context
 	sessionName := determineSessionName(sshSession, cfg)
 
+	var model tea.Model
+	var opts []tea.ProgramOption
+
 	// If ephemeral mode or daemon not available, use old behavior
 	if cfg.Ephemeral {
-		return createEphemeralTUIOSInstance(sshSession, pty.Window.Width, pty.Window.Height)
+		model, opts = createEphemeralTUIOSInstance(sshSession, pty.Window.Width, pty.Window.Height)
+	} else {
+		// Try to connect to daemon
+		var err error
+		model, opts, err = createDaemonTUIOSInstance(sshSession, sessionName, pty.Window.Width, pty.Window.Height, cfg, clientCaps)
+		if err != nil {
+			log.Printf("Warning: Failed to connect to daemon, using ephemeral mode: %v", err)
+			model, opts = createEphemeralTUIOSInstance(sshSession, pty.Window.Width, pty.Window.Height)
+		}
 	}
 
-	// Try to connect to daemon
-	model, opts, err := createDaemonTUIOSInstance(sshSession, sessionName, pty.Window.Width, pty.Window.Height, cfg)
-	if err != nil {
-		log.Printf("Warning: Failed to connect to daemon, using ephemeral mode: %v", err)
-		return createEphemeralTUIOSInstance(sshSession, pty.Window.Width, pty.Window.Height)
-	}
-
-	// Close the daemon client when the SSH session ends, otherwise the client
-	// read loop, its socket, and the daemon-side connState leak per connection.
+	// Tear down when the SSH session ends. In daemon mode this closes the daemon
+	// client, otherwise its read loop, socket, and the daemon-side connState leak
+	// per connection. In ephemeral mode it closes the local windows, otherwise
+	// each disconnect leaks a shell process and its PTY inside this long-lived
+	// server. Cleanup is idempotent.
 	if o, ok := model.(*app.OS); ok {
 		go func() {
 			<-sshSession.Context().Done()
@@ -196,6 +211,15 @@ func createEphemeralTUIOSInstance(sshSession ssh.Session, width, height int) (te
 		Height:          height,
 		IsSSHMode:       true,
 		SSHSession:      sshSession,
+		// Route kitty/sixel APC sequences to the SSH session so they reach the
+		// client's terminal. The passthrough enables itself only when the
+		// client's detected capabilities (installed via SetClientCapabilities)
+		// say the terminal can render them, so this is a no-op for a plain
+		// client. RemoteClient forces file-medium transmissions to be
+		// re-encoded as direct data, since the client cannot read server paths.
+		EnableGraphicsPassthrough: true,
+		GraphicsOutput:            sshSession,
+		GraphicsRemoteClient:      true,
 	})
 
 	return tuiosInstance, []tea.ProgramOption{
@@ -204,7 +228,7 @@ func createEphemeralTUIOSInstance(sshSession ssh.Session, width, height int) (te
 }
 
 // createDaemonTUIOSInstance creates a TUIOS instance connected to the daemon
-func createDaemonTUIOSInstance(sshSession ssh.Session, sessionName string, width, height int, cfg *SSHServerConfig) (tea.Model, []tea.ProgramOption, error) {
+func createDaemonTUIOSInstance(sshSession ssh.Session, sessionName string, width, height int, cfg *SSHServerConfig, clientCaps *session.ClientCapabilities) (tea.Model, []tea.ProgramOption, error) {
 	// Connect to daemon
 	client := session.NewTUIClient()
 	version := cfg.Version
@@ -212,20 +236,10 @@ func createDaemonTUIOSInstance(sshSession ssh.Session, sessionName string, width
 		version = "ssh-client"
 	}
 
-	// Try to detect host capabilities for SSH sessions
-	// Note: SSH doesn't forward terminal pixel queries, so this may return defaults
-	// For better graphics support, use a local session instead of SSH
-	hostCaps := app.GetHostCapabilities()
-	clientCaps := &session.ClientCapabilities{
-		PixelWidth:    hostCaps.PixelWidth,
-		PixelHeight:   hostCaps.PixelHeight,
-		CellWidth:     hostCaps.CellWidth,
-		CellHeight:    hostCaps.CellHeight,
-		KittyGraphics: hostCaps.KittyGraphics,
-		SixelGraphics: hostCaps.SixelGraphics,
-		TerminalName:  hostCaps.TerminalName,
-	}
-
+	// Forward the CLIENT's capabilities to the daemon. The daemon uses the cell
+	// pixel size to set each PTY's winsize pixel fields, which drive SGR-pixel
+	// mouse reporting (DEC 1016) and kitty geometry. These must describe the
+	// terminal the user connected from, not the server.
 	if err := client.ConnectWithCapabilities(version, width, height, clientCaps); err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to daemon: %w", err)
 	}
@@ -280,6 +294,11 @@ func createDaemonTUIOSInstance(sshSession ssh.Session, sessionName string, width
 		DaemonClient:              client,
 		SessionName:               sessionName,
 		EnableGraphicsPassthrough: true,
+		// Route graphics to the SSH session so kitty/sixel APCs reach the
+		// client's terminal, and re-encode file-medium transmissions as direct
+		// data since the client cannot read server-local paths.
+		GraphicsOutput:       sshSession,
+		GraphicsRemoteClient: true,
 	})
 
 	// Restore state from daemon if available

--- a/internal/server/ssh_caps.go
+++ b/internal/server/ssh_caps.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/session"
+	"github.com/charmbracelet/ssh"
+)
+
+// Terminals known to render the kitty graphics protocol. The client's terminal,
+// not the server's, is what must display forwarded images, so this is keyed off
+// the identity the client reports over the SSH connection.
+var kittyCapableTerminals = map[string]bool{
+	"kitty":   true,
+	"ghostty": true,
+	"wezterm": true,
+}
+
+// Terminals known to render sixel graphics. Kept separate from the kitty set
+// because most kitty-capable terminals do not do sixel and forwarding a sixel
+// stream to a terminal that cannot decode it corrupts the screen.
+var sixelCapableTerminals = map[string]bool{
+	"wezterm": true,
+	"foot":    true,
+	"contour": true,
+	"mlterm":  true,
+	"mintty":  true,
+	"xterm":   true,
+}
+
+// detectClientGraphics inspects what a connected SSH client reports about its
+// terminal and returns the graphics capabilities TUIOS should use for that
+// session. Everything here is passive: it reads the TERM from the pty-req, any
+// environment the client forwarded, and the pixel dimensions the client sent
+// with the pty-req. It never writes a query to the session or reads its input,
+// because the bubbletea program owns the session's input stream and a second
+// reader on the same SSH channel would steal bytes from it.
+func detectClientGraphics(sshSession ssh.Session) *session.ClientCapabilities {
+	pty, _, _ := sshSession.Pty()
+	return buildClientCapabilities(pty.Term, sshSession.Environ(), pty.Window)
+}
+
+// buildClientCapabilities is the pure decision function behind
+// detectClientGraphics, split out so it can be tested without an SSH handshake.
+func buildClientCapabilities(term string, environ []string, win ssh.Window) *session.ClientCapabilities {
+	env := parseEnviron(environ)
+	name := terminalName(term, env)
+
+	caps := &session.ClientCapabilities{TerminalName: name}
+
+	caps.KittyGraphics = kittyCapableTerminals[name]
+	caps.SixelGraphics = sixelCapableTerminals[name]
+
+	// Explicit client overrides win over identity-based guesses.
+	switch env["TUIOS_KITTY_GRAPHICS"] {
+	case "1":
+		caps.KittyGraphics = true
+	case "0":
+		caps.KittyGraphics = false
+	}
+	switch env["TUIOS_SIXEL_GRAPHICS"] {
+	case "1":
+		caps.SixelGraphics = true
+	case "0":
+		caps.SixelGraphics = false
+	}
+
+	// Cell pixel size comes from the pty-req pixel dimensions the client sent.
+	// The pixel-mouse (SGR-pixel, DEC 1016) and kitty geometry paths need it,
+	// and over SSH the only honest source is the client, not the server.
+	cw, ch := cellSizeFromWindow(win)
+	caps.CellWidth = cw
+	caps.CellHeight = ch
+	if win.WidthPixels > 0 {
+		caps.PixelWidth = win.WidthPixels
+	}
+	if win.HeightPixels > 0 {
+		caps.PixelHeight = win.HeightPixels
+	}
+
+	return caps
+}
+
+// cellSizeFromWindow derives a cell's pixel size from the pty-req window, which
+// carries both the character grid and its drawable pixel area. Returns 0,0 when
+// the client sent no pixel dimensions (most SSH clients do), leaving the daemon
+// to fall back to cell-based reporting rather than inventing a size.
+func cellSizeFromWindow(win ssh.Window) (cw, ch int) {
+	if win.Width > 0 && win.WidthPixels > 0 {
+		cw = win.WidthPixels / win.Width
+	}
+	if win.Height > 0 && win.HeightPixels > 0 {
+		ch = win.HeightPixels / win.Height
+	}
+	return cw, ch
+}
+
+// parseEnviron turns a "KEY=VALUE" slice into a map for lookups.
+func parseEnviron(environ []string) map[string]string {
+	m := make(map[string]string, len(environ))
+	for _, kv := range environ {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			m[kv[:i]] = kv[i+1:]
+		}
+	}
+	return m
+}
+
+// terminalName resolves a canonical terminal identity from the client's TERM
+// and any forwarded environment. TERM is always present over SSH (it rides in
+// the pty-req); TERM_PROGRAM and friends are only present when the client is
+// configured to forward them, so they refine the guess rather than drive it.
+func terminalName(term string, env map[string]string) string {
+	termProgram := strings.ToLower(env["TERM_PROGRAM"])
+	switch {
+	case strings.Contains(termProgram, "ghostty"):
+		return "ghostty"
+	case strings.Contains(termProgram, "kitty"):
+		return "kitty"
+	case strings.Contains(termProgram, "wezterm"):
+		return "wezterm"
+	case strings.Contains(termProgram, "iterm"):
+		return "iterm2"
+	case strings.Contains(termProgram, "contour"):
+		return "contour"
+	case strings.Contains(termProgram, "foot"):
+		return "foot"
+	}
+
+	if env["KITTY_WINDOW_ID"] != "" {
+		return "kitty"
+	}
+	if env["GHOSTTY_RESOURCES_DIR"] != "" {
+		return "ghostty"
+	}
+	if env["WEZTERM_PANE"] != "" {
+		return "wezterm"
+	}
+
+	t := strings.ToLower(term)
+	switch {
+	case strings.Contains(t, "ghostty"):
+		return "ghostty"
+	case strings.Contains(t, "kitty"):
+		return "kitty"
+	case strings.Contains(t, "wezterm"):
+		return "wezterm"
+	case strings.Contains(t, "foot"):
+		return "foot"
+	case strings.Contains(t, "contour"):
+		return "contour"
+	case strings.Contains(t, "mlterm"):
+		return "mlterm"
+	case strings.Contains(t, "xterm"):
+		return "xterm"
+	}
+	return ""
+}
+
+// clientToHostCapabilities projects the client's reported capabilities onto the
+// app-level HostCapabilities that GetHostCapabilities serves. KittyFileTransfer
+// is always false: a file-medium transmission names a path on the server, which
+// the remote client cannot read, so the passthrough must re-encode as direct.
+func clientToHostCapabilities(c *session.ClientCapabilities) *app.HostCapabilities {
+	if c == nil {
+		return nil
+	}
+	return &app.HostCapabilities{
+		KittyGraphics:     c.KittyGraphics,
+		KittyFileTransfer: false,
+		SixelGraphics:     c.SixelGraphics,
+		TrueColor:         true,
+		TerminalName:      c.TerminalName,
+		PixelWidth:        c.PixelWidth,
+		PixelHeight:       c.PixelHeight,
+		CellWidth:         c.CellWidth,
+		CellHeight:        c.CellHeight,
+	}
+}

--- a/internal/server/ssh_caps_test.go
+++ b/internal/server/ssh_caps_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/ssh"
+)
+
+func TestBuildClientCapabilities_KittyFromTerm(t *testing.T) {
+	// A kitty client forwards TERM=xterm-kitty in the pty-req even when no other
+	// environment is forwarded. That alone must enable kitty graphics.
+	caps := buildClientCapabilities("xterm-kitty", nil, ssh.Window{Width: 80, Height: 24})
+	if !caps.KittyGraphics {
+		t.Fatalf("expected kitty graphics enabled for TERM=xterm-kitty, got caps=%+v", caps)
+	}
+	if caps.TerminalName != "kitty" {
+		t.Errorf("expected terminal name kitty, got %q", caps.TerminalName)
+	}
+}
+
+func TestBuildClientCapabilities_GhosttyFromTerm(t *testing.T) {
+	caps := buildClientCapabilities("xterm-ghostty", nil, ssh.Window{Width: 80, Height: 24})
+	if !caps.KittyGraphics {
+		t.Fatalf("expected kitty graphics enabled for ghostty, got caps=%+v", caps)
+	}
+}
+
+func TestBuildClientCapabilities_WeztermFromTermProgram(t *testing.T) {
+	// WezTerm often reports TERM=xterm-256color, so it can only be told apart by
+	// a forwarded TERM_PROGRAM. It supports both kitty and sixel.
+	env := []string{"TERM_PROGRAM=WezTerm"}
+	caps := buildClientCapabilities("xterm-256color", env, ssh.Window{Width: 80, Height: 24})
+	if !caps.KittyGraphics {
+		t.Fatalf("expected kitty graphics enabled for WezTerm, got caps=%+v", caps)
+	}
+	if !caps.SixelGraphics {
+		t.Errorf("expected sixel graphics enabled for WezTerm, got caps=%+v", caps)
+	}
+}
+
+func TestBuildClientCapabilities_PlainXtermNoGraphics(t *testing.T) {
+	// A plain xterm-256color client with nothing forwarded must NOT get kitty
+	// graphics: forwarding APCs to a terminal that cannot render them corrupts
+	// the screen. This is the case the old server-capabilities code got right
+	// only by accident (headless server) and wrong when the server itself ran
+	// in a graphics terminal.
+	caps := buildClientCapabilities("xterm-256color", nil, ssh.Window{Width: 80, Height: 24})
+	if caps.KittyGraphics {
+		t.Fatalf("expected kitty graphics disabled for plain xterm, got caps=%+v", caps)
+	}
+}
+
+func TestBuildClientCapabilities_EnvOverride(t *testing.T) {
+	// An explicit client override wins over identity-based detection, both ways.
+	on := buildClientCapabilities("xterm-256color", []string{"TUIOS_KITTY_GRAPHICS=1"}, ssh.Window{})
+	if !on.KittyGraphics {
+		t.Errorf("expected override to enable kitty, got %+v", on)
+	}
+	off := buildClientCapabilities("xterm-kitty", []string{"TUIOS_KITTY_GRAPHICS=0"}, ssh.Window{})
+	if off.KittyGraphics {
+		t.Errorf("expected override to disable kitty, got %+v", off)
+	}
+}
+
+func TestBuildClientCapabilities_CellSizeFromPixels(t *testing.T) {
+	// When the client sends pixel dimensions in the pty-req, the cell pixel size
+	// must be derived from them. The pixel-mouse (DEC 1016) path depends on this
+	// coming from the client, not the server.
+	win := ssh.Window{Width: 80, Height: 24, WidthPixels: 800, HeightPixels: 480}
+	caps := buildClientCapabilities("xterm-kitty", nil, win)
+	if caps.CellWidth != 10 {
+		t.Errorf("expected cell width 10 (800/80), got %d", caps.CellWidth)
+	}
+	if caps.CellHeight != 20 {
+		t.Errorf("expected cell height 20 (480/24), got %d", caps.CellHeight)
+	}
+	if caps.PixelWidth != 800 || caps.PixelHeight != 480 {
+		t.Errorf("expected pixel dims 800x480, got %dx%d", caps.PixelWidth, caps.PixelHeight)
+	}
+}
+
+func TestBuildClientCapabilities_NoPixelsNoCellSize(t *testing.T) {
+	// Most SSH clients send no pixel dimensions. We must not invent a cell size;
+	// leaving it zero lets the daemon fall back to cell-based mouse reporting.
+	caps := buildClientCapabilities("xterm-kitty", nil, ssh.Window{Width: 80, Height: 24})
+	if caps.CellWidth != 0 || caps.CellHeight != 0 {
+		t.Errorf("expected zero cell size without pixel dims, got %dx%d", caps.CellWidth, caps.CellHeight)
+	}
+}
+
+func TestClientToHostCapabilities_NeverForwardsFiles(t *testing.T) {
+	// The client is remote, so it cannot read a server-local file path. The host
+	// capabilities projected for the passthrough must always report
+	// KittyFileTransfer=false so file-medium transmissions are re-encoded as
+	// direct data.
+	in := buildClientCapabilities("xterm-kitty", nil, ssh.Window{Width: 80, Height: 24, WidthPixels: 800, HeightPixels: 480})
+	host := clientToHostCapabilities(in)
+	if host == nil {
+		t.Fatal("expected non-nil host capabilities")
+	}
+	if host.KittyFileTransfer {
+		t.Error("expected KittyFileTransfer=false for a remote SSH client")
+	}
+	if !host.KittyGraphics {
+		t.Error("expected KittyGraphics carried through")
+	}
+	if host.CellWidth != 10 || host.CellHeight != 20 {
+		t.Errorf("expected cell size carried through, got %dx%d", host.CellWidth, host.CellHeight)
+	}
+}
+
+func TestClientToHostCapabilities_Nil(t *testing.T) {
+	if clientToHostCapabilities(nil) != nil {
+		t.Error("expected nil in, nil out")
+	}
+}

--- a/internal/server/ssh_smoke_test.go
+++ b/internal/server/ssh_smoke_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// freePort asks the OS for an unused localhost TCP port and returns it. There is
+// a small window between closing the listener and the server rebinding, which is
+// acceptable for a test.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	return port
+}
+
+// TestSSHServer_AcceptsPTYSessionAndRenders starts the SSH server on localhost
+// with a throwaway generated host key, connects with a real SSH client
+// requesting a PTY, and asserts the TUIOS instance comes up and paints
+// something. This exercises teaHandler end to end: capability detection,
+// ephemeral instance creation, and the bubbletea program running over SSH.
+func TestSSHServer_AcceptsPTYSessionAndRenders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH integration test in short mode")
+	}
+
+	port := freePort(t)
+	hostKey := filepath.Join(t.TempDir(), "test_host_key")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- StartSSHServer(ctx, &SSHServerConfig{
+			Host:      "127.0.0.1",
+			Port:      port,
+			KeyPath:   hostKey,
+			Ephemeral: true, // no daemon: keep the test self-contained
+			Version:   "test",
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-serveErr:
+		case <-time.After(5 * time.Second):
+			t.Log("server did not shut down within timeout")
+		}
+	})
+
+	// Dial until the listener is up (host key generation + bind take a moment).
+	clientCfg := &gossh.ClientConfig{
+		User:            "tester",
+		Auth:            nil, // the server runs with NoClientAuth
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	addr := net.JoinHostPort("127.0.0.1", port)
+
+	var client *gossh.Client
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c, err := gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			client = c
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("could not connect to SSH server: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	defer func() { _ = client.Close() }()
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	// A kitty client, so capability detection has something to enable.
+	if err := sess.Setenv("TERM_PROGRAM", "ghostty"); err != nil {
+		// Setenv may be rejected if the server does not accept env; not fatal.
+		t.Logf("setenv rejected (ok): %v", err)
+	}
+
+	modes := gossh.TerminalModes{gossh.ECHO: 0}
+	if err := sess.RequestPty("xterm-kitty", 24, 80, modes); err != nil {
+		t.Fatalf("request pty: %v", err)
+	}
+
+	stdout, err := sess.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("start shell: %v", err)
+	}
+
+	// The TUI should paint an initial frame promptly. Read whatever arrives
+	// within a generous window and assert it is non-empty.
+	got := make(chan int, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		total := 0
+		for total == 0 {
+			n, rerr := stdout.Read(buf)
+			total += n
+			if rerr != nil {
+				break
+			}
+		}
+		got <- total
+	}()
+
+	select {
+	case n := <-got:
+		if n == 0 {
+			t.Fatal("TUIOS produced no output over SSH")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for TUIOS output over SSH")
+	}
+}


### PR DESCRIPTION
`tuios ssh` did not do kitty graphics passthrough, and a QC pass of the ssh path found a real resource leak plus several things worth knowing.

## Root cause of no-graphics-over-ssh (confirmed)

`createDaemonTUIOSInstance` called `app.GetHostCapabilities()`, which probes the SERVER's local /dev/tty, and forwarded that as the client's capabilities; the passthrough writer wrote to the server's /dev/tty. Over ssh the terminal that must render is the CLIENT's (the kitty you connect from), reached over the ssh channel. On a headless server the kitty probe is false, so passthrough was disabled; even when enabled, APCs went to the server and never reached the client. Ephemeral ssh sessions got no passthrough at all.

## What changed

- Detect the CLIENT, not the server (new internal/server/ssh_caps.go): passive detection from what the client reports over the connection: TERM in the pty-req, forwarded env (TERM_PROGRAM, and TUIOS_KITTY_GRAPHICS / TUIOS_SIXEL_GRAPHICS overrides), and the pty-req pixel dimensions for cell size. Deliberately NOT an active kitty query: the reply lands on the ssh channel bubbletea owns, and a second reader on a channel with no read deadline would steal bubbletea's input. Kitty is enabled for kitty/ghostty/wezterm or an explicit override.
- Route graphics to the client: the passthrough output type went from *os.File to io.Writer, and both the ephemeral and daemon paths pass the ssh.Session as the output, so APCs flow through the same pipe as the text and reach the client.
- Carry the client's cell pixel size to the daemon, which drives the SGR-pixel mouse (1016) work that just merged and kitty geometry. Previously this was the server's, now the client's.
- Remote-client file handling: a remote client cannot read a server-local path, so file-medium transmissions (t=f/t=t/t=s) are re-encoded as direct data while keeping native placement, clipping, and delete. KittyFileTransfer is forced off for ssh clients.

## QC findings

- Resize: working (wish forwards window-change to tea.WindowSizeMsg; daemon negotiates multi-client min size).
- Input: working, and pixel-mouse now gets the correct client cell size.
- Ephemeral disconnect: was BROKEN, fixed. Only the daemon path wired teardown, and Cleanup only closed the daemon client, so an ephemeral ssh session leaked a shell process, its PTY, and window goroutines on every disconnect (the instance is a goroutine in a long-lived server, so process exit never reaps it). Cleanup now closes local windows and the disconnect path is wired for both.
- Daemon reconnect and the daemon-to-ephemeral fallback: working, and the fallback now has graphics and cleanup too.
- Host key auto-generates (ed25519). Minor: it writes ~/.ssh/tuios_host_key, so an account without ~/.ssh could fail to write.

## Flagged, not fixed

- No authentication: StartSSHServer sets no auth handlers, so charmbracelet/ssh defaults to NoClientAuth, meaning anyone who reaches the port gets a session. Fine for a deliberate LAN share, but it should be a conscious choice; recommend optional authorized_keys.
- Multi-client capability race: client caps are installed process-wide, so simultaneous clients with different terminals share the last value for the live cell-math consumers (the per-connection graphics-enable is snapshotted and unaffected). Documented in code.
- Graphics write cost: the emulated pty does two bytes.Replace copies for newline translation, harmless for graphics but doubles copies of large frames.

## Tests (there was none for ssh)

- internal/server/ssh_caps_test.go: the capability decision table (kitty via TERM, ghostty and wezterm via TERM_PROGRAM, plain xterm none, env overrides both ways, cell size from pixel dims, remote clients never claim file transfer).
- internal/app/ssh_graphics_routing_test.go: passthrough enables and writes to the routed writer for a kitty client, stays disabled for a plain client, remote clients re-encode files while a local host still reads them.
- internal/server/ssh_smoke_test.go: starts the server on localhost with a throwaway host key, connects with a real x/crypto/ssh client requesting a pty, asserts the tui comes up and paints.

go build, go vet, gofmt, go test ./..., and the nested e2e module all green. go mod tidy reclassified golang.org/x/crypto from indirect to direct (the smoke test uses it), the only go.mod change.