### PR TITLE
feat(clipboard): native system clipboard fallback for VTE terminals

### DIFF
--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -38,34 +38,30 @@ func (m *OS) CopyToClipboard(text string) tea.Cmd {
 	}
 	m.CancelPendingCopy()
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return m.clipboardWriteCmd(text)
+	return m.WriteClipboard(text)
 }
 
-// clipboardWriteCmd prefers a native system clipboard (wl-copy, xclip, pbcopy)
-// when one is reachable, and falls back to OSC 52 (tea.SetClipboard) otherwise.
-// OSC 52 is the right channel for remote clients with no local clipboard of
-// their own; a native tool is the right channel for terminals like GNOME
-// Terminal/Ptyxis whose VTE never implements OSC 52.
+// WriteClipboard writes text to the system clipboard and is the one write
+// path: copy mode's y, the scrollback browser, link and path copies, drag and
+// multi-click selections, and the pane menu all land here. It prefers a native
+// system clipboard (wl-copy, xclip, pbcopy) when one is reachable for this
+// session, and always returns the OSC 52 message (tea.SetClipboard) on top.
 //
-// The native path is only taken for a session that is both local (not SSH, not
-// a browser client: under tuios ssh / tuios-web, WAYLAND_DISPLAY/DISPLAY
-// describe the operator's desktop, and a native read/write would move data
-// between two people) and VTE-hosted (the only family that never implements
-// OSC 52; everywhere else spawning wl-copy/xclip would just duplicate entries
-// in the clipboard manager on every selection for no gain).
-func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
-	local := !m.IsSSHMode && !m.BrowserClient
-	// The write is wrapped so the native path runs *and* the same
-	// setClipboardMsg that tea.SetClipboard produces is still returned: Bubble
-	// Tea forwards that message as OSC 52, which is harmless in terminals that do
-	// not implement it and a second, redundant path in those that do. The
-	// double write is idempotent (same text), and the native one is what makes
-	// VTE-based terminals (GNOME Terminal, Ptyxis) work at all.
+// The native write is decided by nativeClipboardTool, here on the Update loop;
+// the Cmd it returns only closes over the tool pointer and the text. The OSC
+// 52 message is still returned when the native path ran: in the VTE terminals
+// the gate allows it is ignored (they do not implement OSC 52, which is why
+// the native tool exists at all), and if the host detection ever misfires on a
+// terminal that does implement it, the query lands the text anyway. Nothing
+// ever writes twice: where OSC 52 works, the native path is off, and where the
+// native path is on, OSC 52 is ignored.
+func (m *OS) WriteClipboard(text string) tea.Cmd {
+	tool := m.nativeClipboardTool()
 	return func() tea.Msg {
-		if local && ShouldUseNativeClipboard(m.Settings.ClipboardLocalFallback) {
+		if tool != nil {
 			// Best-effort: if the native write fails (permissions, compositor
 			// gone), the OSC 52 message below is still the safety net.
-			_ = DetectClipboardTool().Write(text)
+			_ = tool.Write(text)
 		}
 		return tea.SetClipboard(text)()
 	}
@@ -109,7 +105,7 @@ func (m *OS) HandlePendingCopy(seq uint64) tea.Cmd {
 	text := m.pendingCopy
 	m.pendingCopy = ""
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return m.clipboardWriteCmd(text)
+	return m.WriteClipboard(text)
 }
 
 // PendingCopyText reports the text a deferred write is holding, for tests and

--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -38,7 +38,30 @@ func (m *OS) CopyToClipboard(text string) tea.Cmd {
 	}
 	m.CancelPendingCopy()
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(text)
+	return m.clipboardWriteCmd(text)
+}
+
+// clipboardWriteCmd prefers a native system clipboard (wl-copy, xclip, pbcopy)
+// when one is reachable, and falls back to OSC 52 (tea.SetClipboard) otherwise.
+// OSC 52 is the right channel for remote clients with no local clipboard of
+// their own; a native tool is the right channel for terminals like GNOME
+// Terminal/Ptyxis whose VTE never implements OSC 52.
+func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
+	// The write is wrapped so the native path runs *and* the same
+	// setClipboardMsg that tea.SetClipboard produces is still returned: Bubble
+	// Tea forwards that message as OSC 52, which is harmless in terminals that do
+	// not implement it and a second, redundant path in those that do. The
+	// double write is idempotent (same text), and the native one is what makes
+	// VTE-based terminals (GNOME Terminal, Ptyxis) work at all.
+	return func() tea.Msg {
+		if m.Settings.ClipboardLocalFallback && LocalClipboardAvailable() {
+			// Best-effort: if the native write fails (permissions, compositor
+			// gone), the OSC 52 message below is still the safety net.
+			_ = DetectClipboardTool().Write(text)
+		}
+		return tea.SetClipboard(text)()
+	}
+}
 }
 
 // DeferCopyToClipboard holds text back until delay has passed with no further
@@ -79,7 +102,7 @@ func (m *OS) HandlePendingCopy(seq uint64) tea.Cmd {
 	text := m.pendingCopy
 	m.pendingCopy = ""
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(text)
+	return m.clipboardWriteCmd(text)
 }
 
 // PendingCopyText reports the text a deferred write is holding, for tests and

--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -46,7 +46,15 @@ func (m *OS) CopyToClipboard(text string) tea.Cmd {
 // OSC 52 is the right channel for remote clients with no local clipboard of
 // their own; a native tool is the right channel for terminals like GNOME
 // Terminal/Ptyxis whose VTE never implements OSC 52.
+//
+// The native path is only taken for a session that is both local (not SSH, not
+// a browser client: under tuios ssh / tuios-web, WAYLAND_DISPLAY/DISPLAY
+// describe the operator's desktop, and a native read/write would move data
+// between two people) and VTE-hosted (the only family that never implements
+// OSC 52; everywhere else spawning wl-copy/xclip would just duplicate entries
+// in the clipboard manager on every selection for no gain).
 func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
+	local := !m.IsSSHMode && !m.BrowserClient
 	// The write is wrapped so the native path runs *and* the same
 	// setClipboardMsg that tea.SetClipboard produces is still returned: Bubble
 	// Tea forwards that message as OSC 52, which is harmless in terminals that do
@@ -54,7 +62,7 @@ func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
 	// double write is idempotent (same text), and the native one is what makes
 	// VTE-based terminals (GNOME Terminal, Ptyxis) work at all.
 	return func() tea.Msg {
-		if m.Settings.ClipboardLocalFallback && LocalClipboardAvailable() {
+		if local && m.Settings.ClipboardLocalFallback && LocalClipboardAvailable() {
 			// Best-effort: if the native write fails (permissions, compositor
 			// gone), the OSC 52 message below is still the safety net.
 			_ = DetectClipboardTool().Write(text)

--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -62,14 +62,13 @@ func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
 	// double write is idempotent (same text), and the native one is what makes
 	// VTE-based terminals (GNOME Terminal, Ptyxis) work at all.
 	return func() tea.Msg {
-		if local && m.Settings.ClipboardLocalFallback && LocalClipboardAvailable() {
+		if local && ShouldUseNativeClipboard(m.Settings.ClipboardLocalFallback) {
 			// Best-effort: if the native write fails (permissions, compositor
 			// gone), the OSC 52 message below is still the safety net.
 			_ = DetectClipboardTool().Write(text)
 		}
 		return tea.SetClipboard(text)()
 	}
-}
 }
 
 // DeferCopyToClipboard holds text back until delay has passed with no further

--- a/internal/app/clipboard_local.go
+++ b/internal/app/clipboard_local.go
@@ -2,9 +2,9 @@ package app
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/Gaurav-Gosain/tuios/internal/config"
@@ -71,19 +71,30 @@ func detectClipboardTool(env detectClipboardToolEnv) *clipboardTool {
 // Write sends text to the native clipboard. The tool owns the data: wl-copy
 // forks a keeper process that holds the selection until it is replaced, which
 // is exactly the semantics we want (the text stays available after we exit).
-// The write is started but not waited on: waiting would block until the keeper
-// is replaced, which for a copy that nobody pastes is effectively forever.
-// cmd.Start returns as soon as the keeper has the content, and a later copy
-// replaces it naturally (wl-clipboard handles the handoff). The goroutine
-// reaps the keeper so it never lingers as a zombie in the process table.
+//
+// The write itself is reported: a keeper that died before consuming stdin
+// (compositor gone mid-copy) surfaces as an error from the pipe instead of
+// being lost. The process is not waited on — waiting would block until the
+// keeper is replaced, which for a copy that nobody pastes is effectively
+// forever — so the reaping stays in a goroutine, and a write only blocks while
+// the text is larger than the pipe buffer and the keeper is slow to consume
+// it, which is fine on the Cmd goroutine the write runs on.
 func (t *clipboardTool) Write(text string) error {
 	cmd := exec.Command(t.copyCmd[0], t.copyCmd[1:]...)
-	cmd.Stdin = strings.NewReader(text)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	_, werr := io.WriteString(stdin, text)
+	cerr := stdin.Close()
 	go cmd.Wait() // reap the keeper so it does not become a zombie
-	return nil
+	if werr != nil {
+		return werr
+	}
+	return cerr
 }
 
 // pasteTimeout bounds a clipboard read. A hung xclip (X server gone, selinux
@@ -103,37 +114,38 @@ func (t *clipboardTool) Read() (string, error) {
 	return string(out), err
 }
 
-// localClipboardAvailable reports whether a native clipboard tool is usable
-// right now. Called on every copy/paste so a tool disappearing (session end,
-// compositor exit) degrades gracefully back to OSC 52.
-func LocalClipboardAvailable() bool {
-	return DetectClipboardTool() != nil
-}
-
-// ShouldUseNativeClipboard is the single decision point for the clipboard
-// fallback. The native tool is only reached for when ALL of these hold:
-//  1. the config option is on,
-//  2. the host terminal is VTE (the only family that never implements OSC 52;
+// nativeClipboardTool is the single decision point for the clipboard fallback:
+// it returns the native tool to use for this session, or nil when tuios must
+// go through OSC 52 alone. The paste path (RequestHostPaste) and the write
+// path (WriteClipboard) both call it once, on the Update loop, and hand the
+// result to their Cmd, so the goroutine only ever sees a plain tool pointer
+// and never touches the model.
+//
+// The native tool is reached only when ALL of these hold:
+//  1. the session is local — not SSH, not a browser client: under tuios ssh /
+//     tuios-web the human is elsewhere, and WAYLAND_DISPLAY / DISPLAY describe
+//     the operator's desktop, so a native read or write would move data
+//     between two people,
+//  2. the config option is on,
+//  3. the host terminal is VTE (the only family that never implements OSC 52;
 //     everywhere else OSC 52 already works and spawning wl-copy/xclip would
 //     just duplicate entries in the clipboard manager on every selection),
-//  3. a tool is actually reachable.
-//
-// The SSH/browser gate lives at the call sites (clipboardWriteCmd and the
-// paste path): only those know whether the human is sitting at this machine.
-// Under tuios ssh / tuios-web, WAYLAND_DISPLAY/DISPLAY describe the operator's
-// desktop, so a native read/write would move data between two people.
-func ShouldUseNativeClipboard(fallbackEnabled bool) bool {
-	return shouldUseNativeClipboard(detectClipboardToolEnv{os.Getenv, lookPath}, config.HostIsVTE(), fallbackEnabled)
+//  4. a tool is actually reachable.
+func (m *OS) nativeClipboardTool() *clipboardTool {
+	if m.IsSSHMode || m.BrowserClient {
+		return nil
+	}
+	return nativeClipboardToolFor(detectClipboardToolEnv{os.Getenv, lookPath}, config.HostIsVTE(), m.Settings.ClipboardLocalFallback)
 }
 
-func shouldUseNativeClipboard(env detectClipboardToolEnv, hostIsVTE, fallbackEnabled bool) bool {
-	if !fallbackEnabled {
-		return false
+// nativeClipboardToolFor is nativeClipboardTool with the environment, the host
+// detection and the setting injected, so the VTE/setting/tool half of the
+// decision stays a table test with no compositor and no real env.
+func nativeClipboardToolFor(env detectClipboardToolEnv, hostIsVTE, fallbackEnabled bool) *clipboardTool {
+	if !fallbackEnabled || !hostIsVTE {
+		return nil
 	}
-	if !hostIsVTE {
-		return false
-	}
-	return detectClipboardTool(env) != nil
+	return detectClipboardTool(env)
 }
 
 func lookPath(name string) bool {

--- a/internal/app/clipboard_local.go
+++ b/internal/app/clipboard_local.go
@@ -122,8 +122,8 @@ func LocalClipboardAvailable() bool {
 // paste path): only those know whether the human is sitting at this machine.
 // Under tuios ssh / tuios-web, WAYLAND_DISPLAY/DISPLAY describe the operator's
 // desktop, so a native read/write would move data between two people.
-func ShouldUseNativeClipboard() bool {
-	return shouldUseNativeClipboard(detectClipboardToolEnv{os.Getenv, lookPath}, config.HostIsVTE(), config.ClipboardLocalFallback)
+func ShouldUseNativeClipboard(fallbackEnabled bool) bool {
+	return shouldUseNativeClipboard(detectClipboardToolEnv{os.Getenv, lookPath}, config.HostIsVTE(), fallbackEnabled)
 }
 
 func shouldUseNativeClipboard(env detectClipboardToolEnv, hostIsVTE, fallbackEnabled bool) bool {

--- a/internal/app/clipboard_local.go
+++ b/internal/app/clipboard_local.go
@@ -1,9 +1,13 @@
 package app
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
 )
 
 // clipboardTool describes a native system clipboard command pair. TUIOS normally
@@ -20,32 +24,45 @@ import (
 type clipboardTool struct {
 	name     string   // human-readable, for logs/notifications
 	copyCmd  []string // e.g. {"wl-copy"}
-	pasteCmd []string // e.g. {"wl-paste"}
+	pasteCmd []string // e.g. {"wl-paste", "-n"}
 }
 
-// detectClipboardTool finds a native clipboard tool for the current session.
+// detectClipboardToolEnv is the environment a clipboard decision is made from.
+// Both fields are injectable so the whole decision table (Wayland vs X11 vs
+// macOS, tool present or not) becomes a plain table test with no compositor.
+type detectClipboardToolEnv struct {
+	getenv   func(string) string
+	lookPath func(string) bool
+}
+
+// DetectClipboardTool finds a native clipboard tool for the current session.
 // Returns nil when none is available (headless server, no clipboard binaries).
 // Detection order: Wayland (wl-clipboard) → X11 (xclip, xsel) → macOS (pbcopy).
 func DetectClipboardTool() *clipboardTool {
+	return detectClipboardTool(detectClipboardToolEnv{os.Getenv, lookPath})
+}
+
+func detectClipboardTool(env detectClipboardToolEnv) *clipboardTool {
+	getenv, lp := env.getenv, env.lookPath
 	// Wayland. XDG_RUNTIME_DIR + WAYLAND_DISPLAY must both be set for the
 	// socket to be reachable; checking the env guards against a tool present
 	// but unusable.
-	if os.Getenv("XDG_RUNTIME_DIR") != "" && os.Getenv("WAYLAND_DISPLAY") != "" {
-		if lookPath("wl-copy") && lookPath("wl-paste") {
-			return &clipboardTool{name: "wl-clipboard", copyCmd: []string{"wl-copy"}, pasteCmd: []string{"wl-paste"}}
+	if getenv("XDG_RUNTIME_DIR") != "" && getenv("WAYLAND_DISPLAY") != "" {
+		if lp("wl-copy") && lp("wl-paste") {
+			return &clipboardTool{name: "wl-clipboard", copyCmd: []string{"wl-copy"}, pasteCmd: []string{"wl-paste", "-n"}}
 		}
 	}
 	// X11.
-	if os.Getenv("DISPLAY") != "" {
-		if lookPath("xclip") {
+	if getenv("DISPLAY") != "" {
+		if lp("xclip") {
 			return &clipboardTool{name: "xclip", copyCmd: []string{"xclip", "-selection", "clipboard"}, pasteCmd: []string{"xclip", "-selection", "clipboard", "-o"}}
 		}
-		if lookPath("xsel") {
+		if lp("xsel") {
 			return &clipboardTool{name: "xsel", copyCmd: []string{"xsel", "--clipboard", "--input"}, pasteCmd: []string{"xsel", "--clipboard", "--output"}}
 		}
 	}
 	// macOS.
-	if lookPath("pbcopy") && lookPath("pbpaste") {
+	if lp("pbcopy") && lp("pbpaste") {
 		return &clipboardTool{name: "pbcopy/pbpaste", copyCmd: []string{"pbcopy"}, pasteCmd: []string{"pbpaste"}}
 	}
 	return nil
@@ -57,18 +74,33 @@ func DetectClipboardTool() *clipboardTool {
 // The write is started but not waited on: waiting would block until the keeper
 // is replaced, which for a copy that nobody pastes is effectively forever.
 // cmd.Start returns as soon as the keeper has the content, and a later copy
-// replaces it naturally (wl-clipboard handles the handoff).
+// replaces it naturally (wl-clipboard handles the handoff). The goroutine
+// reaps the keeper so it never lingers as a zombie in the process table.
 func (t *clipboardTool) Write(text string) error {
 	cmd := exec.Command(t.copyCmd[0], t.copyCmd[1:]...)
 	cmd.Stdin = strings.NewReader(text)
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait() // reap the keeper so it does not become a zombie
+	return nil
 }
 
-// read returns the current native clipboard contents. Best-effort: an empty
+// pasteTimeout bounds a clipboard read. A hung xclip (X server gone, selinux
+// stall) would otherwise leave the paste pending forever; with the timeout the
+// read fails and the caller falls back to OSC 52.
+const pasteTimeout = 2 * time.Second
+
+// Read returns the current native clipboard contents. Best-effort: an empty
 // clipboard or a failed read yields an empty string.
 func (t *clipboardTool) Read() (string, error) {
-	out, err := exec.Command(t.pasteCmd[0], t.pasteCmd[1:]...).Output()
-	return strings.TrimSuffix(string(out), "\n"), err
+	ctx, cancel := context.WithTimeout(context.Background(), pasteTimeout)
+	defer cancel()
+	// wl-paste -n suppresses the trailing newline wl-paste adds by default;
+	// xclip -o and pbpaste do not add one, so a selection genuinely ending in
+	// a newline keeps it instead of losing it to a TrimSuffix.
+	out, err := exec.CommandContext(ctx, t.pasteCmd[0], t.pasteCmd[1:]...).Output()
+	return string(out), err
 }
 
 // localClipboardAvailable reports whether a native clipboard tool is usable
@@ -76,6 +108,32 @@ func (t *clipboardTool) Read() (string, error) {
 // compositor exit) degrades gracefully back to OSC 52.
 func LocalClipboardAvailable() bool {
 	return DetectClipboardTool() != nil
+}
+
+// ShouldUseNativeClipboard is the single decision point for the clipboard
+// fallback. The native tool is only reached for when ALL of these hold:
+//  1. the config option is on,
+//  2. the host terminal is VTE (the only family that never implements OSC 52;
+//     everywhere else OSC 52 already works and spawning wl-copy/xclip would
+//     just duplicate entries in the clipboard manager on every selection),
+//  3. a tool is actually reachable.
+//
+// The SSH/browser gate lives at the call sites (clipboardWriteCmd and the
+// paste path): only those know whether the human is sitting at this machine.
+// Under tuios ssh / tuios-web, WAYLAND_DISPLAY/DISPLAY describe the operator's
+// desktop, so a native read/write would move data between two people.
+func ShouldUseNativeClipboard() bool {
+	return shouldUseNativeClipboard(detectClipboardToolEnv{os.Getenv, lookPath}, config.HostIsVTE(), config.ClipboardLocalFallback)
+}
+
+func shouldUseNativeClipboard(env detectClipboardToolEnv, hostIsVTE, fallbackEnabled bool) bool {
+	if !fallbackEnabled {
+		return false
+	}
+	if !hostIsVTE {
+		return false
+	}
+	return detectClipboardTool(env) != nil
 }
 
 func lookPath(name string) bool {

--- a/internal/app/clipboard_local.go
+++ b/internal/app/clipboard_local.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// clipboardTool describes a native system clipboard command pair. TUIOS normally
+// talks to the clipboard through OSC 52, which requires the user's terminal to
+// implement it. Terminals built on VTE (GNOME Terminal, Ptyxis) do not, so the
+// copy/paste actions silently fail there. When the process runs on a machine
+// with a native clipboard tool (wl-clipboard, xclip, pbcopy), we write to and
+// read from the system clipboard directly instead of depending on the terminal.
+//
+// OSC 52 remains the fallback for remote clients: a client SSH'd into a
+// headless box has no native clipboard of its own, and the terminal on the
+// other end of the wire is the only channel that can reach the user's real
+// clipboard. Local-first, OSC 52 as the safety net.
+type clipboardTool struct {
+	name     string   // human-readable, for logs/notifications
+	copyCmd  []string // e.g. {"wl-copy"}
+	pasteCmd []string // e.g. {"wl-paste"}
+}
+
+// detectClipboardTool finds a native clipboard tool for the current session.
+// Returns nil when none is available (headless server, no clipboard binaries).
+// Detection order: Wayland (wl-clipboard) → X11 (xclip, xsel) → macOS (pbcopy).
+func DetectClipboardTool() *clipboardTool {
+	// Wayland. XDG_RUNTIME_DIR + WAYLAND_DISPLAY must both be set for the
+	// socket to be reachable; checking the env guards against a tool present
+	// but unusable.
+	if os.Getenv("XDG_RUNTIME_DIR") != "" && os.Getenv("WAYLAND_DISPLAY") != "" {
+		if lookPath("wl-copy") && lookPath("wl-paste") {
+			return &clipboardTool{name: "wl-clipboard", copyCmd: []string{"wl-copy"}, pasteCmd: []string{"wl-paste"}}
+		}
+	}
+	// X11.
+	if os.Getenv("DISPLAY") != "" {
+		if lookPath("xclip") {
+			return &clipboardTool{name: "xclip", copyCmd: []string{"xclip", "-selection", "clipboard"}, pasteCmd: []string{"xclip", "-selection", "clipboard", "-o"}}
+		}
+		if lookPath("xsel") {
+			return &clipboardTool{name: "xsel", copyCmd: []string{"xsel", "--clipboard", "--input"}, pasteCmd: []string{"xsel", "--clipboard", "--output"}}
+		}
+	}
+	// macOS.
+	if lookPath("pbcopy") && lookPath("pbpaste") {
+		return &clipboardTool{name: "pbcopy/pbpaste", copyCmd: []string{"pbcopy"}, pasteCmd: []string{"pbpaste"}}
+	}
+	return nil
+}
+
+// Write sends text to the native clipboard. The tool owns the data: wl-copy
+// forks a keeper process that holds the selection until it is replaced, which
+// is exactly the semantics we want (the text stays available after we exit).
+// The write is started but not waited on: waiting would block until the keeper
+// is replaced, which for a copy that nobody pastes is effectively forever.
+// cmd.Start returns as soon as the keeper has the content, and a later copy
+// replaces it naturally (wl-clipboard handles the handoff).
+func (t *clipboardTool) Write(text string) error {
+	cmd := exec.Command(t.copyCmd[0], t.copyCmd[1:]...)
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Start()
+}
+
+// read returns the current native clipboard contents. Best-effort: an empty
+// clipboard or a failed read yields an empty string.
+func (t *clipboardTool) Read() (string, error) {
+	out, err := exec.Command(t.pasteCmd[0], t.pasteCmd[1:]...).Output()
+	return strings.TrimSuffix(string(out), "\n"), err
+}
+
+// localClipboardAvailable reports whether a native clipboard tool is usable
+// right now. Called on every copy/paste so a tool disappearing (session end,
+// compositor exit) degrades gracefully back to OSC 52.
+func LocalClipboardAvailable() bool {
+	return DetectClipboardTool() != nil
+}
+
+func lookPath(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}

--- a/internal/app/clipboard_local_test.go
+++ b/internal/app/clipboard_local_test.go
@@ -194,8 +194,8 @@ func TestNativeClipboardToolDecision(t *testing.T) {
 // built from shell commands that need no compositor (tee/cat to a temp file).
 // This is the deterministic part of the contract: Write launches the keeper
 // without blocking and reaps it, Read captures stdout. The real wl-copy round
-// trip is covered by TestClipboardToolRoundTrip, which runs only when a Wayland
-// socket is actually reachable (never in the isolated test tree).
+// trip is covered by TestClipboardToolRoundTrip, which stubs wl-clipboard with
+// shell scripts on a temp PATH and runs everywhere.
 func TestClipboardToolWriteReadLogic(t *testing.T) {
 	clipFile := filepath.Join(t.TempDir(), "clip.txt")
 
@@ -253,12 +253,25 @@ func TestClipboardToolWriteReadLogic(t *testing.T) {
 // table above cannot see: a remote session (SSH or browser client) must never
 // reach for the native tool, because WAYLAND_DISPLAY / DISPLAY describe the
 // operator's desktop and a native read or write would move data between two
-// people. The tool must also be refused when the config option is off. These
-// rows return before any environment probing, so they are deterministic.
+// people. The tool must also be refused when the config option is off.
+//
+// The environment is set up so a local client WOULD reach the tool: VTE_VERSION
+// is set and wl-clipboard is stubbed on PATH. That is what makes the rows below
+// meaningful — an earlier draft ran in a bare tree where no local client could
+// reach the tool either, so every row returned nil and deleting the session
+// gate below changed nothing. Here the SSH, browser and fallback-off rows are
+// the only thing that can return nil.
 func TestNativeClipboardToolGate(t *testing.T) {
+	clip := stubClipboardSession(t)
 	if !config.DefaultSettings().ClipboardLocalFallback {
 		t.Fatalf("the fallback is off by default; this gate test assumes it on")
 	}
+
+	local := &OS{Settings: config.DefaultSettings()}
+	if got := local.nativeClipboardTool(); got == nil {
+		t.Fatalf("a local VTE session with wl-clipboard on PATH did not reach the native tool (clip=%s); the gate rows below are vacuous", clip)
+	}
+
 	rows := []struct {
 		name string
 		os   *OS
@@ -286,23 +299,7 @@ func TestNativeClipboardToolGate(t *testing.T) {
 // which exercises the same detection → Write → Read plumbing with no
 // compositor, and runs everywhere.
 func TestClipboardToolRoundTrip(t *testing.T) {
-	bin := t.TempDir()
-	clip := filepath.Join(bin, "clipboard")
-	stubs := map[string]string{
-		filepath.Join(bin, "wl-copy"):  "#!/bin/sh\ncat > " + clip + "\n",
-		filepath.Join(bin, "wl-paste"): "#!/bin/sh\nexec cat " + clip + "\n",
-	}
-	for path, body := range stubs {
-		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
-			t.Fatalf("stub %s: %v", path, err)
-		}
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	// Detection needs a Wayland session; name one explicitly, since the
-	// isolated test tree never has one. The scripts above stand in for the
-	// compositor.
-	t.Setenv("XDG_RUNTIME_DIR", bin)
-	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	stubClipboardSession(t)
 
 	tool := DetectClipboardTool()
 	if tool == nil {
@@ -325,4 +322,72 @@ func TestClipboardToolRoundTrip(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("round trip mismatch: wrote %q, read back %q (err=%v)", sentinel, got, err)
+}
+
+// stubClipboardSession points the test process at a throwaway wl-clipboard:
+// shell-script stubs on a temp PATH, a named Wayland session, and VTE_VERSION
+// set, so config.HostIsVTE() and detection both see a local VTE session with a
+// reachable tool. It returns the file the wl-copy stub writes to, so a test can
+// assert the native path really ran. t.Setenv restores the real environment
+// when the test ends, so no other test sees it.
+func stubClipboardSession(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	clip := filepath.Join(bin, "clipboard")
+	stubs := map[string]string{
+		filepath.Join(bin, "wl-copy"):  "#!/bin/sh\ncat > " + clip + "\n",
+		filepath.Join(bin, "wl-paste"): "#!/bin/sh\nexec cat " + clip + "\n",
+	}
+	for path, body := range stubs {
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("stub %s: %v", path, err)
+		}
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("XDG_RUNTIME_DIR", bin)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("VTE_VERSION", "1")
+	// VTE_VERSION is the LAST marker detectHostTerminal consults, after
+	// TERM_PROGRAM, KITTY_WINDOW_ID, WEZTERM_EXECUTABLE, TERM, etc. A dev
+	// machine's real terminal would otherwise win over the stubbed session, so
+	// blank every earlier marker and leave VTE_VERSION as the only one.
+	for _, k := range []string{
+		"TERM_PROGRAM", "KITTY_WINDOW_ID", "GHOSTTY_RESOURCES_DIR",
+		"GHOSTTY_BIN_DIR", "ALACRITTY_WINDOW_ID", "ALACRITTY_SOCKET",
+		"WEZTERM_EXECUTABLE", "TERM",
+	} {
+		t.Setenv(k, "")
+	}
+	return clip
+}
+
+// TestWriteClipboardReachesNativeTool connects the single write path to the
+// native tool. TestClipboardToolWriteReadLogic exercises clipboardTool.Write on
+// its own and TestNativeClipboardToolDecision pins the decision table, but
+// nothing used to prove that WriteClipboard — the method every copy in the app
+// goes through — actually runs the native write when one is available. Making
+// the native write unreachable (nativeClipboardTool returning nil) leaves the
+// wl-copy stub untouched, so this test is the guard that fails.
+func TestWriteClipboardReachesNativeTool(t *testing.T) {
+	clip := stubClipboardSession(t)
+	m := &OS{Settings: config.DefaultSettings()}
+
+	const sentinel = "tuios-writeclipboard-sentinel"
+	cmd := m.WriteClipboard(sentinel)
+	if cmd == nil {
+		t.Fatalf("WriteClipboard returned no command")
+	}
+	cmd() // the Cmd runs the native write, then returns the OSC 52 message
+
+	// The wl-copy stub keeper lands the bytes asynchronously (Start semantics),
+	// so poll briefly instead of sleeping a fixed amount.
+	for i := 0; i < 100; i++ {
+		got, err := os.ReadFile(clip)
+		if err == nil && string(got) == sentinel {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got, _ := os.ReadFile(clip)
+	t.Fatalf("the native write never reached wl-copy: clip holds %q, want %q", got, sentinel)
 }

--- a/internal/app/clipboard_local_test.go
+++ b/internal/app/clipboard_local_test.go
@@ -1,45 +1,198 @@
 package app
 
 import (
-	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
 
-// TestDetectClipboardToolMatchesEnv verifies that detection is consistent with
-// the environment: when a Wayland session + wl-clipboard are present we must
-// find a tool; when neither display nor tool exists we must return nil. This
-// keeps the guard logic honest without requiring a compositor in CI.
-func TestDetectClipboardToolMatchesEnv(t *testing.T) {
-	wayland := os.Getenv("WAYLAND_DISPLAY") != "" && os.Getenv("XDG_RUNTIME_DIR") != ""
-	x11 := os.Getenv("DISPLAY") != ""
-	hasWLCopy := lookPath("wl-copy") && lookPath("wl-paste")
-	hasXClip := lookPath("xclip") || lookPath("xsel")
-	hasPB := lookPath("pbcopy") && lookPath("pbpaste")
-
-	tool := DetectClipboardTool()
-
-	expectTool := (wayland && hasWLCopy) || (x11 && hasXClip) || hasPB
-	if expectTool && tool == nil {
-		t.Fatalf("environment has a usable clipboard (wayland=%v x11=%v wl=%v xclip=%v pb=%v) but DetectClipboardTool returned nil",
-			wayland, x11, hasWLCopy, hasXClip, hasPB)
+// detectClipboardToolEnv built from explicit getenv/lookPath closures, so the
+// whole Wayland / X11 / macOS / none decision table runs as a plain table test
+// with no compositor, no display, and no clipboard binaries on PATH.
+func envWith(g func(string) string, lp func(string) bool) detectClipboardToolEnv {
+	if g == nil {
+		g = func(string) string { return "" }
 	}
-	if !expectTool && tool != nil {
-		t.Fatalf("DetectClipboardTool returned %q but no clipboard tool is detectable in this environment", tool.name)
+	if lp == nil {
+		lp = func(string) bool { return false }
 	}
-	if tool != nil && (tool.copyCmd == nil || tool.pasteCmd == nil) {
-		t.Fatalf("tool %q has incomplete commands: copy=%v paste=%v", tool.name, tool.copyCmd, tool.pasteCmd)
+	return detectClipboardToolEnv{getenv: g, lookPath: lp}
+}
+
+// TestDetectClipboardToolTable pins the decision table. Each row names the
+// environment, what the host looks like, and which tool (if any) must be
+// found. This is the test Gaurav's review asked for: detection takes getenv and
+// lookPath as parameters, so the entire table is exercised without a
+// compositor and without the host machine's real environment leaking in.
+func TestDetectClipboardToolTable(t *testing.T) {
+	no := func(string) bool { return false }
+	waylandEnv := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
+	x11Env := map[string]string{"DISPLAY": ":0"}
+
+	tests := []struct {
+		name     string
+		getenv   func(string) string
+		lookPath func(string) bool
+		want     *clipboardTool
+	}{
+		{
+			name:     "wayland session with wl-clipboard",
+			getenv:   func(k string) string { return waylandEnv[k] },
+			lookPath: func(b string) bool { return b == "wl-copy" || b == "wl-paste" },
+			want:     &clipboardTool{name: "wl-clipboard", copyCmd: []string{"wl-copy"}, pasteCmd: []string{"wl-paste", "-n"}},
+		},
+		{
+			name:     "wayland session without wl-paste",
+			getenv:   func(k string) string { return waylandEnv[k] },
+			lookPath: func(b string) bool { return b == "wl-copy" },
+			want:     nil,
+		},
+		{
+			name:     "wayland env vars but no tool on path",
+			getenv:   func(k string) string { return waylandEnv[k] },
+			lookPath: no,
+			want:     nil,
+		},
+		{
+			name:     "x11 with xclip",
+			getenv:   func(k string) string { return x11Env[k] },
+			lookPath: func(b string) bool { return b == "xclip" },
+			want:     &clipboardTool{name: "xclip", copyCmd: []string{"xclip", "-selection", "clipboard"}, pasteCmd: []string{"xclip", "-selection", "clipboard", "-o"}},
+		},
+		{
+			name:     "x11 with xsel only",
+			getenv:   func(k string) string { return x11Env[k] },
+			lookPath: func(b string) bool { return b == "xsel" },
+			want:     &clipboardTool{name: "xsel", copyCmd: []string{"xsel", "--clipboard", "--input"}, pasteCmd: []string{"xsel", "--clipboard", "--output"}},
+		},
+		{
+			name:     "x11 without any tool",
+			getenv:   func(k string) string { return x11Env[k] },
+			lookPath: no,
+			want:     nil,
+		},
+		{
+			name:     "macOS with pbcopy/pbpaste",
+			lookPath: func(b string) bool { return b == "pbcopy" || b == "pbpaste" },
+			want:     &clipboardTool{name: "pbcopy/pbpaste", copyCmd: []string{"pbcopy"}, pasteCmd: []string{"pbpaste"}},
+		},
+		{
+			name:     "headless box with wl-clipboard but no display env",
+			getenv:   func(string) string { return "" },
+			lookPath: func(b string) bool { return b == "wl-copy" || b == "wl-paste" },
+			want:     nil, // no display socket -> tool unusable, must not be reported
+		},
+		{
+			name: "remote-like: XDG_RUNTIME_DIR set but no WAYLAND_DISPLAY",
+			getenv: func(k string) string {
+				if k == "XDG_RUNTIME_DIR" {
+					return "/run/user/1000"
+				}
+				return ""
+			},
+			lookPath: func(b string) bool { return b == "wl-copy" || b == "wl-paste" },
+			want:     nil, // half a wayland env is not a wayland session
+		},
+		{
+			name:     "nothing at all",
+			getenv:   nil,
+			lookPath: nil,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectClipboardTool(envWith(tt.getenv, tt.lookPath))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("detectClipboardTool() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldUseNativeClipboardDecision pins the gating that prevents the data
+// leak Gaurav flagged: the native path must be refused on any non-VTE host even
+// when a tool exists, and refused when the config option is off. The getenv
+// injection makes the whole matrix testable with no compositor and no real env.
+func TestShouldUseNativeClipboardDecision(t *testing.T) {
+	waylandWithTool := envWith(
+		func(k string) string {
+			m := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
+			return m[k]
+		},
+		func(b string) bool { return b == "wl-copy" || b == "wl-paste" },
+	)
+	noTool := envWith(
+		func(k string) string {
+			m := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
+			return m[k]
+		},
+		func(string) bool { return false },
+	)
+
+	tests := []struct {
+		name            string
+		env             detectClipboardToolEnv
+		hostIsVTE       bool
+		fallbackEnabled bool
+		want            bool
+	}{
+		{
+			name:            "VTE host + tool + fallback on → native path",
+			env:             waylandWithTool,
+			hostIsVTE:       true,
+			fallbackEnabled: true,
+			want:            true,
+		},
+		{
+			name:            "non-VTE host (kitty) + tool + fallback on → OSC 52 only",
+			env:             waylandWithTool,
+			hostIsVTE:       false,
+			fallbackEnabled: true,
+			want:            false, // kitty implements OSC 52; no spawned tool, no dup entries
+		},
+		{
+			name:            "VTE host + no tool + fallback on → OSC 52 only",
+			env:             noTool,
+			hostIsVTE:       true,
+			fallbackEnabled: true,
+			want:            false,
+		},
+		{
+			name:            "VTE host + tool + fallback OFF → OSC 52 only",
+			env:             waylandWithTool,
+			hostIsVTE:       true,
+			fallbackEnabled: false,
+			want:            false,
+		},
+		{
+			name:            "headless + fallback on → false",
+			env:             envWith(nil, nil),
+			hostIsVTE:       true,
+			fallbackEnabled: true,
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldUseNativeClipboard(tt.env, tt.hostIsVTE, tt.fallbackEnabled)
+			if got != tt.want {
+				t.Fatalf("shouldUseNativeClipboard() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
 // TestClipboardToolWriteReadLogic exercises Write/Read against a fake tool
 // built from shell commands that need no compositor (tee/cat to a temp file).
 // This is the deterministic part of the contract: Write launches the keeper
-// without blocking, Read captures stdout. The real wl-copy round trip is
-// covered by TestClipboardToolRoundTrip, which runs only when a Wayland socket
-// is actually reachable (never in the isolated test tree).
+// without blocking and reaps it, Read captures stdout. The real wl-copy round
+// trip is covered by TestClipboardToolRoundTrip, which runs only when a Wayland
+// socket is actually reachable (never in the isolated test tree).
 func TestClipboardToolWriteReadLogic(t *testing.T) {
 	clipFile := filepath.Join(t.TempDir(), "clip.txt")
 
@@ -50,7 +203,7 @@ func TestClipboardToolWriteReadLogic(t *testing.T) {
 	}
 
 	// Write must return without blocking (Start semantics) and the keeper
-	// process must have been launched.
+	// process must have been launched and reaped (no zombie).
 	if err := fake.Write("hello-tuios-clipboard"); err != nil {
 		t.Fatalf("Write failed: %v", err)
 	}
@@ -104,37 +257,5 @@ func TestClipboardToolRoundTrip(t *testing.T) {
 	if tool == nil {
 		t.Skip("no native clipboard tool detected in this environment")
 	}
-
-	// The package TestMain points XDG_RUNTIME_DIR at a temp tree. Without a
-	// real wayland socket there, wl-copy/wl-paste cannot reach any compositor,
-	// so the round trip is meaningless here. Detect that and skip.
-	rt := os.Getenv("XDG_RUNTIME_DIR")
-	if rt == "" || !strings.Contains(rt, "run/user") {
-		t.Skipf("XDG_RUNTIME_DIR=%q is not a real user runtime dir (test tree?), skipping live round trip", rt)
-	}
-	if _, err := os.Stat(filepath.Join(rt, os.Getenv("WAYLAND_DISPLAY"))); err != nil {
-		t.Skipf("no Wayland socket at %s/%s: %v", rt, os.Getenv("WAYLAND_DISPLAY"), err)
-	}
-
-	sentinel := "tuios-clipboard-test-" + strings.Repeat("x", 8)
-	if err := tool.Write(sentinel); err != nil {
-		t.Fatalf("Write failed: %v", err)
-	}
-	got, err := tool.Read()
-	if err != nil {
-		t.Fatalf("Read failed: %v (tool=%s, XDG_RUNTIME_DIR=%q, WAYLAND_DISPLAY=%q)",
-			err, tool.name, rt, os.Getenv("WAYLAND_DISPLAY"))
-	}
-	if !strings.Contains(got, "tuios-clipboard-test") {
-		t.Fatalf("round trip mismatch: wrote %q, read back %q", sentinel, got)
-	}
-}
-
-// TestLocalClipboardAvailableMatchesDetect checks that the boolean helper agrees
-// with DetectClipboardTool, so callers cannot see a tool through one and not
-// the other.
-func TestLocalClipboardAvailableMatchesDetect(t *testing.T) {
-	if LocalClipboardAvailable() != (DetectClipboardTool() != nil) {
-		t.Fatal("LocalClipboardAvailable() and DetectClipboardTool() disagree")
-	}
+	t.Skip("live round trip requires a compositor socket; run manually in a session")
 }

--- a/internal/app/clipboard_local_test.go
+++ b/internal/app/clipboard_local_test.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/config"
 )
 
 // detectClipboardToolEnv built from explicit getenv/lookPath closures, so the
@@ -113,11 +116,11 @@ func TestDetectClipboardToolTable(t *testing.T) {
 	}
 }
 
-// TestShouldUseNativeClipboardDecision pins the gating that prevents the data
-// leak Gaurav flagged: the native path must be refused on any non-VTE host even
-// when a tool exists, and refused when the config option is off. The getenv
+// TestNativeClipboardToolDecision pins the gating that prevents the data leak
+// Gaurav flagged: the native path must be refused on any non-VTE host even when
+// a tool exists, and refused when the config option is off. The getenv
 // injection makes the whole matrix testable with no compositor and no real env.
-func TestShouldUseNativeClipboardDecision(t *testing.T) {
+func TestNativeClipboardToolDecision(t *testing.T) {
 	waylandWithTool := envWith(
 		func(k string) string {
 			m := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
@@ -179,9 +182,9 @@ func TestShouldUseNativeClipboardDecision(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldUseNativeClipboard(tt.env, tt.hostIsVTE, tt.fallbackEnabled)
+			got := nativeClipboardToolFor(tt.env, tt.hostIsVTE, tt.fallbackEnabled) != nil
 			if got != tt.want {
-				t.Fatalf("shouldUseNativeClipboard() = %v, want %v", got, tt.want)
+				t.Fatalf("nativeClipboardToolFor() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -246,16 +249,80 @@ func TestClipboardToolWriteReadLogic(t *testing.T) {
 	}
 }
 
-// TestClipboardToolRoundTrip writes a sentinel through the real native tool
-// and reads it back. It only runs when a Wayland socket is actually reachable
-// from the test process: the package TestMain redirects XDG_RUNTIME_DIR to a
-// throwaway tree, so under `go test` this always skips — which is exactly what
-// we want, because the isolated tree has no compositor socket. Run it manually
-// (or in a non-isolated harness) to validate against a live session.
+// TestNativeClipboardToolGate pins the session half of the gate, which the
+// table above cannot see: a remote session (SSH or browser client) must never
+// reach for the native tool, because WAYLAND_DISPLAY / DISPLAY describe the
+// operator's desktop and a native read or write would move data between two
+// people. The tool must also be refused when the config option is off. These
+// rows return before any environment probing, so they are deterministic.
+func TestNativeClipboardToolGate(t *testing.T) {
+	if !config.DefaultSettings().ClipboardLocalFallback {
+		t.Fatalf("the fallback is off by default; this gate test assumes it on")
+	}
+	rows := []struct {
+		name string
+		os   *OS
+	}{
+		{"ssh session", &OS{Settings: config.DefaultSettings(), IsSSHMode: true}},
+		{"browser client", &OS{Settings: config.DefaultSettings(), BrowserClient: true}},
+		{"fallback off", &OS{Settings: func() config.Settings {
+			s := config.DefaultSettings()
+			s.ClipboardLocalFallback = false
+			return s
+		}()}},
+	}
+	for _, tt := range rows {
+		if got := tt.os.nativeClipboardTool(); got != nil {
+			t.Fatalf("%s reached for the native clipboard: %v", tt.name, got.name)
+		}
+	}
+}
+
+// TestClipboardToolRoundTrip writes a sentinel through a tool discovered the
+// way the real one is — DetectClipboardTool walking PATH — and reads it back.
+// The package TestMain points the environment at a throwaway tree, so
+// detection can never see the host session's compositor or real tools; this
+// test stubs wl-clipboard with shell scripts in a temp dir on PATH instead,
+// which exercises the same detection → Write → Read plumbing with no
+// compositor, and runs everywhere.
 func TestClipboardToolRoundTrip(t *testing.T) {
+	bin := t.TempDir()
+	clip := filepath.Join(bin, "clipboard")
+	stubs := map[string]string{
+		filepath.Join(bin, "wl-copy"):  "#!/bin/sh\ncat > " + clip + "\n",
+		filepath.Join(bin, "wl-paste"): "#!/bin/sh\nexec cat " + clip + "\n",
+	}
+	for path, body := range stubs {
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("stub %s: %v", path, err)
+		}
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Detection needs a Wayland session; name one explicitly, since the
+	// isolated test tree never has one. The scripts above stand in for the
+	// compositor.
+	t.Setenv("XDG_RUNTIME_DIR", bin)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+
 	tool := DetectClipboardTool()
 	if tool == nil {
-		t.Skip("no native clipboard tool detected in this environment")
+		t.Fatalf("detection did not find the stubbed wl-clipboard on PATH")
 	}
-	t.Skip("live round trip requires a compositor socket; run manually in a session")
+
+	const sentinel = "tuios-round-trip-sentinel"
+	if err := tool.Write(sentinel); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	// The stub keeper lands the bytes asynchronously (Start semantics, like
+	// the real wl-copy), so poll briefly instead of sleeping a fixed amount.
+	var got string
+	var err error
+	for i := 0; i < 100; i++ {
+		got, err = tool.Read()
+		if err == nil && got == sentinel {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("round trip mismatch: wrote %q, read back %q (err=%v)", sentinel, got, err)
 }

--- a/internal/app/clipboard_local_test.go
+++ b/internal/app/clipboard_local_test.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDetectClipboardToolMatchesEnv verifies that detection is consistent with
+// the environment: when a Wayland session + wl-clipboard are present we must
+// find a tool; when neither display nor tool exists we must return nil. This
+// keeps the guard logic honest without requiring a compositor in CI.
+func TestDetectClipboardToolMatchesEnv(t *testing.T) {
+	wayland := os.Getenv("WAYLAND_DISPLAY") != "" && os.Getenv("XDG_RUNTIME_DIR") != ""
+	x11 := os.Getenv("DISPLAY") != ""
+	hasWLCopy := lookPath("wl-copy") && lookPath("wl-paste")
+	hasXClip := lookPath("xclip") || lookPath("xsel")
+	hasPB := lookPath("pbcopy") && lookPath("pbpaste")
+
+	tool := DetectClipboardTool()
+
+	expectTool := (wayland && hasWLCopy) || (x11 && hasXClip) || hasPB
+	if expectTool && tool == nil {
+		t.Fatalf("environment has a usable clipboard (wayland=%v x11=%v wl=%v xclip=%v pb=%v) but DetectClipboardTool returned nil",
+			wayland, x11, hasWLCopy, hasXClip, hasPB)
+	}
+	if !expectTool && tool != nil {
+		t.Fatalf("DetectClipboardTool returned %q but no clipboard tool is detectable in this environment", tool.name)
+	}
+	if tool != nil && (tool.copyCmd == nil || tool.pasteCmd == nil) {
+		t.Fatalf("tool %q has incomplete commands: copy=%v paste=%v", tool.name, tool.copyCmd, tool.pasteCmd)
+	}
+}
+
+// TestClipboardToolWriteReadLogic exercises Write/Read against a fake tool
+// built from shell commands that need no compositor (tee/cat to a temp file).
+// This is the deterministic part of the contract: Write launches the keeper
+// without blocking, Read captures stdout. The real wl-copy round trip is
+// covered by TestClipboardToolRoundTrip, which runs only when a Wayland socket
+// is actually reachable (never in the isolated test tree).
+func TestClipboardToolWriteReadLogic(t *testing.T) {
+	clipFile := filepath.Join(t.TempDir(), "clip.txt")
+
+	fake := &clipboardTool{
+		name:     "fake-file",
+		copyCmd:  []string{"sh", "-c", "cat > " + clipFile},
+		pasteCmd: []string{"cat", clipFile},
+	}
+
+	// Write must return without blocking (Start semantics) and the keeper
+	// process must have been launched.
+	if err := fake.Write("hello-tuios-clipboard"); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// The fake keeper writes asynchronously (Start semantics, like wl-copy's
+	// real keeper), so poll briefly for the content instead of sleeping: a
+	// real wl-copy keeper stays alive until replaced, which is fine — we only
+	// care that the content reached the clipboard.
+	var got string
+	for i := 0; i < 50; i++ {
+		var err error
+		got, err = fake.Read()
+		if err == nil && strings.Contains(got, "hello-tuios-clipboard") {
+			break
+		}
+		// tiny sleep to let the keeper land the bytes
+		time.Sleep(10 * time.Millisecond)
+		if i == 49 {
+			t.Fatalf("round trip mismatch: wrote %q, read back %q (err=%v)", "hello-tuios-clipboard", got, err)
+		}
+	}
+
+	// Write again with new content: the second keeper must replace the first
+	// (for wl-clipboard this is a natural handoff; for the fake it is a new
+	// write to the same file).
+	if err := fake.Write("second-write"); err != nil {
+		t.Fatalf("second Write failed: %v", err)
+	}
+	var got2 string
+	for i := 0; i < 50; i++ {
+		var err error
+		got2, err = fake.Read()
+		if err == nil && strings.Contains(got2, "second-write") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+		if i == 49 {
+			t.Fatalf("second round trip mismatch: read back %q (err=%v)", got2, err)
+		}
+	}
+}
+
+// TestClipboardToolRoundTrip writes a sentinel through the real native tool
+// and reads it back. It only runs when a Wayland socket is actually reachable
+// from the test process: the package TestMain redirects XDG_RUNTIME_DIR to a
+// throwaway tree, so under `go test` this always skips — which is exactly what
+// we want, because the isolated tree has no compositor socket. Run it manually
+// (or in a non-isolated harness) to validate against a live session.
+func TestClipboardToolRoundTrip(t *testing.T) {
+	tool := DetectClipboardTool()
+	if tool == nil {
+		t.Skip("no native clipboard tool detected in this environment")
+	}
+
+	// The package TestMain points XDG_RUNTIME_DIR at a temp tree. Without a
+	// real wayland socket there, wl-copy/wl-paste cannot reach any compositor,
+	// so the round trip is meaningless here. Detect that and skip.
+	rt := os.Getenv("XDG_RUNTIME_DIR")
+	if rt == "" || !strings.Contains(rt, "run/user") {
+		t.Skipf("XDG_RUNTIME_DIR=%q is not a real user runtime dir (test tree?), skipping live round trip", rt)
+	}
+	if _, err := os.Stat(filepath.Join(rt, os.Getenv("WAYLAND_DISPLAY"))); err != nil {
+		t.Skipf("no Wayland socket at %s/%s: %v", rt, os.Getenv("WAYLAND_DISPLAY"), err)
+	}
+
+	sentinel := "tuios-clipboard-test-" + strings.Repeat("x", 8)
+	if err := tool.Write(sentinel); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	got, err := tool.Read()
+	if err != nil {
+		t.Fatalf("Read failed: %v (tool=%s, XDG_RUNTIME_DIR=%q, WAYLAND_DISPLAY=%q)",
+			err, tool.name, rt, os.Getenv("WAYLAND_DISPLAY"))
+	}
+	if !strings.Contains(got, "tuios-clipboard-test") {
+		t.Fatalf("round trip mismatch: wrote %q, read back %q", sentinel, got)
+	}
+}
+
+// TestLocalClipboardAvailableMatchesDetect checks that the boolean helper agrees
+// with DetectClipboardTool, so callers cannot see a tool through one and not
+// the other.
+func TestLocalClipboardAvailableMatchesDetect(t *testing.T) {
+	if LocalClipboardAvailable() != (DetectClipboardTool() != nil) {
+		t.Fatal("LocalClipboardAvailable() and DetectClipboardTool() disagree")
+	}
+}

--- a/internal/app/clipboard_paste.go
+++ b/internal/app/clipboard_paste.go
@@ -41,6 +41,21 @@ func (m *OS) ClipboardReadUnsupportedReason() string {
 // RequestHostPaste asks the terminal for its clipboard, or says why it cannot.
 // It is the one way in: the paste key and the pane menu's Paste row both call
 // it, so neither can offer a paste the other has already found impossible.
+//
+// Everything the model owns happens here, on the Update loop: the
+// unsupported-notice, the sequence bump, the deadline, and the decision of
+// whether a native tool is reachable (one detection, in nativeClipboardTool).
+// The deadline is armed up front for both read paths: the native read is
+// bounded by its own timeout inside the tool, and if it eats into or outlives
+// the deadline, the report fires on time and a late answer still pastes.
+//
+// The Cmd this returns closes over plain local values — the sequence and the
+// tool — and only reads: the native clipboard when a tool was found and
+// answers, and, when that read fails, the OSC 52 query the terminal itself may
+// answer. Nothing touches the model off the loop; an earlier draft of the
+// native fallback re-entered RequestHostPaste from inside the Cmd goroutine,
+// bumping pasteSeq under the Update loop's feet, which is the race this shape
+// removes.
 func (m *OS) RequestHostPaste() tea.Cmd {
 	if reason := m.ClipboardReadUnsupportedReason(); reason != "" {
 		m.ShowNotification(reason, "warning", m.Settings.NotificationDuration)
@@ -49,9 +64,21 @@ func (m *OS) RequestHostPaste() tea.Cmd {
 	m.pasteSeq++
 	m.pastePending = true
 	seq := m.pasteSeq
+
+	tool := m.nativeClipboardTool()
 	return tea.Batch(
-		tea.ReadClipboard,
 		tea.Tick(hostPasteTimeout, func(time.Time) tea.Msg { return PasteTimeoutMsg{Seq: seq} }),
+		func() tea.Msg {
+			if tool != nil {
+				if text, err := tool.Read(); err == nil {
+					return tea.ClipboardMsg{Content: text, Selection: 'c'}
+				}
+				// Native read failed (hung tool, empty selection, compositor
+				// gone): fall back to the OSC 52 read, which terminals that
+				// implement it answer with a tea.ClipboardMsg.
+			}
+			return tea.ReadClipboard()
+		},
 	)
 }
 

--- a/internal/app/link_open.go
+++ b/internal/app/link_open.go
@@ -54,7 +54,7 @@ func (m *OS) CopyLink(rawURL string) tea.Cmd {
 		return nil
 	}
 	m.ShowNotification("Copied the link.", "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(rawURL)
+	return m.WriteClipboard(rawURL)
 }
 
 // OpenLink performs the default action for a link.
@@ -76,20 +76,20 @@ func (m *OS) OpenLink(rawURL string) tea.Cmd {
 	if !linkOpenableScheme(rawURL) {
 		m.ShowNotification("tuios can not open that kind of link. The address is on your clipboard.",
 			"warning", m.Settings.NotificationDuration)
-		return tea.SetClipboard(rawURL)
+		return m.WriteClipboard(rawURL)
 	}
 
 	// Not a local file, so it needs the viewer's own machine.
 	if m.IsRemoteClient() {
 		m.ShowNotification("Copied the link. A remote client can not open it for you.",
 			"info", m.Settings.NotificationDuration)
-		return tea.SetClipboard(rawURL)
+		return m.WriteClipboard(rawURL)
 	}
 	if err := openInOSViewer(rawURL); err != nil {
 		m.LogError("Failed to open link %s: %v", rawURL, err)
 		m.ShowNotification("Could not open the link. It is on your clipboard.",
 			"error", m.Settings.NotificationDuration)
-		return tea.SetClipboard(rawURL)
+		return m.WriteClipboard(rawURL)
 	}
 	m.ShowNotification("Opened the link.", "success", m.Settings.NotificationDuration)
 	return nil
@@ -147,7 +147,7 @@ func (m *OS) openLocalPath(path, rawURL string) tea.Cmd {
 	if err != nil {
 		m.ShowNotification("That file is gone. The link is on your clipboard.",
 			"warning", m.Settings.NotificationDuration)
-		return tea.SetClipboard(rawURL)
+		return m.WriteClipboard(rawURL)
 	}
 	if info.IsDir() {
 		return m.openDirectoryLink(path)
@@ -175,7 +175,7 @@ func (m *OS) openDirectoryLink(path string) tea.Cmd {
 	}
 	m.ShowNotification("Copied the folder path. Turn the sidebar on to browse it.",
 		"info", m.Settings.NotificationDuration)
-	return tea.SetClipboard(path)
+	return m.WriteClipboard(path)
 }
 
 // linkEditor is the argv the editor pane runs. $EDITOR then $VISUAL then vi, in

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -439,6 +439,7 @@ func (m *OS) settingsCategories() []settingsCategory {
 			opt("appearance.scrollback_lines"),
 			opt("appearance.scroll_lines"),
 			opt("appearance.copy_on_select"),
+			opt("appearance.clipboard_local_fallback"),
 			opt("appearance.word_characters"),
 			opt("appearance.zoom_max_width"),
 			custom("debug.show_key_events", m.showKeysItem()),

--- a/internal/app/sidebar_files.go
+++ b/internal/app/sidebar_files.go
@@ -549,7 +549,7 @@ func (m *OS) fileViewOpen(dir, name string, isDir bool) tea.Cmd {
 		return cmd
 	}
 	m.ShowNotification("Copied the path.", "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(full)
+	return m.WriteClipboard(full)
 }
 
 // FileViewCd sends a cd to the pane the section was opened from, for the

--- a/internal/config/hostterm.go
+++ b/internal/config/hostterm.go
@@ -58,12 +58,6 @@ func detectHostTerminal(getenv func(string) string) HostTerminal {
 	if getenv("ALACRITTY_WINDOW_ID") != "" || getenv("ALACRITTY_SOCKET") != "" {
 		return HostAlacritty
 	}
-	// VTE-based terminals (GNOME Terminal, Ptyxis, Tilix) set VTE_VERSION.
-	// This is the marker the native clipboard fallback keys off: VTE never
-	// implements OSC 52, so the host needs the system tool instead.
-	if getenv("VTE_VERSION") != "" {
-		return HostVTE
-	}
 	if getenv("WEZTERM_EXECUTABLE") != "" {
 		return HostWezTerm
 	}
@@ -76,6 +70,12 @@ func detectHostTerminal(getenv func(string) string) HostTerminal {
 		return HostAlacritty
 	case strings.Contains(term, "rio"):
 		return HostRio
+	}
+	// VTE-based terminals (GNOME Terminal, Ptyxis, Tilix) set VTE_VERSION.
+	// This is the marker the native clipboard fallback keys off: VTE never
+	// implements OSC 52, so the host needs the system tool instead.
+	if getenv("VTE_VERSION") != "" {
+		return HostVTE
 	}
 	return HostUnknown
 }

--- a/internal/config/hostterm.go
+++ b/internal/config/hostterm.go
@@ -19,6 +19,7 @@ const (
 	HostKitty         HostTerminal = "kitty"
 	HostWezTerm       HostTerminal = "WezTerm"
 	HostAlacritty     HostTerminal = "Alacritty"
+	HostVTE           HostTerminal = "VTE"
 	HostVSCode        HostTerminal = "VS Code"
 	HostRio           HostTerminal = "Rio"
 	HostWarp          HostTerminal = "Warp"
@@ -56,6 +57,12 @@ func detectHostTerminal(getenv func(string) string) HostTerminal {
 	}
 	if getenv("ALACRITTY_WINDOW_ID") != "" || getenv("ALACRITTY_SOCKET") != "" {
 		return HostAlacritty
+	}
+	// VTE-based terminals (GNOME Terminal, Ptyxis, Tilix) set VTE_VERSION.
+	// This is the marker the native clipboard fallback keys off: VTE never
+	// implements OSC 52, so the host needs the system tool instead.
+	if getenv("VTE_VERSION") != "" {
+		return HostVTE
 	}
 	if getenv("WEZTERM_EXECUTABLE") != "" {
 		return HostWezTerm
@@ -131,3 +138,12 @@ func MacOptionAdvice(host HostTerminal, chord string) string {
 // reach tuios even with macos-option-as-alt on and the Kitty protocol negotiated.
 const GhosttyAltArrowAdvice = "Ghostty rewrites alt+left/alt+right to word motions: " +
 	"add keybind = alt+left=unbind and keybind = alt+right=unbind to unbind them"
+
+// HostIsVTE reports whether the outer terminal is built on VTE (GNOME Terminal,
+// Ptyxis, Tilix...). VTE terminals never implement OSC 52, so tuios needs the
+// native system clipboard path to reach the user's clipboard there. Everywhere
+// else, OSC 52 is the preferred channel and a spawned clipboard tool would only
+// duplicate entries in the clipboard manager.
+func HostIsVTE() bool {
+	return detectHostTerminal(os.Getenv) == HostVTE
+}

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -132,6 +132,11 @@ var optionSpecs = []Option{
 		Default:     "true",
 	},
 	{
+		Path: "appearance.clipboard_local_fallback", Type: OptionBool, Section: "appearance",
+		Description: "Use the native system clipboard (wl-copy/xclip/pbcopy) when available",
+		Default:     "true",
+	},
+	{
 		Path: "appearance.focus_follows_mouse", Type: OptionBool, Section: "appearance",
 		Description: "Focus the pane under the cursor as the mouse moves",
 		Default:     "false",

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -249,6 +249,17 @@ type Settings struct {
 	// Set via appearance.copy_on_select config.
 	CopyOnSelect bool
 
+	// ClipboardLocalFallback writes to and reads from a native system clipboard
+	// tool (wl-copy/wl-paste, xclip, pbcopy) when one is reachable, instead of
+	// depending on the terminal implementing OSC 52. Terminals built on VTE
+	// (GNOME Terminal, Ptyxis) never implement OSC 52, so copy/paste silently
+	// failed there. The native path also emits OSC 52, so terminals that do
+	// implement it get the same text twice (idempotent) and remote clients with
+	// no native clipboard of their own still work. Turn it off to force the pure
+	// OSC 52 path.
+	// Set via appearance.clipboard_local_fallback config.
+	ClipboardLocalFallback bool
+
 	// FocusFollowsMouse focuses the pane under the cursor as the mouse moves over
 	// it, without a click and without entering terminal mode. It is a divisive
 	// window-manager habit, so it defaults off and users opt in.
@@ -413,6 +424,7 @@ func DefaultSettings() Settings {
 		ScrollbackLines:             DefaultScrollbackLines,
 		ScrollLines:                 3,
 		CopyOnSelect:                true,
+		ClipboardLocalFallback:      true,
 		FocusFollowsMouse:           false,
 		AltDrag:                     true,
 		ClickToType:                 ClickToTypeSingle,

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -150,34 +150,34 @@ type DaemonConfig struct {
 
 // AppearanceConfig holds appearance-related settings
 type AppearanceConfig struct {
-	BorderStyle          string  `toml:"border_style"`           // Border style: rounded, normal, thick, double, hidden, block, ascii, outer-half-block, inner-half-block (borderless mode not yet implemented)
-	ZenMode              string  `toml:"zen_mode"`               // Zen mode: disabled, always, mouse (default: disabled)
-	Links                string  `toml:"links"`                  // Links tuios acts on: off, marked, all (default: all)
-	HideWindowButtons    bool    `toml:"hide_window_buttons"`    // Hide window control buttons (minimize, maximize, close)
-	WindowButtonStyle    string  `toml:"window_button_style"`    // Window control style: pill, dots (default: pill)
-	WindowButtonPosition string  `toml:"window_button_position"` // Which end of the title bar the window controls sit on: right, left (default: right)
-	HideScrollbar        bool    `toml:"hide_scrollbar"`         // Hide the window scrollbar thumb on the border
-	ScrollbackLines      int     `toml:"scrollback_lines"`       // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
-	ScrollLines          int     `toml:"scroll_lines"`           // Lines scrolled per mouse wheel notch (default: 3, min: 1, max: 50)
-	CopyOnSelect         *bool   `toml:"copy_on_select"`         // Copy a mouse selection to the clipboard on release (default: true)
+	BorderStyle            string  `toml:"border_style"`             // Border style: rounded, normal, thick, double, hidden, block, ascii, outer-half-block, inner-half-block (borderless mode not yet implemented)
+	ZenMode                string  `toml:"zen_mode"`                 // Zen mode: disabled, always, mouse (default: disabled)
+	Links                  string  `toml:"links"`                    // Links tuios acts on: off, marked, all (default: all)
+	HideWindowButtons      bool    `toml:"hide_window_buttons"`      // Hide window control buttons (minimize, maximize, close)
+	WindowButtonStyle      string  `toml:"window_button_style"`      // Window control style: pill, dots (default: pill)
+	WindowButtonPosition   string  `toml:"window_button_position"`   // Which end of the title bar the window controls sit on: right, left (default: right)
+	HideScrollbar          bool    `toml:"hide_scrollbar"`           // Hide the window scrollbar thumb on the border
+	ScrollbackLines        int     `toml:"scrollback_lines"`         // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
+	ScrollLines            int     `toml:"scroll_lines"`             // Lines scrolled per mouse wheel notch (default: 3, min: 1, max: 50)
+	CopyOnSelect           *bool   `toml:"copy_on_select"`           // Copy a mouse selection to the clipboard on release (default: true)
 	ClipboardLocalFallback *bool   `toml:"clipboard_local_fallback"` // Use native system clipboard (wl-copy/xclip/pbcopy) when available (default: true)
-	FocusFollowsMouse    *bool   `toml:"focus_follows_mouse"`    // Focus the pane under the cursor as the mouse moves (default: false)
-	AltDrag              *bool   `toml:"alt_drag"`               // Alt + left-drag moves a pane (default: true)
-	ClickToType          string  `toml:"click_to_type"`          // What a click on a pane's content does in window-management mode: single, double, off (default: single)
-	WordCharacters       *string `toml:"word_characters"`        // Punctuation that counts as part of a word for double-click selection (default: "@-./_~?&=%+#")
-	DockbarPosition      string  `toml:"dockbar_position"`       // Dockbar position: bottom, top, hidden
-	PreferredShell       string  `toml:"preferred_shell"`        // Preferred shell: if empty, auto-detect based on platform.
-	AnimationsEnabled    *bool   `toml:"animations_enabled"`     // Enable UI animations (default: true). Set to false for instant transitions.
-	ConfirmQuit          *bool   `toml:"confirm_quit"`           // Always show quit confirmation dialog (default: false). When false, only shown if foreground processes are running.
-	WhichKeyEnabled      *bool   `toml:"whichkey_enabled"`       // Show which-key popup after pressing leader key (default: true)
-	WhichKeyPosition     string  `toml:"whichkey_position"`      // Which-key popup position: bottom-right, bottom-left, top-right, top-left, center (default: bottom-right)
-	WindowTitlePosition  string  `toml:"window_title_position"`  // Window title position: bottom, top, hidden (default: bottom). Shows CustomName if set, else terminal title.
-	HideClock            bool    `toml:"hide_clock"`             // Hide the clock overlay (deprecated, use show_clock)
-	ShowClock            bool    `toml:"show_clock"`             // Show the clock overlay (default: false)
-	ShowCPU              bool    `toml:"show_cpu"`               // Show CPU graph in dock (default: false)
-	ShowRAM              bool    `toml:"show_ram"`               // Show RAM usage in dock (default: false)
-	Theme                string  `toml:"theme"`                  // Color theme name (e.g., dracula, nord, my-custom-theme)
-	SharedBorders        *bool   `toml:"shared_borders"`         // Share borders between adjacent tiled windows (default: false)
+	FocusFollowsMouse      *bool   `toml:"focus_follows_mouse"`      // Focus the pane under the cursor as the mouse moves (default: false)
+	AltDrag                *bool   `toml:"alt_drag"`                 // Alt + left-drag moves a pane (default: true)
+	ClickToType            string  `toml:"click_to_type"`            // What a click on a pane's content does in window-management mode: single, double, off (default: single)
+	WordCharacters         *string `toml:"word_characters"`          // Punctuation that counts as part of a word for double-click selection (default: "@-./_~?&=%+#")
+	DockbarPosition        string  `toml:"dockbar_position"`         // Dockbar position: bottom, top, hidden
+	PreferredShell         string  `toml:"preferred_shell"`          // Preferred shell: if empty, auto-detect based on platform.
+	AnimationsEnabled      *bool   `toml:"animations_enabled"`       // Enable UI animations (default: true). Set to false for instant transitions.
+	ConfirmQuit            *bool   `toml:"confirm_quit"`             // Always show quit confirmation dialog (default: false). When false, only shown if foreground processes are running.
+	WhichKeyEnabled        *bool   `toml:"whichkey_enabled"`         // Show which-key popup after pressing leader key (default: true)
+	WhichKeyPosition       string  `toml:"whichkey_position"`        // Which-key popup position: bottom-right, bottom-left, top-right, top-left, center (default: bottom-right)
+	WindowTitlePosition    string  `toml:"window_title_position"`    // Window title position: bottom, top, hidden (default: bottom). Shows CustomName if set, else terminal title.
+	HideClock              bool    `toml:"hide_clock"`               // Hide the clock overlay (deprecated, use show_clock)
+	ShowClock              bool    `toml:"show_clock"`               // Show the clock overlay (default: false)
+	ShowCPU                bool    `toml:"show_cpu"`                 // Show CPU graph in dock (default: false)
+	ShowRAM                bool    `toml:"show_ram"`                 // Show RAM usage in dock (default: false)
+	Theme                  string  `toml:"theme"`                    // Color theme name (e.g., dracula, nord, my-custom-theme)
+	SharedBorders          *bool   `toml:"shared_borders"`           // Share borders between adjacent tiled windows (default: false)
 	// Customization
 	BorderFocusedColor     string `toml:"border_focused_color"`      // Hex color for focused pane border (e.g., "#89b4fa")
 	BorderUnfocusedColor   string `toml:"border_unfocused_color"`    // Hex color for unfocused pane border (e.g., "#585b70")

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -160,6 +160,7 @@ type AppearanceConfig struct {
 	ScrollbackLines      int     `toml:"scrollback_lines"`       // Number of lines to keep in scrollback buffer (default: 10000, min: 100, max: 1000000)
 	ScrollLines          int     `toml:"scroll_lines"`           // Lines scrolled per mouse wheel notch (default: 3, min: 1, max: 50)
 	CopyOnSelect         *bool   `toml:"copy_on_select"`         // Copy a mouse selection to the clipboard on release (default: true)
+	ClipboardLocalFallback *bool   `toml:"clipboard_local_fallback"` // Use native system clipboard (wl-copy/xclip/pbcopy) when available (default: true)
 	FocusFollowsMouse    *bool   `toml:"focus_follows_mouse"`    // Focus the pane under the cursor as the mouse moves (default: false)
 	AltDrag              *bool   `toml:"alt_drag"`               // Alt + left-drag moves a pane (default: true)
 	ClickToType          string  `toml:"click_to_type"`          // What a click on a pane's content does in window-management mode: single, double, off (default: single)
@@ -1356,6 +1357,11 @@ func ApplyAppearanceConfig(cfg *UserConfig, s *Settings) {
 	// CopyOnSelect defaults to true (nil means use default)
 	if cfg.Appearance.CopyOnSelect != nil {
 		s.CopyOnSelect = *cfg.Appearance.CopyOnSelect
+	}
+
+	// ClipboardLocalFallback defaults to true (nil means use default)
+	if cfg.Appearance.ClipboardLocalFallback != nil {
+		ClipboardLocalFallback = *cfg.Appearance.ClipboardLocalFallback
 	}
 
 	// FocusFollowsMouse defaults to false; a pointer so turning it off in the

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -1361,7 +1361,7 @@ func ApplyAppearanceConfig(cfg *UserConfig, s *Settings) {
 
 	// ClipboardLocalFallback defaults to true (nil means use default)
 	if cfg.Appearance.ClipboardLocalFallback != nil {
-		ClipboardLocalFallback = *cfg.Appearance.ClipboardLocalFallback
+		s.ClipboardLocalFallback = *cfg.Appearance.ClipboardLocalFallback
 	}
 
 	// FocusFollowsMouse defaults to false; a pointer so turning it off in the

--- a/internal/input/clipboard_paste_key_test.go
+++ b/internal/input/clipboard_paste_key_test.go
@@ -1,0 +1,106 @@
+package input
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+	"github.com/Gaurav-Gosain/tuios/internal/terminal"
+)
+
+// pasteKeyOS builds an OS in terminal mode with a focused window, ready to
+// route the terminal_paste_host key the way a real session would.
+func pasteKeyOS(t *testing.T, mutate func(*app.OS)) *app.OS {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	o := app.NewOS(app.OSOptions{
+		UserConfig:      cfg,
+		KeybindRegistry: config.NewKeybindRegistry(cfg),
+	})
+	o.Width, o.Height = 120, 40
+	o.EffectiveWidth, o.EffectiveHeight = 120, 40
+	o.Windows = []*terminal.Window{
+		{ID: "a", CustomName: "editor", X: 0, Y: 0, Width: 60, Height: 30, Workspace: 1},
+	}
+	o.CurrentWorkspace, o.FocusedWindow = 1, 0
+	o.Mode = app.TerminalMode
+	o.Settings = config.DefaultSettings()
+	if mutate != nil {
+		mutate(o)
+	}
+	return o
+}
+
+// pasteKey is the physical chord the default config binds to terminal_paste_host.
+func pasteKey() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl | tea.ModShift}
+}
+
+// lastNotificationMessage returns the most recent notification's message.
+func lastNotificationMessage(o *app.OS) string {
+	if len(o.Notifications) == 0 {
+		return ""
+	}
+	return o.Notifications[len(o.Notifications)-1].Message
+}
+
+// TestBrowserPasteKeySaysWhy checks that a browser client's paste key says why
+// paste cannot work instead of quietly waiting forever.
+//
+// The terminal in a browser tab never answers the OSC 52 read query, and
+// bubbletea's ReadClipboard has no deadline, so a bare read there would wait
+// forever with nothing on screen. Routing the key through RequestHostPaste
+// makes it say at once what is wrong and which key does work.
+func TestBrowserPasteKeySaysWhy(t *testing.T) {
+	o := pasteKeyOS(t, func(o *app.OS) {
+		o.BrowserClient = true
+		o.RemoteClient = true
+	})
+
+	o2, cmd := HandleKeyPress(pasteKey(), o)
+
+	if cmd != nil {
+		t.Fatalf("the browser paste key sent a clipboard query that can never be answered")
+	}
+	msg := lastNotificationMessage(o2)
+	if msg == "" {
+		t.Fatalf("the browser paste key did nothing and said nothing")
+	}
+	if !strings.Contains(msg, "ctrl+v") {
+		t.Fatalf("the message does not say what to do instead: %q", msg)
+	}
+}
+
+// TestPasteKeyArmsTheDeadline checks that the paste key routes through
+// RequestHostPaste, whose reply is a batch that arms the OSC 52 timeout.
+// A bare tea.ReadClipboard has no deadline, so a terminal that never answers
+// would look broken instead of being reported.
+func TestPasteKeyArmsTheDeadline(t *testing.T) {
+	o := pasteKeyOS(t, nil)
+
+	o2, cmd := HandleKeyPress(pasteKey(), o)
+
+	if cmd == nil {
+		t.Fatalf("a terminal client's paste key produced no command")
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.BatchMsg); !ok {
+		t.Fatalf("the paste key returned %T, not a batch; the timeout is not armed", msg)
+	}
+	// The batch must carry the read query; a batch that only ticks and never
+	// reads would arm a deadline nobody is waiting on.
+	found := false
+	for _, c := range msg.(tea.BatchMsg) {
+		if c != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the batch contains no commands at all")
+	}
+	if o2 == nil {
+		t.Fatalf("the paste key returned a nil OS")
+	}
+}

--- a/internal/input/copymode_clipboard_test.go
+++ b/internal/input/copymode_clipboard_test.go
@@ -1,0 +1,103 @@
+package input
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/app"
+	"github.com/Gaurav-Gosain/tuios/internal/config"
+)
+
+// stubClipboardSession points the test process at a throwaway wl-clipboard:
+// shell-script stubs on a temp PATH, a named Wayland session, and VTE_VERSION
+// set. It returns the file the wl-copy stub writes to. The app package keeps
+// the same helper for its own clipboard tests; a test in this package cannot
+// import it, so it lives here too.
+func stubClipboardSession(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	clip := filepath.Join(bin, "clipboard")
+	stubs := map[string]string{
+		filepath.Join(bin, "wl-copy"):  "#!/bin/sh\ncat > " + clip + "\n",
+		filepath.Join(bin, "wl-paste"): "#!/bin/sh\nexec cat " + clip + "\n",
+	}
+	for path, body := range stubs {
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("stub %s: %v", path, err)
+		}
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("XDG_RUNTIME_DIR", bin)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("VTE_VERSION", "1")
+	// VTE_VERSION is the LAST marker detectHostTerminal consults, after
+	// TERM_PROGRAM, KITTY_WINDOW_ID, WEZTERM_EXECUTABLE, TERM, etc. A dev
+	// machine's real terminal would otherwise win over the stubbed session, so
+	// blank every earlier marker and leave VTE_VERSION as the only one.
+	for _, k := range []string{
+		"TERM_PROGRAM", "KITTY_WINDOW_ID", "GHOSTTY_RESOURCES_DIR",
+		"GHOSTTY_BIN_DIR", "ALACRITTY_WINDOW_ID", "ALACRITTY_SOCKET",
+		"WEZTERM_EXECUTABLE", "TERM",
+	} {
+		t.Setenv(k, "")
+	}
+	return clip
+}
+
+var yankedRe = regexp.MustCompile(`Yanked (\d+) chars`)
+
+// TestCopyModeYankReachesNativeTool pins copy mode's yank to the native write
+// path. "y" routes through copyModeEffects.SetClipboard, and apply hands the
+// text to app.OS.WriteClipboard, which runs wl-copy on a VTE host. If apply
+// regressed to a bare tea.SetClipboard (OSC 52 only), the yank would never
+// touch the native tool and the wl-copy stub would receive nothing — which is
+// exactly what this test fails on. The units and the decision table are covered
+// elsewhere; this is the wiring test between them.
+func TestCopyModeYankReachesNativeTool(t *testing.T) {
+	clip := stubClipboardSession(t)
+	win := newCopyModeWindow(t, "copymode-clip-0001")
+	o := &app.OS{Settings: config.DefaultSettings(), Mode: app.WindowManagementMode}
+
+	// Jump to the top of the buffer so the cursor sits on real content
+	// ("alpha beta gamma delta..."), then select in visual char mode and yank
+	// the way a user would. Without the jump the cursor starts past the last
+	// written cell and the yank comes back empty.
+	HandleCopyModeKey(key("g"), o, win) // gg: top of the buffer
+	HandleCopyModeKey(key("g"), o, win)
+	HandleCopyModeKey(key("v"), o, win)
+	HandleCopyModeKey(key("l"), o, win)
+	_, cmd := HandleCopyModeKey(key("y"), o, win)
+	if cmd == nil {
+		t.Fatalf("y in visual mode returned no command")
+	}
+
+	// The handler reports how many chars it yanked; the native write must land
+	// exactly that text in the stub.
+	var yanked int
+	for _, msg := range notificationMessages(o) {
+		if m := yankedRe.FindStringSubmatch(msg); m != nil {
+			yanked, _ = strconv.Atoi(m[1])
+		}
+	}
+	if yanked == 0 {
+		t.Fatalf("no yank notification; copy mode did not yank: %v", notificationMessages(o))
+	}
+
+	cmd() // apply's WriteClipboard Cmd: native write to the stub, then OSC 52
+
+	// The wl-copy stub keeper lands the bytes asynchronously (Start semantics),
+	// so poll briefly instead of sleeping a fixed amount.
+	for i := 0; i < 100; i++ {
+		got, err := os.ReadFile(clip)
+		if err == nil && len(got) == yanked {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got, _ := os.ReadFile(clip)
+	t.Fatalf("the yank never reached wl-copy: stub holds %d chars (%q), want %d", len(got), got, yanked)
+}

--- a/internal/input/copymode_effects.go
+++ b/internal/input/copymode_effects.go
@@ -88,8 +88,8 @@ func (fx *copyModeEffects) apply(o *app.OS, window *terminal.Window) (*app.OS, t
 	if fx.enterTerminal && o != nil {
 		cmd = o.EnterTerminalMode()
 	}
-	if fx.setClipboard {
-		cmd = tea.SetClipboard(fx.clipboard)
+	if fx.setClipboard && o != nil {
+		cmd = o.WriteClipboard(fx.clipboard)
 	}
 	return o, cmd
 }

--- a/internal/input/handler.go
+++ b/internal/input/handler.go
@@ -82,9 +82,9 @@ func HandleInput(msg tea.Msg, o *app.OS) (tea.Model, tea.Cmd) {
 		}
 		return o, nil
 	case tea.ClipboardMsg:
-		// Handle OSC 52 clipboard read response (from tea.ReadClipboard).
-		// The terminal answered, so the pending query's timeout is disarmed
-		// whatever mode this client is in.
+		// A paste answer arrived - the terminal's OSC 52 reply or the native
+		// tool's read, both end here - so the pending query's timeout is
+		// disarmed whatever mode this client is in.
 		o.NotePasteArrived()
 		// Only handle paste in terminal mode
 		if o.Mode == app.TerminalMode {

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -331,7 +331,13 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	// convention.
 	if sectionAction(msg, o, (*config.KeybindRegistry).GetTerminalModeAction) == "terminal_paste_host" {
 		if focusedWindow != nil {
-			if config.ClipboardLocalFallback && app.LocalClipboardAvailable() {
+			// Native clipboard read only for a local, VTE-hosted session: under
+			// tuios ssh / tuios-web the human is elsewhere, and WAYLAND_DISPLAY /
+			// DISPLAY describe the operator's desktop, so a native read would pull
+			// the operator's clipboard into a remote pane. VTE never implements
+			// OSC 52, so everywhere else the OSC 52 read below is the right path.
+			local := !o.IsSSHMode && !o.BrowserClient
+			if local && app.ShouldUseNativeClipboard() {
 				tool := app.DetectClipboardTool()
 				return o, func() tea.Msg {
 					text, err := tool.Read()

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -320,16 +320,30 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Handle paste shortcuts - intercept and request clipboard via OSC 52.
-	// Plain ctrl+v is deliberately not bound to terminal_paste_host so it falls
-	// through to the passthrough block and reaches the child PTY as 0x16 (needed
-	// for vim visual-block, etc.), matching the tmux/zellij convention.
+	// Handle paste shortcuts - intercept and request the clipboard. Prefer a
+	// native system clipboard (wl-paste, xclip, pbcopy) when one is reachable;
+	// fall back to OSC 52 (tea.ReadClipboard) which terminals that implement it
+	// answer with a tea.ClipboardMsg. Both paths end in the same message, which
+	// handler.go routes to handleClipboardPaste, so the paste destination logic
+	// is shared. Plain ctrl+v is deliberately not bound to terminal_paste_host
+	// so it falls through to the passthrough block and reaches the child PTY as
+	// 0x16 (needed for vim visual-block, etc.), matching the tmux/zellij
+	// convention.
 	if sectionAction(msg, o, (*config.KeybindRegistry).GetTerminalModeAction) == "terminal_paste_host" {
 		if focusedWindow != nil {
-			// Ask the terminal for its clipboard via OSC 52. The reply arrives
-			// as a tea.ClipboardMsg, handled in handler.go, and a terminal that
-			// never replies is reported instead. See app.RequestHostPaste.
-			return o, o.RequestHostPaste()
+			if config.ClipboardLocalFallback && app.LocalClipboardAvailable() {
+				tool := app.DetectClipboardTool()
+				return o, func() tea.Msg {
+					text, err := tool.Read()
+					if err != nil {
+						return nil
+					}
+					return tea.ClipboardMsg{Content: text, Selection: 'c'}
+				}
+			}
+			// Use tea.ReadClipboard to request clipboard via OSC 52
+			// This will generate a tea.ClipboardMsg which we handle in handler.go
+			return o, tea.ReadClipboard
 		}
 		return o, nil
 	}

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -342,7 +342,11 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 				return o, func() tea.Msg {
 					text, err := tool.Read()
 					if err != nil {
-						return nil
+						// Native read failed (hung tool, empty selection,
+						// compositor gone): fall back to OSC 52 so the paste
+						// is not silently lost. VTE never answers, but any
+						// terminal that does implement it still gets the text.
+						return tea.ReadClipboard()
 					}
 					return tea.ClipboardMsg{Content: text, Selection: 'c'}
 				}

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -337,23 +337,25 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 			// the operator's clipboard into a remote pane. VTE never implements
 			// OSC 52, so everywhere else the OSC 52 read below is the right path.
 			local := !o.IsSSHMode && !o.BrowserClient
-			if local && app.ShouldUseNativeClipboard() {
+			if local && app.ShouldUseNativeClipboard(o.Settings.ClipboardLocalFallback) {
 				tool := app.DetectClipboardTool()
 				return o, func() tea.Msg {
 					text, err := tool.Read()
 					if err != nil {
 						// Native read failed (hung tool, empty selection,
-						// compositor gone): fall back to OSC 52 so the paste
-						// is not silently lost. VTE never answers, but any
-						// terminal that does implement it still gets the text.
-						return tea.ReadClipboard()
+						// compositor gone): fall back to the host paste path
+						// so the OSC 52 read still arms the deadline and the
+						// browser client still hears why paste cannot work.
+						return o.RequestHostPaste()()
 					}
 					return tea.ClipboardMsg{Content: text, Selection: 'c'}
 				}
 			}
-			// Use tea.ReadClipboard to request clipboard via OSC 52
-			// This will generate a tea.ClipboardMsg which we handle in handler.go
-			return o, tea.ReadClipboard
+			// Request the clipboard via the host paste path: it routes through
+			// RequestHostPaste so the browser client is told why paste cannot
+			// work and the OSC 52 deadline is armed (a terminal that never
+			// answers is reported instead of looking broken).
+			return o, o.RequestHostPaste()
 		}
 		return o, nil
 	}

--- a/internal/input/keyboard_terminal.go
+++ b/internal/input/keyboard_terminal.go
@@ -320,10 +320,12 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Handle paste shortcuts - intercept and request the clipboard. Prefer a
-	// native system clipboard (wl-paste, xclip, pbcopy) when one is reachable;
-	// fall back to OSC 52 (tea.ReadClipboard) which terminals that implement it
-	// answer with a tea.ClipboardMsg. Both paths end in the same message, which
+	// Handle paste shortcuts - intercept and request the clipboard. The whole
+	// decision lives in RequestHostPaste: it says why paste cannot work when it
+	// cannot, decides on the Update loop whether a native tool is reachable,
+	// arms the OSC 52 deadline, and returns one Cmd that does the reading, so
+	// the key path stays a plain return and nothing touches the model off the
+	// loop. Both the native and the OSC 52 read end in the same message, which
 	// handler.go routes to handleClipboardPaste, so the paste destination logic
 	// is shared. Plain ctrl+v is deliberately not bound to terminal_paste_host
 	// so it falls through to the passthrough block and reaches the child PTY as
@@ -331,30 +333,6 @@ func HandleTerminalModeKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cmd) {
 	// convention.
 	if sectionAction(msg, o, (*config.KeybindRegistry).GetTerminalModeAction) == "terminal_paste_host" {
 		if focusedWindow != nil {
-			// Native clipboard read only for a local, VTE-hosted session: under
-			// tuios ssh / tuios-web the human is elsewhere, and WAYLAND_DISPLAY /
-			// DISPLAY describe the operator's desktop, so a native read would pull
-			// the operator's clipboard into a remote pane. VTE never implements
-			// OSC 52, so everywhere else the OSC 52 read below is the right path.
-			local := !o.IsSSHMode && !o.BrowserClient
-			if local && app.ShouldUseNativeClipboard(o.Settings.ClipboardLocalFallback) {
-				tool := app.DetectClipboardTool()
-				return o, func() tea.Msg {
-					text, err := tool.Read()
-					if err != nil {
-						// Native read failed (hung tool, empty selection,
-						// compositor gone): fall back to the host paste path
-						// so the OSC 52 read still arms the deadline and the
-						// browser client still hears why paste cannot work.
-						return o.RequestHostPaste()()
-					}
-					return tea.ClipboardMsg{Content: text, Selection: 'c'}
-				}
-			}
-			// Request the clipboard via the host paste path: it routes through
-			// RequestHostPaste so the browser client is told why paste cannot
-			// work and the OSC 52 deadline is armed (a terminal that never
-			// answers is reported instead of looking broken).
 			return o, o.RequestHostPaste()
 		}
 		return o, nil

--- a/internal/input/mouse_select.go
+++ b/internal/input/mouse_select.go
@@ -172,9 +172,10 @@ func copyModeLineCells(window *terminal.Window, absY int) []uv.Cell {
 // the highlight up rather than clearing it, so the user can see what they got;
 // the next press clears it, as does typing.
 //
-// The clipboard path is the same tea.SetClipboard (OSC 52) that copy mode's y
-// has always used, so it reaches exactly the environments that already did,
-// including over SSH, and no more.
+// The clipboard write is WriteClipboard, the one write path copy mode's y and
+// the scrollback browser also use. Its native tool is gated to local VTE
+// sessions, so over SSH this reaches the operator's terminal exactly the way
+// OSC 52 always did, and no more.
 func finishMouseSelection(o *app.OS, window *terminal.Window) tea.Cmd {
 	cm := window.CopyMode
 	if cm == nil || !cm.Active {

--- a/internal/input/scrollback_browser.go
+++ b/internal/input/scrollback_browser.go
@@ -143,7 +143,7 @@ func HandleScrollbackBrowserKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cm
 				fmt.Sprintf("Copied %d chars", len(text)),
 				"success", o.Settings.NotificationDuration,
 			)
-			return o, tea.SetClipboard(text)
+			return o, o.WriteClipboard(text)
 		}
 		o.ShowNotification("Nothing to copy", "warning", o.Settings.NotificationDuration)
 
@@ -155,7 +155,7 @@ func HandleScrollbackBrowserKey(msg tea.KeyPressMsg, o *app.OS) (*app.OS, tea.Cm
 				fmt.Sprintf("Copied: %s", truncateForNotif(text, 30)),
 				"success", o.Settings.NotificationDuration,
 			)
-			return o, tea.SetClipboard(text)
+			return o, o.WriteClipboard(text)
 		}
 
 	// Paste selected command back to terminal
@@ -471,7 +471,7 @@ func handleBrowserOutputModeKey(keyStr string, browser *scrollback.Browser, o *a
 					"success", o.Settings.NotificationDuration,
 				)
 				vim.EnsureVisible()
-				return o, tea.SetClipboard(text)
+				return o, o.WriteClipboard(text)
 			}
 		} else {
 			text := vim.SelectedText()
@@ -481,7 +481,7 @@ func handleBrowserOutputModeKey(keyStr string, browser *scrollback.Browser, o *a
 					"success", o.Settings.NotificationDuration,
 				)
 				vim.EnsureVisible()
-				return o, tea.SetClipboard(text)
+				return o, o.WriteClipboard(text)
 			}
 		}
 		o.ShowNotification("Nothing to copy", "warning", o.Settings.NotificationDuration)

--- a/skills/tuios/SKILL.md
+++ b/skills/tuios/SKILL.md
@@ -893,7 +893,7 @@ like "make it look like X" usually means some of each:
 | **Spacing** | ground between panes, padding inside overlay panels | `appearance.gap`, `appearance.panel_padding` |
 | **Composition** | what a window title, a workspace tab and the clock carry | `window_title_format`, `dock_workspace_tab_format`, `clock_format` |
 
-The 121 options above are scalars, and spacing and composition are set with them
+The 122 options above are scalars, and spacing and composition are set with them
 like any other. Colour and shape are not: each is a name from an open set
 standing for a document kept in a directory rather than a value in the config
 file, which is why both have a verb of their own rather than a row in


### PR DESCRIPTION
## What

Copy and paste in TUIOS went through OSC 52 exclusively, which requires the user terminal to implement that escape sequence. Terminals built on VTE (GNOME Terminal, Ptyxis) never do, so the copy/paste actions silently did nothing there — the context menu opened and the notifications fired, but the clipboard never changed.

## Root cause

`tea.SetClipboard`/`tea.ReadClipboard` emit/consume OSC 52. VTE-based terminals ignore the sequence entirely. The app has no other channel to the system clipboard.

## Fix

Detect a native system clipboard tool when one is reachable and use it for the write and the read:

1. **`internal/app/clipboard_local.go`** (new): detects `wl-copy`/`wl-paste` (Wayland), `xclip`/`xsel` (X11), `pbcopy`/`pbpaste` (macOS) based on session env + binaries present. `Write` launches the keeper (Start semantics, matching wl-clipboard ownership), `Read` captures stdout.
2. **`clipboard_copy.go`**: `CopyToClipboard`/`HandlePendingCopy` now go through `clipboardWriteCmd`, which writes natively when available *and* still returns the normal `setClipboardMsg` (so OSC 52 is also emitted — redundant but idempotent in terminals that support it, and the safety net when no native tool exists).
3. **`keyboard_terminal.go`**: `terminal_paste_host` prefers a native read when one is reachable, emitting the same `tea.ClipboardMsg` the OSC 52 path would, so paste routing in `handler.go` is shared. Falls back to `tea.ReadClipboard`.
4. **Config**: new `appearance.clipboard_local_fallback` (default `true`) forces pure OSC 52 when set to false. Row added to the settings panel.

## Why safe

- Remote clients (SSH to a headless box) have no native clipboard: detection returns nil, pure OSC 52 path unchanged.
- The double write is idempotent (same text twice).
- The existing `TestSettingsPanelReachesEveryOption` guard passes (row added).
- All package suites pass: `internal/app` (145s), `internal/input`, `internal/config`.

## Verification

End-to-end against a detached daemon with wl-clipboard present: the daemon process (running under the systemd user manager session) writes to and reads from the Wayland clipboard successfully. Unit tests cover detection, the Write/Read contract with a fake tool (deterministic in CI), and skip the live round trip when XDG_RUNTIME_DIR is a test tree.