### PR TITLE
Forward the kitty keyboard associated-text field, so typing works in graphics apps

### DIFF
--- a/internal/input/keyboard_terminal_kitty_test.go
+++ b/internal/input/keyboard_terminal_kitty_test.go
@@ -1,0 +1,106 @@
+package input
+
+import (
+	"os/exec"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// capturePty is a fake xpty.Pty that records what SendInput writes on the
+// native (non-daemon) path, where SendInput writes straight to the PTY.
+type capturePty struct{ got []byte }
+
+func (p *capturePty) Write(b []byte) (int, error) { p.got = append(p.got, b...); return len(b), nil }
+func (p *capturePty) Read([]byte) (int, error)    { return 0, nil }
+func (p *capturePty) Close() error                { return nil }
+func (p *capturePty) Fd() uintptr                 { return 0 }
+func (p *capturePty) Resize(_, _ int) error       { return nil }
+func (p *capturePty) Size() (int, int, error)     { return 80, 24, nil }
+func (p *capturePty) Name() string                { return "capture-pty" }
+func (p *capturePty) Start(_ *exec.Cmd) error     { return nil }
+
+// forwardNative runs a keypress through the real terminal-mode input handler
+// against a focused, local-PTY window whose emulator has been fed flagsSeq, and
+// returns the bytes that reached the PTY.
+func forwardNative(t *testing.T, flagsSeq string, msg tea.KeyPressMsg) string {
+	t.Helper()
+	em := vt.NewEmulator(80, 24)
+	t.Cleanup(func() { _ = em.Close() })
+	if flagsSeq != "" {
+		_, _ = em.Write([]byte(flagsSeq))
+	}
+	pty := &capturePty{}
+	win := &terminal.Window{ID: "kitty-native-0001", Terminal: em, Pty: pty, X: 0, Y: 0, Width: 82, Height: 26}
+	o := &app.OS{Mode: app.TerminalMode, FocusedWindow: 0, Windows: []*terminal.Window{win}}
+	HandleTerminalModeKey(msg, o)
+	return string(pty.got)
+}
+
+// forwardDaemon is forwardNative for the daemon path, where SendInput hands the
+// bytes to DaemonWriteFunc instead of a PTY. The encoding decision is shared, so
+// both transports must observe identical bytes.
+func forwardDaemon(t *testing.T, flagsSeq string, msg tea.KeyPressMsg) string {
+	t.Helper()
+	em := vt.NewEmulator(80, 24)
+	t.Cleanup(func() { _ = em.Close() })
+	if flagsSeq != "" {
+		_, _ = em.Write([]byte(flagsSeq))
+	}
+	var got []byte
+	win := &terminal.Window{
+		ID: "kitty-daemon-0001", Terminal: em, DaemonMode: true,
+		DaemonWriteFunc: func(b []byte) error { got = append(got, b...); return nil },
+		X:               0, Y: 0, Width: 82, Height: 26,
+	}
+	o := &app.OS{Mode: app.TerminalMode, FocusedWindow: 0, Windows: []*terminal.Window{win}}
+	HandleTerminalModeKey(msg, o)
+	return string(got)
+}
+
+// pushAll is the flag set awrit pushes at startup (CSI >31u): every kitty
+// keyboard enhancement, including report-associated-keys. terminal-browser
+// pushes the same minus alternate-keys (CSI >27u) once a text field is focused.
+const pushAll = "\x1b[>31u"
+
+// TestForwardKittyKeyboardPane pins the bytes a keypress produces for a pane
+// that has enabled the kitty keyboard protocol, versus a plain pane that has
+// not. The kitty column is exactly what terminal-browser and awrit parse back
+// into the typed key; the legacy column is the untouched control-byte encoding
+// a normal shell expects. It asserts the native and daemon transports agree.
+func TestForwardKittyKeyboardPane(t *testing.T) {
+	tests := []struct {
+		name   string
+		msg    tea.KeyPressMsg
+		kitty  string // expected bytes to a pane with CSI >31u active
+		legacy string // expected bytes to a pane with no kitty keyboard flags
+	}{
+		{"plain letter", tea.KeyPressMsg{Code: 'a', Text: "a"}, "\x1b[97;1;97u", "a"},
+		{"capital letter", tea.KeyPressMsg{Code: 'x', ShiftedCode: 'X', Text: "X", Mod: tea.ModShift}, "\x1b[120;2;88u", "X"},
+		{"enter", tea.KeyPressMsg{Code: tea.KeyEnter}, "\x1b[13u", "\r"},
+		{"backspace", tea.KeyPressMsg{Code: tea.KeyBackspace}, "\x1b[127u", "\x7f"},
+		{"up arrow", tea.KeyPressMsg{Code: tea.KeyUp}, "\x1b[A", "\x1b[A"},
+		{"ctrl+a", tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl}, "\x1b[97;5u", "\x01"},
+		{"bare escape", tea.KeyPressMsg{Code: tea.KeyEscape}, "\x1b[27u", "\x1b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := forwardNative(t, pushAll, tt.msg); got != tt.kitty {
+				t.Errorf("native kitty pane: got %q, want %q", got, tt.kitty)
+			}
+			if got := forwardDaemon(t, pushAll, tt.msg); got != tt.kitty {
+				t.Errorf("daemon kitty pane: got %q, want %q", got, tt.kitty)
+			}
+			if got := forwardNative(t, "", tt.msg); got != tt.legacy {
+				t.Errorf("native legacy pane: got %q, want %q", got, tt.legacy)
+			}
+			if got := forwardDaemon(t, "", tt.msg); got != tt.legacy {
+				t.Errorf("daemon legacy pane: got %q, want %q", got, tt.legacy)
+			}
+		})
+	}
+}

--- a/internal/vt/kitty_keyboard.go
+++ b/internal/vt/kitty_keyboard.go
@@ -3,6 +3,9 @@ package vt
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -247,12 +250,49 @@ func EncodeKeyCSIu(key KeyPressEvent, flags int) string {
 		return encodeTildeKeyCSIu(24, key.Mod, flags)
 	}
 
-	// For regular keys, encode as CSI code ; modifiers u
+	// For regular keys, encode as CSI code ; modifiers u.
+	//
+	// When the pane requested the associated-text flag, a key that produces
+	// text must carry that text as the third CSI-u field so the app inserts the
+	// character the user actually typed. Without it, an app that honours the
+	// flag it asked for (terminal-browser escalates to CSI >27u on text focus,
+	// awrit pushes CSI >31u) has only the base key code to work with: it inserts
+	// the unshifted character, so Shift+A types "a", ":" types ";", and any
+	// non-ASCII text is dropped. The field is a colon-separated list of the
+	// produced text's Unicode code points; see the kitty keyboard protocol.
 	modParam := kittyModParam(key.Mod)
+	if flags&ansi.KittyReportAssociatedKeys != 0 {
+		if text := kittyAssociatedText(key.Text); text != "" {
+			return fmt.Sprintf("\x1b[%d;%d;%su", code, modParam, text)
+		}
+	}
 	if modParam > 1 {
 		return fmt.Sprintf("\x1b[%d;%du", code, modParam)
 	}
 	return fmt.Sprintf("\x1b[%du", code)
+}
+
+// kittyAssociatedText renders a key's produced text as the colon-separated
+// decimal code-point list the kitty keyboard protocol uses for its associated
+// text field. It returns "" when there is no text to report: an empty string,
+// or text that is a lone control character (Enter, Tab, Backspace and Escape
+// carry their semantics in the key code, not as insertable text, and a kitty
+// app expects no text field for them).
+func kittyAssociatedText(text string) string {
+	if text == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range text {
+		if unicode.IsControl(r) {
+			return ""
+		}
+		if b.Len() > 0 {
+			b.WriteByte(':')
+		}
+		b.WriteString(strconv.Itoa(int(r)))
+	}
+	return b.String()
 }
 
 // encodeSpecialKeyCSIu encodes a special key (arrow, home, end, F1-F4) in CSI u format.

--- a/internal/vt/kitty_keyboard_test.go
+++ b/internal/vt/kitty_keyboard_test.go
@@ -268,6 +268,118 @@ func TestEncodeKeyCSIu(t *testing.T) {
 	}
 }
 
+// TestEncodeKeyCSIuAssociatedText pins the associated-text field the kitty
+// keyboard protocol requires once a pane sets the report-associated-keys flag.
+// Without the third CSI-u field, an app that asked for it (terminal-browser
+// escalates to CSI >27u on text focus, awrit pushes CSI >31u) inserts the base
+// key code, so Shift+A types "a" and shifted symbols come out wrong. These are
+// the exact bytes those parsers turn back into the typed character.
+func TestEncodeKeyCSIuAssociatedText(t *testing.T) {
+	const all = ansi.KittyAllFlags                    // 31: disambiguate|events|alternate|all-keys|assoc
+	const focus = ansi.KittyDisambiguateEscapeCodes | // 27: what terminal-browser pushes on text focus
+		ansi.KittyReportEventTypes |
+		ansi.KittyReportAllKeysAsEscapeCodes |
+		ansi.KittyReportAssociatedKeys
+
+	tests := []struct {
+		name     string
+		key      KeyPressEvent
+		flags    int
+		expected string
+	}{
+		{
+			name:     "plain letter carries its text (flags 31)",
+			key:      KeyPressEvent{Code: 'a', Text: "a"},
+			flags:    all,
+			expected: "\x1b[97;1;97u",
+		},
+		{
+			name:     "plain letter carries its text (flags 27)",
+			key:      KeyPressEvent{Code: 'a', Text: "a"},
+			flags:    focus,
+			expected: "\x1b[97;1;97u",
+		},
+		{
+			name:     "shifted letter reports the shifted text, base code",
+			key:      KeyPressEvent{Code: 'x', ShiftedCode: 'X', Text: "X", Mod: ModShift},
+			flags:    all,
+			expected: "\x1b[120;2;88u",
+		},
+		{
+			name:     "shifted symbol reports the shifted text",
+			key:      KeyPressEvent{Code: ';', ShiftedCode: ':', Text: ":", Mod: ModShift},
+			flags:    all,
+			expected: "\x1b[59;2;58u",
+		},
+		{
+			name:     "space reports its text",
+			key:      KeyPressEvent{Code: KeySpace, Text: " "},
+			flags:    all,
+			expected: "\x1b[32;1;32u",
+		},
+		{
+			name:     "non-ascii text is reported by code point",
+			key:      KeyPressEvent{Code: 'e', Text: "é"},
+			flags:    all,
+			expected: "\x1b[101;1;233u",
+		},
+		{
+			name:     "enter has no associated text",
+			key:      KeyPressEvent{Code: KeyEnter},
+			flags:    all,
+			expected: "\x1b[13u",
+		},
+		{
+			name:     "backspace has no associated text",
+			key:      KeyPressEvent{Code: KeyBackspace},
+			flags:    all,
+			expected: "\x1b[127u",
+		},
+		{
+			name:     "escape has no associated text",
+			key:      KeyPressEvent{Code: KeyEscape},
+			flags:    all,
+			expected: "\x1b[27u",
+		},
+		{
+			name:     "ctrl+letter has no associated text",
+			key:      KeyPressEvent{Code: 'a', Mod: ModCtrl},
+			flags:    all,
+			expected: "\x1b[97;5u",
+		},
+		{
+			name:     "up arrow is unchanged under all flags",
+			key:      KeyPressEvent{Code: KeyUp},
+			flags:    all,
+			expected: "\x1b[A",
+		},
+		{
+			// A control character delivered as Text (never a real keypress, but
+			// worth pinning) must not become a text field.
+			name:     "control text is dropped",
+			key:      KeyPressEvent{Code: 'm', Text: "\r"},
+			flags:    all,
+			expected: "\x1b[109u",
+		},
+		{
+			// disambiguate-only: the pane never asked for associated text, so a
+			// plain letter still goes as legacy text (empty CSI-u result).
+			name:     "no associated text without the flag",
+			key:      KeyPressEvent{Code: 'a', Text: "a"},
+			flags:    ansi.KittyDisambiguateEscapeCodes,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EncodeKeyCSIu(tt.key, tt.flags); got != tt.expected {
+				t.Errorf("EncodeKeyCSIu(%+v, %d) = %q, want %q", tt.key, tt.flags, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestKittyModParam(t *testing.T) {
 	tests := []struct {
 		mod      KeyMod


### PR DESCRIPTION
Typing did not work inside a kitty-graphics browser (terminal-browser, awrit) in a tuios pane. Mouse works (PR #118); keys were dropped or wrong.

## Not the obvious bug

The suspected cause (tuios forwards raw bytes regardless of the pane's kitty keyboard flags) was refuted by capture. At flags=1 (disambiguate) tuios already encoded CSI-u correctly: Enter=`\x1b[13u`, Esc=`\x1b[27u`, Ctrl+A=`\x1b[97;5u`, arrows=`\x1b[A`.

## The real bug

terminal-browser and awrit push the FULL flag set (awrit `\x1b[>31u`, terminal-browser `\x1b[>1u` escalating to `\x1b[>27u` on a focused text field), and both sets include report-associated-text (flag 16). Their key handler inserts the associated-text field of a CSI-u report when present, otherwise the base code point.

At those flags tuios sent BARE reports with no text field: `a` to `\x1b[97u`, Shift+X to `\x1b[120;2u`, `:` to `\x1b[59;2u`. So the browser inserted the base code point: capitals came out lowercase, shifted symbols wrong, non-ASCII dropped. Typing was broken.

## Fix

internal/vt/kitty_keyboard.go: when the pane set report-associated-keys and the key produced non-control text, `EncodeKeyCSIu` appends the associated-text field as colon-separated code points: `\x1b[<code>;<mods>;<text>u`. Now `a` to `\x1b[97;1;97u`, Shift+X to `\x1b[120;2;88u`, `:` to `\x1b[59;2;58u`.

Keys whose meaning is the code carry no text field (Enter `\x1b[13u`, Backspace `\x1b[127u`, Esc `\x1b[27u`, arrows, Ctrl+letter). Panes without kitty flags keep legacy bytes untouched.

## Verification

- internal/vt/kitty_keyboard_test.go: associated-text at flags 27 and 31 (plain, shifted, symbol, space, non-ASCII, and the no-text keys).
- internal/input/keyboard_terminal_kitty_test.go: drives the real HandleTerminalModeKey and captures bytes on both the native and daemon transports, kitty vs legacy.
- Both fail on a clean origin/main (confirmed: main drops the text field) and pass here.

go build, go vet, gofmt, go test ./..., and the nested e2e module all green. The change is one file (kitty_keyboard.go); the native and daemon SendInput paths share the encode path, so no transport change was needed. This also fixes any kitty-keyboard TUI (neovim, etc.) typing in a tuios pane, not only the browser.