### PR TITLE
test(session): regression guards for xterm palette and bright slot mapping

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -521,16 +521,17 @@ Request:
 Response:
 
 ```json
-{"result": {"type": "pane_content", "source": "recent", "styled": false, "content": "..."}}
+{"result": {"type": "pane_content", "source": "recent", "styled": false, "resolved": false, "content": "..."}}
 ```
 
-Without `resolved`, a `styled` capture emits the colours exactly as the guest
-sent them: a program that draws with SGR `31` comes back as `\x1b[31m`, and the
-consumer resolves that index against its own palette. That is the intended
-contract: appearance is client-owned and the daemon has no theme. `resolved`
-exists for consumers that render the capture verbatim and therefore need the
-colours already resolved; it takes the palette explicitly so the daemon still
-knows nothing about themes.
+The reply echoes `resolved` so a consumer can tell whether the capture it
+received was rewritten. Without `resolved`, a `styled` capture emits the
+colours exactly as the guest sent them: a program that draws with SGR `31`
+comes back as `\x1b[31m`, and the consumer resolves that index against its
+own palette. That is the intended contract: appearance is client-owned and
+the daemon has no theme. `resolved` exists for consumers that render the
+capture verbatim and therefore need the colours already resolved; it takes
+the palette explicitly so the daemon still knows nothing about themes.
 
 ```json
 {"verb": "capture-pane", "params": {"session": "work", "source": "visible", "styled": true, "resolved": true, "palette": ["#45475a", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#bac2de", "#585b70", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#a6adc8"]}}

--- a/internal/session/resolve_sgr_test.go
+++ b/internal/session/resolve_sgr_test.go
@@ -75,6 +75,24 @@ func TestResolveSGRBrightBackground(t *testing.T) {
 	}
 }
 
+func TestResolveSGRBrightForegroundUsesBrightSlot(t *testing.T) {
+	// A palette whose bright slots differ from the normal ones, so a
+	// regression that maps 91 to pal[1] (normal red) instead of pal[9]
+	// (bright red) cannot hide behind a theme that repeats its colours
+	// in slots 8-15 (catppuccin, among others, does).
+	pal := mustPalette(t, []string{
+		"#111111", "#222222", "#333333", "#444444",
+		"#555555", "#666666", "#777777", "#888888",
+		"#999999", "#ff0000", "#00ff00", "#ffff00",
+		"#0000ff", "#ff00ff", "#00ffff", "#ffffff",
+	})
+	got := ResolveSGR("\x1b[91m", pal)
+	want := "\x1b[38;2;255;0;0m" // pal[9] = #ff0000, not pal[1] = #222222
+	if got != want {
+		t.Fatalf("ResolveSGR(91) = %q, want %q (bright slot, not normal slot)", got, want)
+	}
+}
+
 func TestResolveSGR256LowIndexUsesPalette(t *testing.T) {
 	pal := mochaPalette()
 	// 38;5;1 is the 256-colour spelling of index 1; the theme palette owns it.
@@ -259,6 +277,22 @@ func TestXtermPaletteIsRGB(t *testing.T) {
 		}
 		if r == 0 && g == 0 && b == 0 && i != 0 {
 			t.Fatalf("xterm colour %d is black; palette not populated", i)
+		}
+		// Pin the exact RGB as literals — xterm's own defaults, written out
+		// here rather than read back from xtermDefaultHex so a regression to
+		// a colour library's VGA shades (index 1 = #800000) cannot pass by
+		// changing both sides together. The daemon resolves against what
+		// xterm actually paints when no palette is sent; a capture that
+		// disagrees with the terminal is a lie.
+		want := [16][3]int{
+			{0, 0, 0}, {205, 0, 0}, {0, 205, 0}, {205, 205, 0},
+			{0, 0, 238}, {205, 0, 205}, {0, 205, 205}, {229, 229, 229},
+			{127, 127, 127}, {255, 0, 0}, {0, 255, 0}, {255, 255, 0},
+			{92, 92, 255}, {255, 0, 255}, {0, 255, 255}, {255, 255, 255},
+		}[i]
+		if r>>8 != uint32(want[0]) || g>>8 != uint32(want[1]) || b>>8 != uint32(want[2]) {
+			t.Fatalf("xterm colour %d = #%02x%02x%02x, want #%02x%02x%02x (xterm defaults, not VGA)",
+				i, r>>8, g>>8, b>>8, want[0], want[1], want[2])
 		}
 	}
 	// The xterm red (index 1) is a known RGB; confirm it serialises to a


### PR DESCRIPTION
Follow-up to #136 — closing the two test gaps your negative controls found, plus the two smaller notes.

**1. VGA regression now fails.** `TestXtermPaletteIsRGB` pins all 16 xterm default colours as RGB literals written out in the test. Reading the reference back from `xtermDefaultHex` let a VGA regression pass by changing both sides together (the old test only checked the `38;2;` prefix). I verified the guard the way you did: reverting index 1 to `#800000` fails with `xterm colour 1 = #800000, want #cd0000 (xterm defaults, not VGA)`.

**2. Bright-slot mapping now has a guard.** New `TestResolveSGRBrightForegroundUsesBrightSlot` builds a palette whose bright slots differ from the normal ones and asserts `91` resolves through `pal[9]`, not `pal[1]`. `mochaPalette` repeats its colours in slots 8-15 (fiel a catppuccin, which defines no separate brights), so the old test passed either mapping. Mapping `91` to `pal[n-90]` now fails with `want 38;2;255;0;0 (bright slot, not normal slot)`. This also puts `mustPalette` to use — it was previously dead code.

**3. Docs.** The `pane_content` Response example in `docs/protocol.md` now carries the `resolved` field the daemon actually replies with, and the paragraph notes the reply echoes it.

`internal/session` suite: 402 pass. vet and build clean.