### PR TITLE
fix(theme): daemon applies config theme to pane content

### DIFF
--- a/cmd/tuios/session_commands.go
+++ b/cmd/tuios/session_commands.go
@@ -913,6 +913,16 @@ func runDaemon(foreground, disableAutoRestore bool) error {
 		daemonCfg.AgentAutoDetect = userConfig.Daemon.AgentAutoDetect
 		daemonCfg.AgentDetectInterval = time.Duration(userConfig.Daemon.AgentDetectSeconds) * time.Second
 		daemonCfg.AgentBinaries = userConfig.Daemon.AgentBinaries
+
+		// Apply the appearance globals (theme, border style, ...) in the daemon
+		// process too. Every other entrypoint (local, SSH server, tape) funnels
+		// through ApplyAppearanceConfig after LoadUserConfig; without it the
+		// daemon never initializes the theme, theme.IsEnabled() stays false, and
+		// every PTY it creates is born with the terminal's default palette
+		// instead of config.toml's -- the chrome recolors, the pane content does
+		// not. createPTY and the window constructors gate their SetThemeColors on
+		// theme.IsEnabled, so this one call fixes them all.
+		config.ApplyAppearanceConfig(userConfig)
 	}
 
 	daemon := session.NewDaemon(daemonCfg)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/Gaurav-Gosain/tuios/internal/guestenv"
+	"github.com/Gaurav-Gosain/tuios/internal/theme"
 	"github.com/Gaurav-Gosain/tuios/internal/vt"
 )
 
@@ -741,6 +742,20 @@ func (s *Session) createPTY(windowID string, width, height int, cwd string, comm
 	// This maintains scrollback, screen content, cursor position across reconnects
 	terminal := vt.New(width, height)
 	terminal.SetScrollbackMaxLines(10000) // Match default scrollback
+
+	// Apply the daemon's active theme (from config.toml) to every fresh
+	// emulator, not only restored ones: a window created after restore (by a
+	// keybinding, the bootstrap or a client) must be born with the same palette
+	// or the theme never reaches pane content. NewWindow applies the theme for
+	// the local/standalone path; this is the daemon path's equivalent.
+	if theme.IsEnabled() {
+		terminal.SetThemeColors(
+			theme.TerminalFg(),
+			theme.TerminalBg(),
+			theme.TerminalCursor(),
+			theme.GetANSIPalette(),
+		)
+	}
 
 	// For a restored shell, seed the emulator with a one-line banner so the
 	// respawned process is clearly marked. This is written directly (before the


### PR DESCRIPTION
## What

The daemon (`tuios daemon`) never applies the theme from config.toml to pane **content** — only to the chrome a client renders. The theme picker changes borders/dockbar instantly, but every PTY the daemon creates is born with the terminal's default palette.

## Root cause

`runDaemon()` in `cmd/tuios/session_commands.go` was the only entrypoint that loaded the user config without `ApplyAppearanceConfig`. Every other path (local TUI, SSH server, tape, web) funnels through it, so `theme.IsEnabled()` stays `false` in the daemon process. Since `createPTY()` and the window constructors gate `SetThemeColors` on `theme.IsEnabled`, the daemon never initializes the theme and pane content keeps the default colors.

## Fix

Two coordinated changes:

1. **`cmd/tuios/session_commands.go` (runDaemon)**: call `config.ApplyAppearanceConfig(userConfig)` so the daemon initializes the theme globals like every other entrypoint.
2. **`internal/session/session.go` (createPTY)**: apply the active theme's palette to every fresh emulator. `NewWindow` already does this for the local/standalone path; this is the daemon path's equivalent, so windows created after restore (bootstrap, keybindings, clients) are born with the configured palette too.

## Verification

End-to-end against a detached daemon with `theme=3024_day`: `capture-pane --ansi` on a pane that prints SGR 31/42 now emits truecolor `38;2;219;44;32` / `48;2;1;162;81` (the theme's red and green) instead of the bare indices `31`/`42`.

## Notes

- Restored sessions keep old cell colors (the emulator stores resolved RGB, not indices) — this fix makes new output and new windows correct.
- Also fixes: windows created by the bootstrap script or keybindings after restore were born with the wrong palette.