### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ staticcheck ./...          # Static analysis
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Gaurav-Gosain/tuios&type=Date&theme=dark)](https://star-history.com/#Gaurav-Gosain/tuios&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Gaurav-Gosain/tuios&type=Date&theme=dark)](https://star-history.dera.page/#Gaurav-Gosain/tuios&Date)
 
 <p style="display:flex;flex-wrap:wrap;">
 <img alt="GitHub Language Count" src="https://img.shields.io/github/languages/count/Gaurav-Gosain/tuios" style="padding:5px;margin:5px;" />


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub's stargazer API no longer provides the data it relies on. This change points the chart at a working mirror that uses a different data source, so the chart renders again.