### PR TITLE
fix(cli): stop --list-themes warning about a theme nobody asked for

### DIFF
--- a/cmd/tuios/main.go
+++ b/cmd/tuios/main.go
@@ -140,9 +140,7 @@ comprehensive keyboard/mouse interactions.`,
 			}
 
 			if listThemes {
-				if err := theme.Initialize("default"); err != nil {
-					return fmt.Errorf("failed to initialize themes: %w", err)
-				}
+				theme.EnsureRegistry()
 				themes := tint.TintIDs()
 				for _, t := range themes {
 					fmt.Println(t)


### PR DESCRIPTION
## What does this pull request do?

- Resolves: no issue for this one, jsut ran the command and it was sat there
- Description: `tuios --list-themes` warns that a theme called `default` is missing, before it prints the list

---

## Motivation / Context

Bug fix, though a small one. Listing themes puts `Warning: theme "default" not found; using default theme colors` on stderr first, and there is no theme with the id `default` - the 342 ids it goes on to print dont include it. So someone who never picked a theme gets told their theme couldn't be found.

That branch only wants the tint registry built so it has something to list. `theme.Initialize` does build it, but it also tries to activate whatever name you hand it, and warns when the name isn't a real tint.

---

## What has been changed

- Updated logic in `cmd/tuios`: the `--list-themes` branch calls `theme.EnsureRegistry()` instead of `theme.Initialize("default")`. Its doc comment already covers this case, "without enabling theming or changing the current theme"
- The error wrapper goes with it, `Initialize` has no path that returns non-nil
- No docs or test changes

---

## How to verify this change

1. Clone and build: `go build ./cmd/tuios`
2. `./tuios --list-themes 2>&1 >/dev/null` - one warning line on `main`, nothing after the change
3. `./tuios --list-themes | wc -l` - 342 both ways, and the ids come out byte for byte identical
4. `./tuios --preview-theme dracula` and `./tuios --preview-theme nonesuch` are unaffected. The second still warns, which is right - you did name a theme there

---

## Notes on compatibility / installation method

- Platform(s) tested: Linux x86_64
- Installation method tested: built from source, `go build ./cmd/tuios`, pure Go backend
- Version/commit used: `12d91fa`
- Any limitations or blockers: none that I know of. Linux only, but there's nothing platform specific in it

---

## Checklist

- [x] Code changes compile and tests pass
- [ ] Added/Updated relevant documentation - nothing documented changes, `docs/CLI_REFERENCE.md` already just says the flag lists themes
- [ ] Tested across supported platforms and install methods - Linux from source only
- [ ] Added or updated tests - see below
- [x] PR title follows format (e.g., `[BUG]`, `[FEATURE]`, etc.)

---

## Additional Context (optional)

Didn't write a test for it. Pinning "stderr stays empty" means driving the cobra command from a test binary and catching what `log` writes, and thats more machinery than the one line its guarding. Ran `go test ./internal/theme/... ./cmd/tuios/... ./internal/config/...`, all green.

---

Seperate thing you may or may not care about: `internal/theme/theme_test.go` calls `Initialize("default")` in five places, so the same warning turns up in that package's test output too. Left it alone.
