### PR TITLE
Fix panic on wrapped-nil cell colors during terminal render (#124)

### DIFF
--- a/internal/app/color_nil.go
+++ b/internal/app/color_nil.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"image/color"
+	"reflect"
+)
+
+// isNilColor reports whether c carries no drawable color: either an untyped-nil
+// color.Color interface, or a color.Color that wraps a nil pointer such as
+// (*color.RGBA)(nil).
+//
+// color.Color's RGBA method has a value receiver, so invoking it through an
+// interface that holds a nil pointer does not return zeros — it panics with
+// "value method image/color.RGBA.RGBA called using nil *RGBA pointer". Terminal
+// cells occasionally arrive with such wrapped-nil style colors, so every RGBA()
+// call on a cell style color must screen for this first. The common colors
+// (lipgloss.Color, lipgloss.ANSIColor, color.RGBA, …) are non-pointer kinds and
+// return false after a single cheap Kind() check.
+func isNilColor(c color.Color) bool {
+	if c == nil {
+		return true
+	}
+	rv := reflect.ValueOf(c)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
+}
+
+// safeColorEquals reports whether two cell style colors are visually equal
+// without panicking on wrapped-nil colors (see isNilColor). Adjacent cells
+// almost always share the same color interface value, so identity is compared
+// before falling back to the four RGBA computations.
+func safeColorEquals(a, b color.Color) bool {
+	if a == b {
+		return true
+	}
+	if isNilColor(a) || isNilColor(b) {
+		return false
+	}
+	ar, ag, ab, aa := a.RGBA()
+	br, bg, bb, ba := b.RGBA()
+	return ar == br && ag == bg && ab == bb && aa == ba
+}

--- a/internal/app/color_nil_test.go
+++ b/internal/app/color_nil_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"image/color"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func TestIsNilColor(t *testing.T) {
+	var wrappedNil color.Color = (*color.RGBA)(nil)
+	cases := []struct {
+		name string
+		c    color.Color
+		want bool
+	}{
+		{"untyped nil interface", nil, true},
+		{"wrapped nil *color.RGBA", wrappedNil, true},
+		{"real color.RGBA value", color.RGBA{R: 1, G: 2, B: 3, A: 4}, false},
+		{"lipgloss.Color", lipgloss.Color("#ff8700"), false},
+	}
+	for _, tc := range cases {
+		if got := isNilColor(tc.c); got != tc.want {
+			t.Errorf("%s: isNilColor = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestSafeColorEqualsWrappedNilDoesNotPanic is the regression guard for
+// issue #124: a terminal cell whose style color is a wrapped-nil pointer
+// (a color.Color interface holding (*color.RGBA)(nil)) previously crashed the
+// whole app with "value method image/color.RGBA.RGBA called using nil *RGBA
+// pointer" the moment its color was compared during rendering.
+func TestSafeColorEqualsWrappedNilDoesNotPanic(t *testing.T) {
+	var wrappedNil color.Color = (*color.RGBA)(nil)
+	realCol := color.RGBA{R: 10, G: 20, B: 30, A: 255}
+
+	if safeColorEquals(wrappedNil, realCol) {
+		t.Error("wrapped-nil vs real color should not be equal")
+	}
+	if safeColorEquals(realCol, wrappedNil) {
+		t.Error("real vs wrapped-nil color should not be equal")
+	}
+	if !safeColorEquals(realCol, color.RGBA{R: 10, G: 20, B: 30, A: 255}) {
+		t.Error("identical colors should be equal")
+	}
+	if safeColorEquals(realCol, color.RGBA{R: 99, G: 20, B: 30, A: 255}) {
+		t.Error("differing colors should not be equal")
+	}
+	// Two wrapped-nil colors of the same dynamic type are equal by identity and
+	// must not reach the panicking RGBA() call.
+	if !safeColorEquals(wrappedNil, (*color.RGBA)(nil)) {
+		t.Error("two wrapped-nil colors of the same type should be equal")
+	}
+}
+
+// TestHashCellAttrsWrappedNilDoesNotPanic covers the second site that reads a
+// cell style color's RGBA() after only an interface-nil check. A wrapped-nil
+// color must hash like an absent color instead of panicking.
+func TestHashCellAttrsWrappedNilDoesNotPanic(t *testing.T) {
+	sc := NewStyleCache(16)
+	cell := &uv.Cell{
+		Content: "x",
+		Width:   1,
+		Style:   uv.Style{Fg: (*color.RGBA)(nil), Bg: (*color.RGBA)(nil)},
+	}
+	_ = sc.hashCellAttrs(cell, false, false)
+}

--- a/internal/app/render_terminal.go
+++ b/internal/app/render_terminal.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"image/color"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -352,20 +351,8 @@ func (m *OS) renderTerminal(window *terminal.Window, isFocused bool, inTerminalM
 		}
 	}
 
-	safeColorEquals := func(a, b color.Color) bool {
-		// Adjacent cells almost always share the same color interface value, so
-		// compare identity before falling back to the four RGBA computations.
-		if a == b {
-			return true
-		}
-		if a == nil || b == nil {
-			return false
-		}
-		ar, ag, ab, aa := a.RGBA()
-		br, bg, bb, ba := b.RGBA()
-		return ar == br && ag == bg && ab == bb && aa == ba
-	}
-
+	// safeColorEquals is defined at package scope (color_nil.go) so it can guard
+	// against wrapped-nil colors and be exercised directly by tests.
 	styleMatches := func(cell *uv.Cell, isCursorPos bool) bool {
 		if prevCell == nil && cell == nil {
 			return prevIsCursor == isCursorPos

--- a/internal/app/stylecache.go
+++ b/internal/app/stylecache.go
@@ -86,7 +86,7 @@ func (sc *StyleCache) hashCellAttrs(cell *uv.Cell, isCursor bool, isOptimized bo
 	_ = h.WriteByte(byte(attrs >> 56))
 
 	// Hash foreground color
-	if cell.Style.Fg != nil {
+	if !isNilColor(cell.Style.Fg) {
 		if ansiColor, ok := cell.Style.Fg.(lipgloss.ANSIColor); ok {
 			_ = h.WriteByte(1)
 			_ = h.WriteByte(byte(ansiColor))
@@ -104,7 +104,7 @@ func (sc *StyleCache) hashCellAttrs(cell *uv.Cell, isCursor bool, isOptimized bo
 	}
 
 	// Hash background color
-	if cell.Style.Bg != nil {
+	if !isNilColor(cell.Style.Bg) {
 		if ansiColor, ok := cell.Style.Bg.(lipgloss.ANSIColor); ok {
 			_ = h.WriteByte(1)
 			_ = h.WriteByte(byte(ansiColor))


### PR DESCRIPTION
## Summary

Fixes #124 — the app panics during rendering with:

```
value method image/color.RGBA.RGBA called using nil *RGBA pointer
```

## Root cause

A `color.Color` interface can hold a **typed-nil** pointer, e.g. `(*color.RGBA)(nil)`. `color.Color`'s `RGBA()` method has a **value receiver**, so calling it through an interface that wraps a nil pointer does not return zeros — it panics with the message above. A terminal cell can arrive with such a wrapped-nil style color (the reporter hit it a few seconds into a `pi` session).

Two render-path sites called `.RGBA()` after only an interface-nil (`c == nil`) check, which does **not** catch a wrapped-nil pointer:

- `safeColorEquals` in `internal/app/render_terminal.go` (the exact site in the reported stack trace: `renderTerminal.func2`)
- `hashCellAttrs` in `internal/app/stylecache.go` (same cell, hit immediately after when its style is cached — so a fix limited to the first site would just relocate the crash)

## Fix

- Add `isNilColor` (new `internal/app/color_nil.go`) that treats both an untyped-nil interface and a wrapped-nil pointer as "no color". Real colors (`lipgloss.Color`, `lipgloss.ANSIColor`, `color.RGBA`, …) are non-pointer kinds and short-circuit after a single `Kind()` check.
- Promote `safeColorEquals` from a local closure to package scope so it can use the guard **and** be unit-tested directly. The `a == b` identity short-circuit still handles two equal wrapped-nil values without touching `RGBA()`.
- Guard both `hashCellAttrs` color sites with `isNilColor`; a wrapped-nil now hashes like an absent color.

Happy path is unchanged.

## Tests

- New `internal/app/color_nil_test.go` reproduces the **exact** reported panic without the fix and passes with it:
  - `TestSafeColorEqualsWrappedNilDoesNotPanic` — without the fix: `panic: value method image/color.RGBA.RGBA called using nil *RGBA pointer`; with the fix: PASS.
  - `TestHashCellAttrsWrappedNilDoesNotPanic` — covers the stylecache twin site.
  - `TestIsNilColor` — nil interface / wrapped-nil pointer / real value / lipgloss color.
- `go vet ./internal/app/`, `gofmt`, and `go build ./...` are clean.
- Full `go test ./internal/app/` passes (`ok … 135.9s`).

## Note

`isNilColor` uses `reflect` on the pointer-kind check. The `a == b` identity short-circuit and the common non-pointer color kinds keep it off the hot path in practice; happy to switch it to a concrete type-switch fast path if you'd prefer to avoid `reflect` entirely.
