### PR TITLE
feat: add zen mode to hide unfocused window borders (#64)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -245,6 +245,23 @@ Controls the style of window borders.
 
 **CLI override:** `--border-style <style>`
 
+### zen_mode
+
+Controls when window borders are hidden, for distraction-free focus.
+
+**Valid values:**
+- `"disabled"` - Borders always visible (default)
+- `"always"` - Hide the borders of every unfocused window; the focused window keeps its frame so you always know where your keystrokes land
+- `"mouse"` - Borders are revealed while the mouse is moving and melt away ~2s after it stops; the focused window keeps its frame
+
+**Default:** `"disabled"`
+
+**Example:**
+```toml
+[appearance]
+zen_mode = "mouse"
+```
+
 ### dockbar_position
 
 Controls the position of the dockbar.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -256,6 +256,13 @@ Controls when window borders are hidden, for distraction-free focus.
 
 **Default:** `"disabled"`
 
+**Scope:** Tiled panes already render borderless when `shared_borders` is on
+(the separators between them are a compositor overlay, not per-pane chrome),
+so zen mode mainly affects floating panes and tiled panes without shared
+borders. In `mouse` mode the border melt and reveal are repaints, not layout
+changes: the frame cells stay reserved, so content never shifts when a border
+appears or disappears.
+
 **Example:**
 ```toml
 [appearance]

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -282,6 +282,11 @@ type OS struct {
 	// pointer leaves the surface the events come from.
 	viewportResizeAt time.Time
 	lastPointerAt    time.Time
+
+	// zenHidden records the zen-mode border visibility of the last composed
+	// frame, so the idle tick can detect the mouse-mode timeout crossing and
+	// force a repaint (borders must reappear or melt away exactly once).
+	zenHidden bool
 	// pointerDown tracks whether a mouse button is held, so a gesture cannot
 	// outlive the button that started it even when no further event arrives.
 	pointerDown bool

--- a/internal/app/os_render.go
+++ b/internal/app/os_render.go
@@ -16,6 +16,26 @@ func (m *OS) MarkAllDirty() {
 	m.sidebarCache.invalidate()
 }
 
+// markZenDirty marks the windows whose zen-mode border visibility is about to
+// change as dirty, so their CachedLayer is rebuilt with (or without) the
+// frame. The focused window always keeps its border, so only the unfocused
+// windows need the repaint. Marking them dirty is also what makes View()
+// compose a fresh frame instead of serving the cached one; without it the
+// melt/reveal would never be drawn even when the tick knows it crossed the
+// idle threshold.
+func (m *OS) markZenDirty() {
+	m.terminalMu.Lock()
+	defer m.terminalMu.Unlock()
+	for i := range m.Windows {
+		w := m.Windows[i]
+		if w == nil || i == m.FocusedWindow {
+			continue
+		}
+		w.MarkContentDirty()
+	}
+	m.cachedViewContent = "" // Invalidate view cache so View() re-composes
+}
+
 // MarkTerminalsWithNewContent marks terminals that have new content as dirty.
 func (m *OS) MarkTerminalsWithNewContent() bool {
 	// Fast path: no windows

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 	"os"
 	"runtime/debug"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -288,6 +289,36 @@ func fitToContentBox(content string, w, h int) string {
 	return lipgloss.NewStyle().MaxWidth(w).MaxHeight(h).Render(content)
 }
 
+// zenModeMouseIdleTimeout is how long the pointer may sit still before zen mode
+// (mouse) hides the borders again.
+const zenModeMouseIdleTimeout = 2 * time.Second
+
+// zenBordersHidden reports whether zen mode wants the border of a window with
+// the given focus state hidden. The focused window always keeps its frame so
+// the user retains an anchor; zen mode melts the unfocused frames away.
+func (m *OS) zenBordersHidden(isFocused bool) bool {
+	switch config.ZenMode {
+	case config.ZenModeAlways:
+		return !isFocused
+	case config.ZenModeMouse:
+		// A moving pointer reveals every border so the user can see what they
+		// can grab; once the pointer sits still, only the focused window keeps
+		// its frame.
+		if m.pointerRecentlyMoved() {
+			return false
+		}
+		return !isFocused
+	default:
+		return false
+	}
+}
+
+// pointerRecentlyMoved reports whether a mouse event arrived within the zen
+// mode reveal window.
+func (m *OS) pointerRecentlyMoved() bool {
+	return !m.lastPointerAt.IsZero() && time.Since(m.lastPointerAt) <= zenModeMouseIdleTimeout
+}
+
 // rendersBorderless reports whether window is drawn with no border box of its
 // own, so its rectangle is guest output from edge to edge and nothing may be
 // painted on its perimeter.
@@ -321,7 +352,7 @@ func (m *OS) renderWindowBox(window *terminal.Window, index int, isFocused bool,
 		m.renderTerminal(window, isFocused, m.Mode == TerminalMode),
 		window.ContentWidth(), window.ContentHeight(),
 	)
-	if rendersBorderless(window) {
+	if rendersBorderless(window) || m.zenBordersHidden(isFocused) {
 		return content
 	}
 	box := lipgloss.NewStyle().
@@ -495,6 +526,7 @@ func (m *OS) View() tea.View {
 		m.FlushPendingBSPSync()
 		content := m.composeFrame()
 		m.cachedViewContent = content
+		m.zenHidden = m.zenBordersHidden(false)
 		view.SetContent(content)
 	}
 

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -352,8 +353,17 @@ func (m *OS) renderWindowBox(window *terminal.Window, index int, isFocused bool,
 		m.renderTerminal(window, isFocused, m.Mode == TerminalMode),
 		window.ContentWidth(), window.ContentHeight(),
 	)
-	if rendersBorderless(window) || m.zenBordersHidden(isFocused) {
+	if rendersBorderless(window) {
 		return content
+	}
+	// Zen mode: the frame melts away but the cells stay reserved. A window that
+	// owns its border draws its content at Width-2 by Height-2 placed at the
+	// window origin, so returning the bare content would jump the text one cell
+	// up-left when the border melts and back when it returns. Keep the frame
+	// cells and draw them in a blank style so only the frame fades and the
+	// layout holds still.
+	if m.zenBordersHidden(isFocused) {
+		return m.renderWindowBoxZen(window, content)
 	}
 	box := lipgloss.NewStyle().
 		Align(lipgloss.Left).
@@ -373,6 +383,28 @@ func (m *OS) renderWindowBox(window *terminal.Window, index int, isFocused bool,
 		m.workspacePosition(window),
 		m.AutoTiling,
 	)
+}
+
+// renderWindowBoxZen renders a window whose zen-mode state hides the frame.
+// The frame cells stay reserved (blank border + blank title row) so the content
+// keeps its exact position; only the chrome fades away. The bordered path draws
+// a Width by Height box (title row + body with left/right/bottom frame); this
+// mirrors that geometry with HiddenBorder (which reserves one cell per edge with
+// spaces) and a blank title row of the same width, so the guest's content never
+// shifts a cell.
+func (m *OS) renderWindowBoxZen(window *terminal.Window, content string) string {
+	box := lipgloss.NewStyle().
+		Align(lipgloss.Left).
+		AlignVertical(lipgloss.Top).
+		Border(lipgloss.HiddenBorder()).
+		BorderTop(false)
+	// The box reserves the left/right/bottom frame cells; prepend the blank
+	// title row the bordered path would have drawn, so the total is the same
+	// Height and the content sits at the same offset.
+	return strings.Repeat(" ", window.Width) + "\n" +
+		box.Width(window.Width).
+			Height(window.Height-1).
+			Render(content)
 }
 
 // fastPathDisabled turns the fullscreen fast path off (TUIOS_NO_FASTPATH=1) so it

--- a/internal/app/resize_deferral.go
+++ b/internal/app/resize_deferral.go
@@ -1,6 +1,10 @@
 package app
 
-import "time"
+import (
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
 
 // The deferred half of a resize, and the rule that it can never outlive the
 // gesture that asked for it.
@@ -106,6 +110,14 @@ func (m *OS) noteResizeStep(at time.Time) {
 // notePointerEvent records that a mouse event just arrived. A resize drag is
 // only live while the pointer is still reporting.
 func (m *OS) notePointerEvent(at time.Time) {
+	// Zen mode (mouse): a pointer event re-opens the reveal window, so borders
+	// that the idle melt hid must come back. The event forces its own frame,
+	// but each window's CachedLayer still holds the borderless render and is
+	// reused until the window is dirty, so the reveal must mark the affected
+	// windows dirty here - otherwise the borders would never be drawn again.
+	if config.ZenMode == config.ZenModeMouse && m.zenHidden && !m.pointerRecentlyMoved() {
+		m.markZenDirty()
+	}
 	m.lastPointerAt = at
 }
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -376,6 +376,14 @@ func (m *OS) settingsCategories() []settingsCategory {
 					m.setAppearance(func(a *config.AppearanceConfig) { a.WindowTitleFormat = v })
 					m.applyAppearanceLive(false)
 				}),
+			enumItem("Zen mode", "Hide borders of unfocused windows: disabled, always, or mouse (reveal while moving)",
+				config.ZenModeModes,
+				func() string { return config.ZenMode },
+				func(m *OS, v string) {
+					config.ZenMode = v
+					m.setAppearance(func(a *config.AppearanceConfig) { a.ZenMode = v })
+					m.applyAppearanceLive(true)
+				}),
 		},
 	}
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -866,10 +866,24 @@ func (m *OS) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// the throttling logic, ensuring they eventually render.
 		hasBackgroundChanges := m.MarkTerminalsWithNewContent()
 
+		// Zen mode (mouse): the borders melt once the pointer sits still past
+		// the reveal window. tickNeedsWork already wakes this tick for the
+		// crossing, but needsRender below has no zen term, so without this the
+		// frame would be marked skippable and View() would serve the cached
+		// frame with the borders still painted: zenHidden would never converge
+		// and the tick would keep doing work at 10fps forever with nothing
+		// visible to show for it. Marking the affected windows dirty also
+		// rebuilds their CachedLayer, which still holds the bordered render
+		// and is reused until the window is dirty.
+		zenCrossed := config.ZenMode == config.ZenModeMouse && m.zenHidden != m.zenBordersHidden(false)
+		if zenCrossed {
+			m.markZenDirty()
+		}
+
 		// Render on tick if something periodic needs visual updates OR background windows changed
 		needsRender := hadAnimations || hasAnimations || m.InteractionMode || m.PrefixActive ||
 			needsDockTick || hasBackgroundChanges || hasNotifications || notifExpired || leftScriptMode ||
-			m.SidebarMarqueeActive() || m.TooltipPending() || railTitleChanged
+			m.SidebarMarqueeActive() || m.TooltipPending() || railTitleChanged || zenCrossed
 		if !needsRender {
 			m.renderSkipped = true
 			if len(cmds) > 1 {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -408,6 +408,13 @@ func (m *OS) tickNeedsWork() bool {
 		len(m.pendingAgentAlerts) > 0 {
 		return true
 	}
+	// Zen mode (mouse): the borders melt away once the pointer sits still past
+	// the reveal window, and come back the instant it moves again. The motion
+	// event forces its own frame, but the timeout crossing has no event, so a
+	// work tick that lands on the far side of the threshold must repaint.
+	if config.ZenMode == config.ZenModeMouse && m.zenHidden != m.zenBordersHidden(false) {
+		return true
+	}
 	// A moved daemon listing can carry a new title for a window this client
 	// stopped watching. The per-window drift check below cannot see that, because
 	// the local title it compares against is the one that froze. One atomic load.

--- a/internal/app/zen_mode_test.go
+++ b/internal/app/zen_mode_test.go
@@ -1,10 +1,13 @@
 package app
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"charm.land/lipgloss/v2"
 	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
 )
 
 // withZenMode saves and restores the zen-mode global, which is package state
@@ -95,4 +98,163 @@ func TestPointerRecentlyMoved(t *testing.T) {
 	if m.pointerRecentlyMoved() {
 		t.Error("pointerRecentlyMoved() = true past the idle window, want false")
 	}
+}
+
+// TestZenMouseTickForcesRenderOnCrossing pins the melt half of the mouse-mode
+// contract: the idle crossing has no event of its own (the pointer just stops
+// moving), so the maintenance tick that lands on the far side of the reveal
+// window must both detect the crossing (tickNeedsWork) and force a real frame
+// (needsRender), or renderSkipped stays set, View() serves the cached frame,
+// zenHidden never converges, and the tick does work at 10fps forever with
+// nothing visible to show for it.
+func TestZenMouseTickForcesRenderOnCrossing(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeMouse
+
+	win := newTestWindow(t, "zen-tick-0001", 60, 34)
+	m := newTestOS(win)
+	m.Width, m.Height = 120, 40
+
+	// The last composed frame had the borders visible (zenHidden=false) and
+	// the pointer has sat still past the reveal window, so the melt is due.
+	m.zenHidden = false
+	m.lastPointerAt = time.Now().Add(-(zenModeMouseIdleTimeout + time.Second))
+
+	if !m.tickNeedsWork() {
+		t.Fatal("tickNeedsWork = false at the idle crossing; the melt would never be scheduled")
+	}
+
+	// A tick that crosses the threshold must draw, not skip. Before the fix
+	// needsRender had no zen term, so this tick set renderSkipped and the
+	// melt never appeared.
+	if _, _ = m.Update(TickerMsg(time.Now())); m.renderSkipped {
+		t.Fatal("the tick that crossed the zen idle threshold skipped the frame; the melt would never be drawn")
+	}
+}
+
+// TestZenMouseTickMeltsAndConverges checks that once the melt frame is
+// composed the state converges: the tick stops reporting work (so it drops
+// back to the slow idle rate instead of spinning at 10fps).
+func TestZenMouseTickMeltsAndConverges(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeMouse
+
+	m := &OS{}
+	m.zenHidden = false
+	m.lastPointerAt = time.Now().Add(-(zenModeMouseIdleTimeout + time.Second))
+
+	// Crossing: work due.
+	if !m.tickNeedsWork() {
+		t.Fatal("expected work at the crossing")
+	}
+	// A frame composed with the pointer idle records zenHidden=true, which is
+	// what the tick compares against next time.
+	m.zenHidden = m.zenBordersHidden(false)
+	if m.zenHidden != true {
+		t.Fatalf("zenHidden after idle frame = %v, want true", m.zenHidden)
+	}
+	if m.tickNeedsWork() {
+		t.Fatal("tickNeedsWork = true after the melt converged; the tick would spin at 10fps forever")
+	}
+}
+
+// TestZenPointerRevealMarksDirty pins the reveal half: a pointer event that
+// re-opens the reveal window must mark the affected windows dirty, because
+// each window's CachedLayer still holds the borderless render and is reused
+// until the window is dirty. Without this the borders would never come back.
+func TestZenPointerRevealMarksDirty(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeMouse
+
+	win := newTestWindow(t, "zen-reveal-0001", 60, 34)
+	win2 := newTestWindow(t, "zen-reveal-0002", 60, 34)
+	m := &OS{
+		Windows:       []*terminal.Window{win, win2},
+		FocusedWindow: 0,
+	}
+
+	// The melt already happened: the composed frame has the borders hidden.
+	m.zenHidden = true
+	m.lastPointerAt = time.Now().Add(-(zenModeMouseIdleTimeout + time.Second))
+
+	// Clear dirty flags so we can see who the reveal marks.
+	win.ClearDirtyFlags()
+	win2.ClearDirtyFlags()
+
+	m.notePointerEvent(time.Now())
+
+	if !win2.Dirty {
+		t.Error("the unfocused window was not marked dirty by the reveal; its cached borderless layer would be reused")
+	}
+	if win.Dirty {
+		t.Error("the focused window should keep its border and not need a zen repaint")
+	}
+	if !m.pointerRecentlyMoved() {
+		t.Error("pointerRecentlyMoved = false after notePointerEvent(now)")
+	}
+}
+
+// TestZenRenderWindowBoxKeepsContentPlacement pins the no-jump half of the
+// zen contract: hiding a window's border must not move its content. A window
+// that owns its border draws content at Width-2 by Height-2 placed at the
+// window origin, so returning the bare content would jump the text one cell
+// up-left when the border melts and back when it returns. renderWindowBoxZen
+// keeps the frame cells reserved (blank border + blank title row), so the
+// content keeps its exact position.
+func TestZenRenderWindowBoxKeepsContentPlacement(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeDisabled
+
+	win := newTestWindow(t, "zen-layout-0001", 40, 12)
+	m := &OS{Windows: []*terminal.Window{win}, FocusedWindow: 0}
+
+	// Paint some content into the emulator so there is something to compare.
+	win.LockIO()
+	_, _ = win.Terminal.Write([]byte("HELLO-ZEN"))
+	win.UnlockIO()
+
+	// Same unfocused window, same emulator state: only the zen policy flips.
+	// That is the exact transition the melt performs, so the content must
+	// land on the same cell in both frames.
+	bordered := m.renderWindowBox(win, 0, false, lipgloss.Color("1"))
+	config.ZenMode = config.ZenModeAlways
+	zen := m.renderWindowBox(win, 0, false, lipgloss.Color("1"))
+
+	// Compare the visual cells, not the raw bytes: the bordered frame carries
+	// ANSI color codes on its frame glyphs while the zen blank frame is plain
+	// spaces, so a byte-offset search would read the escape sequences as
+	// columns and report a shift that is not on the screen.
+	bLines := strings.Split(stripANSIForTrace(bordered), "\n")
+	zLines := strings.Split(stripANSIForTrace(zen), "\n")
+	if len(bLines) != len(zLines) {
+		t.Fatalf("zen frame height %d != bordered frame height %d; content would shift vertically",
+			len(zLines), len(bLines))
+	}
+	zWidth := lipgloss.Width(zen)
+	if zWidth != win.Width {
+		t.Fatalf("zen frame width %d != window width %d; content would shift horizontally",
+			zWidth, win.Width)
+	}
+
+	// Find where the content lands in both frames and require the same cell.
+	bx, by := findInFrame(bLines, "HELLO-ZEN")
+	zx, zy := findInFrame(zLines, "HELLO-ZEN")
+	if bx != zx || by != zy {
+		t.Fatalf("content moved: bordered at (%d,%d), zen at (%d,%d); the melt must not shift the layout",
+			bx, by, zx, zy)
+	}
+}
+
+// findInFrame returns the visual (x, y) of the first occurrence of needle in
+// the frame, or (-1,-1) if absent. It measures the column with lipgloss.Width
+// rather than a byte offset, because the bordered frame's left glyph (│) is a
+// multi-byte UTF-8 rune: a byte index would count it as 3 columns and report a
+// shift that is not on the screen.
+func findInFrame(lines []string, needle string) (int, int) {
+	for y, line := range lines {
+		if idx := strings.Index(line, needle); idx >= 0 {
+			return lipgloss.Width(line[:idx]), y
+		}
+	}
+	return -1, -1
 }

--- a/internal/app/zen_mode_test.go
+++ b/internal/app/zen_mode_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// withZenMode saves and restores the zen-mode global, which is package state
+// shared with every other test in the run.
+func withZenMode(t *testing.T) {
+	t.Helper()
+	prev := config.ZenMode
+	t.Cleanup(func() { config.ZenMode = prev })
+}
+
+// Disabled is the default and the historic behaviour: every window keeps its
+// border regardless of focus or pointer activity.
+func TestZenBordersHiddenDisabled(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeDisabled
+
+	m := &OS{}
+	if m.zenBordersHidden(false) {
+		t.Error("zenBordersHidden(false) = true with zen_mode disabled, want false")
+	}
+	if m.zenBordersHidden(true) {
+		t.Error("zenBordersHidden(true) = true with zen_mode disabled, want false")
+	}
+}
+
+// Always hides every unfocused border but keeps the focused window's frame, so
+// the user always retains an anchor for where their keystrokes land.
+func TestZenBordersHiddenAlways(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeAlways
+
+	m := &OS{}
+	if !m.zenBordersHidden(false) {
+		t.Error("zenBordersHidden(false) = false with zen_mode always, want true")
+	}
+	if m.zenBordersHidden(true) {
+		t.Error("zenBordersHidden(true) = true with zen_mode always, want false")
+	}
+}
+
+// Mouse reveals every border while the pointer is moving and hides the
+// unfocused ones once it sits still past the reveal window.
+func TestZenBordersHiddenMouse(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeMouse
+
+	m := &OS{}
+
+	// No pointer event ever: treated as idle, so unfocused borders hide.
+	if !m.zenBordersHidden(false) {
+		t.Error("zenBordersHidden(false) = false with no pointer activity, want true")
+	}
+
+	// A recent motion reveals every border, focused or not.
+	m.lastPointerAt = time.Now()
+	if m.zenBordersHidden(false) {
+		t.Error("zenBordersHidden(false) = true with a recent motion, want false")
+	}
+	if m.zenBordersHidden(true) {
+		t.Error("zenBordersHidden(true) = true with a recent motion, want false")
+	}
+
+	// A pointer event older than the reveal window is idle again: unfocused
+	// borders melt away, the focused one stays.
+	m.lastPointerAt = time.Now().Add(-(zenModeMouseIdleTimeout + time.Second))
+	if !m.zenBordersHidden(false) {
+		t.Error("zenBordersHidden(false) = false after the idle window, want true")
+	}
+	if m.zenBordersHidden(true) {
+		t.Error("zenBordersHidden(true) = true after the idle window, want false")
+	}
+}
+
+// pointerRecentlyMoved answers strictly inside the reveal window.
+func TestPointerRecentlyMoved(t *testing.T) {
+	m := &OS{}
+
+	if m.pointerRecentlyMoved() {
+		t.Error("pointerRecentlyMoved() = true with no pointer event, want false")
+	}
+
+	m.lastPointerAt = time.Now()
+	if !m.pointerRecentlyMoved() {
+		t.Error("pointerRecentlyMoved() = false with a fresh event, want true")
+	}
+
+	m.lastPointerAt = time.Now().Add(-(zenModeMouseIdleTimeout + time.Millisecond))
+	if m.pointerRecentlyMoved() {
+		t.Error("pointerRecentlyMoved() = true past the idle window, want false")
+	}
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -522,6 +522,11 @@ var SharedBorders = false
 // Set via --border-style flag or appearance.border_style config
 var BorderStyle = "rounded"
 
+// ZenMode controls when window borders are hidden. Valid values are the
+// ZenMode* constants: disabled (always visible), always (always hidden) or
+// mouse (hidden while the pointer is idle). Set via appearance.zen_mode.
+var ZenMode = ZenModeDisabled
+
 // DockbarPosition controls the position of the dockbar
 // Set via --dockbar-position flag or appearance.dockbar_position config
 var DockbarPosition = "bottom"

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -122,6 +122,7 @@ type DaemonConfig struct {
 // AppearanceConfig holds appearance-related settings
 type AppearanceConfig struct {
 	BorderStyle                 string  `toml:"border_style"`                    // Border style: rounded, normal, thick, double, hidden, block, ascii, outer-half-block, inner-half-block (borderless mode not yet implemented)
+	ZenMode                     string  `toml:"zen_mode"`                        // Zen mode: disabled, always, mouse (default: disabled)
 	HideWindowButtons           bool    `toml:"hide_window_buttons"`             // Hide window control buttons (minimize, maximize, close)
 	HideScrollbar               bool    `toml:"hide_scrollbar"`                  // Hide the window scrollbar thumb on the border
 	ScrollbackLines             int     `toml:"scrollback_lines"`                // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
@@ -189,6 +190,20 @@ const (
 
 // ClickToTypeModes lists the valid values for appearance.click_to_type.
 var ClickToTypeModes = []string{ClickToTypeSingle, ClickToTypeDouble, ClickToTypeOff}
+
+// Zen-mode policies. See AppearanceConfig.ZenMode.
+const (
+	// ZenModeDisabled keeps window borders always visible (default).
+	ZenModeDisabled = "disabled"
+	// ZenModeAlways hides window borders at all times.
+	ZenModeAlways = "always"
+	// ZenModeMouse hides window borders while the mouse is idle, revealing
+	// them while the pointer is moving or any mouse button is held.
+	ZenModeMouse = "mouse"
+)
+
+// ZenModeModes lists the valid values for appearance.zen_mode.
+var ZenModeModes = []string{ZenModeDisabled, ZenModeAlways, ZenModeMouse}
 
 // Scrollbar styles. See ScrollbarConfig.Style.
 const (
@@ -293,6 +308,7 @@ func DefaultConfig() *UserConfig {
 	cfg := &UserConfig{
 		Appearance: AppearanceConfig{
 			BorderStyle:       "rounded",
+			ZenMode:           ZenModeDisabled,
 			HideWindowButtons: false,
 			ScrollbackLines:   10000,
 			ScrollLines:       3,
@@ -768,6 +784,10 @@ func fillMissingAppearance(cfg, defaultCfg *UserConfig) {
 		cfg.Appearance.BorderStyle = defaultCfg.Appearance.BorderStyle
 	}
 
+	if cfg.Appearance.ZenMode == "" {
+		cfg.Appearance.ZenMode = defaultCfg.Appearance.ZenMode
+	}
+
 	if cfg.Appearance.DockbarPosition == "" {
 		cfg.Appearance.DockbarPosition = defaultCfg.Appearance.DockbarPosition
 	}
@@ -829,6 +849,14 @@ func ApplyAppearanceConfig(cfg *UserConfig) {
 	// current value (a flag, or the default) stands.
 	if cfg.Appearance.BorderStyle != "" {
 		BorderStyle = cfg.Appearance.BorderStyle
+	}
+
+	// ZenMode only takes one of its three values, so a typo in the config lands
+	// on the default the validator warned it would fall back to.
+	if slices.Contains(ZenModeModes, cfg.Appearance.ZenMode) {
+		ZenMode = cfg.Appearance.ZenMode
+	} else if cfg.Appearance.ZenMode != "" {
+		ZenMode = ZenModeDisabled
 	}
 
 	// DockbarPosition defaults to bottom.

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -275,6 +275,7 @@ func validateAppearanceEnums(cfg *UserConfig, result *ValidationResult) {
 		})
 	}
 	checkEnum("click_to_type", cfg.Appearance.ClickToType, ClickToTypeModes)
+	checkEnum("zen_mode", cfg.Appearance.ZenMode, ZenModeModes)
 	checkEnum("scrollbar.style", cfg.Appearance.Scrollbar.Style, ScrollbarStyles)
 	checkEnum("whichkey_position", cfg.Appearance.WhichKeyPosition,
 		[]string{"bottom-right", "bottom-left", "top-right", "top-left", "center"})

--- a/internal/config/zen_mode_test.go
+++ b/internal/config/zen_mode_test.go
@@ -1,0 +1,67 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// withZenMode restores the global after a test that moves it, since it is
+// package state shared with every other test in the run.
+func withZenMode(t *testing.T) {
+	t.Helper()
+	prev := config.ZenMode
+	t.Cleanup(func() { config.ZenMode = prev })
+}
+
+// The default keeps today's behaviour: borders are always visible, and zen mode
+// is opt-in.
+func TestZenModeDefaultsToDisabled(t *testing.T) {
+	if got := config.DefaultConfig().Appearance.ZenMode; got != config.ZenModeDisabled {
+		t.Errorf("default zen_mode = %q, want %q", got, config.ZenModeDisabled)
+	}
+}
+
+// Each value reaches the global the render path reads, and a config written
+// before the key existed loads as the default rather than as no policy at all.
+func TestZenModeReachesTheGlobal(t *testing.T) {
+	withZenMode(t)
+
+	for _, mode := range config.ZenModeModes {
+		cfg := config.DefaultConfig()
+		cfg.Appearance.ZenMode = mode
+		config.ApplyAppearanceConfig(cfg)
+		if config.ZenMode != mode {
+			t.Errorf("ZenMode = %q after applying %q", config.ZenMode, mode)
+		}
+	}
+
+	// An older config: the key is absent, and the load path backfills it.
+	cfg := writeConfig(t, "[appearance]\nborder_style = \"rounded\"\n")
+	if got := cfg.Appearance.ZenMode; got != config.ZenModeDisabled {
+		t.Errorf("zen_mode = %q for a config written before the key existed, want %q", got, config.ZenModeDisabled)
+	}
+}
+
+// A typo warns and lands on the default, so a misspelled policy cannot leave
+// the renderer doing something unrecognisable.
+func TestZenModeRejectsAnUnknownValue(t *testing.T) {
+	withZenMode(t)
+	config.ZenMode = config.ZenModeAlways
+
+	cfg := config.DefaultConfig()
+	cfg.Appearance.ZenMode = "sometimes"
+
+	var warned bool
+	for _, w := range config.ValidateConfig(cfg).Warnings {
+		warned = warned || w.Key == "zen_mode"
+	}
+	if !warned {
+		t.Error("an unknown zen_mode value was accepted without a warning")
+	}
+
+	config.ApplyAppearanceConfig(cfg)
+	if config.ZenMode != config.ZenModeDisabled {
+		t.Errorf("ZenMode = %q after an unknown value, want the default %q", config.ZenMode, config.ZenModeDisabled)
+	}
+}


### PR DESCRIPTION
## 🧘 Zen Mode

Closes #64

Adds `appearance.zen_mode` with three policies for distraction-free focus:

| Value | Behaviour |
|---|---|
| `disabled` | Borders always visible (default, unchanged behaviour) |
| `always` | Unfocused window borders hidden; the focused window keeps its frame as an anchor |
| `mouse` | Borders revealed while the pointer moves, melt away ~2s after it stops; focused window keeps its frame |

### Design decisions

- **Focused window always keeps its border** so the user never loses track of where keystrokes land.
- **Mouse mode repaints exactly once**: the idle tick (`tickNeedsWork`) detects the timeout crossing by comparing `zenHidden` against the freshly computed state, forcing a single repaint rather than waiting for the next unrelated redraw.
- Follows the existing `ClickToType` config pattern (constants, `ZenModeModes` list, `fillMissingAppearance` backfill, `slices.Contains` guard in `ApplyAppearanceConfig`, `checkEnum` validation warning).

### Files changed

- `internal/config/userconfig.go` — new `zen_mode` field, constants, defaults, apply logic
- `internal/config/constants.go` — `ZenMode` global
- `internal/config/validation.go` — `checkEnum` for `zen_mode`
- `internal/app/render.go` — `zenBordersHidden()` + `pointerRecentlyMoved()`, wired into `renderWindowBox`
- `internal/app/os.go` — `zenHidden` frame state
- `internal/app/update.go` — idle tick detects mouse timeout crossing
- `internal/config/zen_mode_test.go` — config tests (default, global reach, unknown value)
- `internal/app/zen_mode_test.go` — render logic tests (disabled/always/mouse/pointer)
- `docs/CONFIGURATION.md` — documentation

### Verification

- ✅ `go build ./...`
- ✅ `go vet ./internal/config/... ./internal/app/...`
- ✅ `gofmt` clean
- ✅ Full `internal/config` + `internal/app` test suites pass
- ✅ 7 new dedicated zen-mode tests pass