### PR TITLE
fix(session): reattach replays whole chunks on top of the restored snapshot (#123)

### DIFF
--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -1573,7 +1573,11 @@ func (m *OS) subscribeToPTY(window *terminal.Window, fromSeq int64) {
 	// cannot arrive with nothing listening for it.
 	m.DaemonClient.OnPTYResized(ptyID, window.ResizeFromStream)
 	window.SetStreamOwnsSize(true)
-	err := m.DaemonClient.SubscribePTY(ptyID, fromSeq, func(data []byte) {
+	// A subscribe that follows a restored snapshot is told to the daemon: a
+	// rolled catch-up must replay the tail on top of the snapshot, not clear
+	// it (issue #123). The only path that subscribes with fromSeq zero is the
+	// no-snapshot fallback, so fromSeq > 0 is exactly "a snapshot was applied".
+	err := m.DaemonClient.SubscribePTY(ptyID, fromSeq, fromSeq > 0, func(data []byte) {
 		window.WriteOutputAsync(data)
 	})
 	if err != nil {

--- a/internal/session/daemon_handlers.go
+++ b/internal/session/daemon_handlers.go
@@ -631,6 +631,14 @@ func (d *Daemon) handleSubscribePTY(cs *connState, msg *Message) error {
 	// A resize sent straight after a subscribe used to be broadcast to nobody,
 	// and the pane it belonged to kept the size it had before, on a client that
 	// was by then waiting to be told.
+	// A client that restored a snapshot before subscribing holds an
+	// authoritative copy of the pane's state at resume, so a rolled catch-up
+	// must replay the tail on top of it rather than clear it (issue #123).
+	if payload.FromSnapshot {
+		outputCh := pty.SubscribeFromSnapshot(cs.clientID, resume)
+		go d.streamPTYOutput(cs, pty, outputCh)
+		return nil
+	}
 	outputCh := pty.Subscribe(cs.clientID, resume)
 	go d.streamPTYOutput(cs, pty, outputCh)
 

--- a/internal/session/protocol.go
+++ b/internal/session/protocol.go
@@ -359,9 +359,18 @@ type ResizePTYPayload struct {
 // so the daemon replays only what came after it. Zero means the client has no
 // claim to make and the daemon uses whatever position it recorded for this
 // connection, which is what an older client sends.
+//
+// FromSnapshot marks a subscribe that follows a freshly restored snapshot: the
+// client holds an authoritative copy of the pane's state at FromSeq, so a
+// rolled catch-up (whose ring has moved past FromSeq) must not clear that
+// state before replaying the tail. The clear exists for a client resuming a
+// screen it drew byte by byte, whose missing bytes would otherwise splice two
+// halves of the stream; a snapshot is already the whole of it, and clearing
+// it is what emptied rows a full-screen program had drawn (issue #123).
 type SubscribePTYPayload struct {
-	PTYID   string `json:"pty_id"`
-	FromSeq int64  `json:"from_seq,omitempty"`
+	PTYID        string `json:"pty_id"`
+	FromSeq      int64  `json:"from_seq,omitempty"`
+	FromSnapshot bool   `json:"from_snapshot,omitempty"`
 }
 
 // PTYResizedPayload announces the size the daemon's emulator took, delivered in

--- a/internal/session/pty_resubscribe_wire_test.go
+++ b/internal/session/pty_resubscribe_wire_test.go
@@ -65,7 +65,7 @@ func TestResubscribeOverTheWireReplaysOnlyWhatWasMissed(t *testing.T) {
 	client := attachTestClient(t, "switching")
 
 	var got collector
-	if err := client.SubscribePTY(ptyID, 0, got.add); err != nil {
+	if err := client.SubscribePTY(ptyID, 0, false, got.add); err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
 
@@ -90,7 +90,7 @@ func TestResubscribeOverTheWireReplaysOnlyWhatWasMissed(t *testing.T) {
 			defer pty.subscribersMu.RUnlock()
 			return len(pty.subscribers) == 0
 		})
-		if err := client.SubscribePTY(ptyID, 0, got.add); err != nil {
+		if err := client.SubscribePTY(ptyID, 0, false, got.add); err != nil {
 			t.Fatalf("resubscribe: %v", err)
 		}
 		waitFor(t, "the daemon to take the subscription", func() bool {
@@ -120,7 +120,7 @@ func TestDetachReplaysTheWholePaneOnTheWayBack(t *testing.T) {
 	client := attachTestClient(t, "switching")
 
 	var got collector
-	if err := client.SubscribePTY(ptyID, 0, got.add); err != nil {
+	if err := client.SubscribePTY(ptyID, 0, false, got.add); err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestDetachReplaysTheWholePaneOnTheWayBack(t *testing.T) {
 	if _, err := client.SwitchSession("switching", 80, 24); err != nil {
 		t.Fatalf("switch: %v", err)
 	}
-	if err := client.SubscribePTY(ptyID, 0, got.add); err != nil {
+	if err := client.SubscribePTY(ptyID, 0, false, got.add); err != nil {
 		t.Fatalf("resubscribe: %v", err)
 	}
 

--- a/internal/session/reattach_empty_lines_test.go
+++ b/internal/session/reattach_empty_lines_test.go
@@ -1,0 +1,378 @@
+package session
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gaurav-Gosain/tuios/internal/vt"
+)
+
+// These tests reproduce the reported shape of issue #123: after detach and
+// attach, a full-screen program like top comes back with empty lines
+// interleaved between its output lines.
+//
+// The daemon side is a PTY whose emulator is fed directly (no shell in the
+// middle), so the byte stream, the catch-up ring and the daemon emulator move
+// together exactly as they do under a real PTY. The client side is rebuilt the
+// way restoreTerminalContent rebuilds it: a fresh emulator gets the daemon's
+// snapshot (ApplyTerminalState) and then the stream resumes from the position
+// the snapshot ends at. The client's screen must converge on the daemon's.
+
+// newEmulatedPTY builds a PTY with a live emulator and its vtWriter goroutine,
+// but no real shell: tests feed it bytes directly.
+func newEmulatedPTY(t *testing.T, w, h int) *PTY {
+	t.Helper()
+	p := &PTY{
+		ID:           "ptytest-emulated",
+		subscribers:  make(map[string]*ptySubscriber),
+		outputBuffer: make([]byte, 64*1024),
+		// Small vtWriteChan: the real daemon's is 256 x 16KB chunks, which can
+		// hold 4MB of unprocessed output and lets the emulator fall 4MB behind
+		// the ring. With a small channel the same "emulator behind the ring"
+		// condition is reachable with a test-sized burst.
+		vtWriteChan: make(chan vtChunk, 8),
+		ctx:         context.Background(),
+		terminal:    vt.NewEmulator(w, h),
+	}
+	go p.vtWriter()
+	t.Cleanup(func() {
+		p.outputMu.Lock()
+		defer p.outputMu.Unlock()
+		p.vtWriteChan <- vtChunk{} // never used; closes nothing
+	})
+	return p
+}
+
+// feed writes guest output through the same two paths the read loop uses: the
+// catch-up ring (so a resubscribing client is handed it) and the emulator (so
+// the daemon's screen advances). Like readOutput it blocks on the emulator
+// channel rather than dropping a chunk. It returns the stream position the
+// chunk ends at.
+func (p *PTY) feed(data []byte) int64 {
+	p.outputMu.Lock()
+	seq := p.appendToBuffer(data)
+	p.outputMu.Unlock()
+	select {
+	case p.vtWriteChan <- vtChunk{data: data, seq: seq}:
+	case <-p.ctx.Done():
+		return seq
+	}
+	p.broadcast(ptyChunk{data: data}, seq)
+	return seq
+}
+
+// fedThrough waits until the daemon emulator has consumed every byte fed so
+// far, i.e. vtSeq catches outputSeq.
+func (p *PTY) fedThrough(t *testing.T, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		p.outputMu.RLock()
+		out := p.outputSeq
+		p.outputMu.RUnlock()
+		p.terminalMu.RLock()
+		vt := p.vtSeq
+		p.terminalMu.RUnlock()
+		if vt >= out && out > 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("daemon emulator never consumed the %s", what)
+}
+
+// daemonText renders the daemon emulator's visible grid exactly the way
+// emulatorText renders a client emulator, so the two sides compare cell for
+// cell.
+func (p *PTY) daemonText() string {
+	p.terminalMu.RLock()
+	defer p.terminalMu.RUnlock()
+	if p.terminal == nil {
+		return ""
+	}
+	return terminalText(p.terminal)
+}
+
+// terminalText reads any terminal's visible grid as text, one line per row.
+func terminalText(t vt.Terminal) string {
+	var b strings.Builder
+	for y := range t.Height() {
+		for x := range t.Width() {
+			cell := t.CellAt(x, y)
+			if cell == nil || cell.String() == "" {
+				b.WriteByte(' ')
+				continue
+			}
+			b.WriteString(cell.String())
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// topDraw is the initial full-screen draw a program like top makes: enter the
+// alternate screen, clear it, paint three header rows and three process rows.
+const topDraw = "\x1b[?1049h\x1b[H\x1b[2J" +
+	"\x1b[1;1Htop - 12:00:00 up 1 day" +
+	"\x1b[2;1HTasks: 3 total" +
+	"\x1b[3;1H  PID USER     COMMAND" +
+	"\x1b[4;1H 1234 seba     top" +
+	"\x1b[5;1H 5678 root     sshd" +
+	"\x1b[6;1H 9012 seba     bash"
+
+// topRepaint repaints the three process rows with fresh PIDs, the way top's
+// periodic update does (cursor to row, erase line, write row).
+func topRepaint(base int) string {
+	return "\x1b[4;1H\x1b[2K" + strconv.Itoa(base) + " seba     top" +
+		"\x1b[5;1H\x1b[2K" + strconv.Itoa(base+1) + " root     sshd" +
+		"\x1b[6;1H\x1b[2K" + strconv.Itoa(base+2) + " seba     bash"
+}
+
+// reattach rebuilds a client emulator from the daemon's snapshot, resumes the
+// stream from the snapshot's position, and keeps applying the live stream to
+// the client emulator, exactly what restoreTerminalContent plus the subscribe
+// handler (WriteOutputAsync) do. It returns the client and the subscription.
+func reattachFrom(p *PTY, clientID string) (*vt.Emulator, <-chan ptyChunk) {
+	state := p.GetTerminalState(0, 0)
+	if state == nil {
+		return nil, nil
+	}
+	client := vt.NewEmulator(state.Width, state.Height)
+	ApplyTerminalState(client, state)
+
+	// The daemon-side path a reattaching client takes: it tells the daemon it
+	// restored a snapshot, so a rolled catch-up replays on top of it instead
+	// of clearing it (issue #123).
+	ch := p.SubscribeFromSnapshot(clientID, state.Seq)
+	replay := drain(ch)
+	if len(replay) > 0 {
+		_, _ = client.Write(replay)
+	}
+	// The live stream: every chunk the daemon broadcasts after the replay is
+	// applied to the client, as the client's output handler does.
+	go func() {
+		for chunk := range ch {
+			if len(chunk.data) > 0 {
+				_, _ = client.Write(chunk.data)
+			}
+		}
+	}()
+	return client, ch
+}
+
+// TestReattachAfterTopDrewOnce is the quiescent case: the guest drew its
+// screen and went quiet before the client left, so the attach has nothing to
+// replay. The client must reproduce the daemon's screen exactly.
+func TestReattachAfterTopDrewOnce(t *testing.T) {
+	p := newEmulatedPTY(t, 80, 24)
+	p.feed([]byte(topDraw))
+	p.fedThrough(t, "initial draw")
+
+	client, ch := reattachFrom(p, "repro-quiet")
+	if client == nil {
+		t.Fatal("reattach produced no client emulator")
+	}
+	defer func() { _ = client.Close() }()
+	defer func() { _ = p.Unsubscribe("repro-quiet") }()
+	_ = ch
+
+	want := normalizeText(p.daemonText())
+	got := normalizeText(emulatorText(client))
+	if want != got {
+		t.Errorf("quiet reattach diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
+	}
+}
+
+// TestReattachWhileTopRedraws is the moving case: the guest repaints its rows
+// while the snapshot is taken and the stream resumes, so the catch-up ring
+// carries bytes the snapshot does not. The client must converge on the daemon
+// with no rows skipped, doubled, or interleaved with blanks.
+func TestReattachWhileTopRedraws(t *testing.T) {
+	p := newEmulatedPTY(t, 80, 24)
+	p.feed([]byte(topDraw))
+	p.fedThrough(t, "initial draw")
+
+	// The guest keeps repainting: a few redraws land before the snapshot, and
+	// a few more while the client is being rebuilt.
+	for i := 0; i < 3; i++ {
+		p.feed([]byte(topRepaint(1000 + i*10)))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	client, _ := reattachFrom(p, "repro-moving")
+	if client == nil {
+		t.Fatal("reattach produced no client emulator")
+	}
+	defer func() { _ = client.Close() }()
+	defer func() { _ = p.Unsubscribe("repro-moving") }()
+
+	// More repaints after the resume, then let everything settle.
+	for i := 0; i < 5; i++ {
+		p.feed([]byte(topRepaint(2000 + i*10)))
+		time.Sleep(2 * time.Millisecond)
+	}
+	p.fedThrough(t, "repaints after resume")
+
+	// The live stream applies asynchronously: wait until the client has caught
+	// up to the daemon's latest repaint before comparing.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(emulatorText(client), "2042 seba     bash") {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	want := normalizeText(p.daemonText())
+	got := normalizeText(emulatorText(client))
+	if want != got {
+		t.Errorf("reattach while top redraws diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
+	}
+}
+
+// TestReattachSnapshotWhileEmulatorBehind takes the snapshot while the daemon
+// emulator is still chewing on a large batch of output, so vtSeq trails
+// outputSeq and the catch-up ring has rolled past the snapshot's position. The
+// client must lay the snapshot down and then replay whole chunks, converging
+// on the daemon with no rows skipped, doubled, or blanked.
+func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
+	p := newEmulatedPTY(t, 80, 24)
+	p.feed([]byte(topDraw))
+	p.fedThrough(t, "initial draw")
+
+	// A goroutine feeds a burst of repaints batched into 16KB chunks, exactly
+	// as readOutput reads from the PTY pipe. The small vtWriteChan lets the
+	// emulator fall behind while the ring keeps rolling.
+	feedDone := make(chan struct{})
+	go func() {
+		defer close(feedDone)
+		chunk := make([]byte, 0, 16*1024)
+		for i := 0; i < 20000; i++ {
+			chunk = append(chunk, []byte(topRepaint(10000+i%3000))...)
+			if len(chunk) >= 16*1024 {
+				p.feed(chunk)
+				chunk = chunk[:0]
+			}
+		}
+		if len(chunk) > 0 {
+			p.feed(chunk)
+		}
+	}()
+
+	// Wait until the ring has rolled past where the emulator has got to: the
+	// condition the bug lived in.
+	waitFor := func(desc string, cond func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s", desc)
+	}
+	waitFor("the ring to roll past the emulator", func() bool {
+		p.outputMu.RLock()
+		out := p.outputSeq
+		bufStart := out - int64(p.outputPos)
+		p.outputMu.RUnlock()
+		p.terminalMu.RLock()
+		vt := p.vtSeq
+		p.terminalMu.RUnlock()
+		return out > 70*1024 && vt < bufStart
+	})
+
+	// Snapshot now: vtSeq is behind and the ring no longer holds fromSeq.
+	state := p.GetTerminalState(0, 0)
+	if state == nil {
+		t.Fatal("GetTerminalState returned nil")
+	}
+
+	client := vt.NewEmulator(state.Width, state.Height)
+	ApplyTerminalState(client, state)
+	ch := p.SubscribeFromSnapshot("repro-behind", state.Seq)
+	replay := drain(ch)
+	if len(replay) > 0 {
+		_, _ = client.Write(replay)
+	}
+	go func() {
+		for chunk := range ch {
+			if len(chunk.data) > 0 {
+				_, _ = client.Write(chunk.data)
+			}
+		}
+	}()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = p.Unsubscribe("repro-behind") }()
+
+	// Let the burst finish and both sides settle on the final repaint.
+	<-feedDone
+	p.fedThrough(t, "burst after reattach")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(emulatorText(client), "11999 seba     top") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	want := normalizeText(p.daemonText())
+	got := normalizeText(emulatorText(client))
+	if want != got {
+		t.Errorf("reattach with emulator behind diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
+	}
+}
+
+// TestReattachThenQuitAltScreen covers the reported "it still shows like this
+// even after quitting top": the client reattaches while top runs (alternate
+// screen), then the guest quits top. The shell's main screen underneath must
+// come back intact, and a fresh full-screen program must draw cleanly.
+func TestReattachThenQuitAltScreen(t *testing.T) {
+	p := newEmulatedPTY(t, 80, 24)
+	p.feed([]byte(topDraw))
+	p.fedThrough(t, "initial draw")
+
+	client, ch := reattachFrom(p, "repro-quit")
+	if client == nil {
+		t.Fatal("reattach produced no client emulator")
+	}
+	defer func() { _ = client.Close() }()
+	defer func() { _ = p.Unsubscribe("repro-quit") }()
+	_ = ch
+
+	// The guest quits top: leave the alternate screen.
+	p.feed([]byte("\x1b[?1049l$ ")) // as a shell prompt would after top exits
+	p.fedThrough(t, "quit alt screen")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(emulatorText(client), "$") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	want := normalizeText(p.daemonText())
+	got := normalizeText(emulatorText(client))
+	if want != got {
+		t.Errorf("client after quitting the alt screen diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
+	}
+}
+
+// normalizeText trims trailing whitespace per line and drops trailing empty
+// lines, so two renderings of the same screen compare equal regardless of how
+// each path pads a blank cell.
+func normalizeText(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " \t")
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/session/reattach_empty_lines_test.go
+++ b/internal/session/reattach_empty_lines_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,28 +22,56 @@ import (
 // snapshot (ApplyTerminalState) and then the stream resumes from the position
 // the snapshot ends at. The client's screen must converge on the daemon's.
 
+// lockedClient wraps a client emulator so the live-stream goroutine that
+// writes it and the test body that reads it cannot race. The race detector
+// is on in the project's CI, and a goroutine writing an emulator the test
+// reads through emulatorText without a lock is exactly the report it makes.
+type lockedClient struct {
+	mu   sync.Mutex
+	term *vt.Emulator
+}
+
+func newLockedClient(w, h int) *lockedClient {
+	return &lockedClient{term: vt.NewEmulator(w, h)}
+}
+
+// Write applies stream bytes under the lock.
+func (c *lockedClient) Write(data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, _ = c.term.Write(data)
+}
+
+// Text renders the visible grid under the lock.
+func (c *lockedClient) Text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return emulatorText(c.term)
+}
+
+// Close closes the emulator.
+func (c *lockedClient) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_ = c.term.Close()
+}
+
 // newEmulatedPTY builds a PTY with a live emulator and its vtWriter goroutine,
-// but no real shell: tests feed it bytes directly.
+// but no real shell: tests feed it bytes directly. The vtWriteChan is small so
+// the emulator can be pushed behind the ring with a test-sized burst; the real
+// daemon's channel is 256 x 16KB chunks, which can hold 4MB of unprocessed
+// output.
 func newEmulatedPTY(t *testing.T, w, h int) *PTY {
 	t.Helper()
 	p := &PTY{
 		ID:           "ptytest-emulated",
 		subscribers:  make(map[string]*ptySubscriber),
 		outputBuffer: make([]byte, 64*1024),
-		// Small vtWriteChan: the real daemon's is 256 x 16KB chunks, which can
-		// hold 4MB of unprocessed output and lets the emulator fall 4MB behind
-		// the ring. With a small channel the same "emulator behind the ring"
-		// condition is reachable with a test-sized burst.
-		vtWriteChan: make(chan vtChunk, 8),
-		ctx:         context.Background(),
-		terminal:    vt.NewEmulator(w, h),
+		vtWriteChan:  make(chan vtChunk, 8),
+		ctx:          context.Background(),
+		terminal:     vt.NewEmulator(w, h),
 	}
 	go p.vtWriter()
-	t.Cleanup(func() {
-		p.outputMu.Lock()
-		defer p.outputMu.Unlock()
-		p.vtWriteChan <- vtChunk{} // never used; closes nothing
-	})
 	return p
 }
 
@@ -134,29 +163,30 @@ func topRepaint(base int) string {
 // reattach rebuilds a client emulator from the daemon's snapshot, resumes the
 // stream from the snapshot's position, and keeps applying the live stream to
 // the client emulator, exactly what restoreTerminalContent plus the subscribe
-// handler (WriteOutputAsync) do. It returns the client and the subscription.
-func reattachFrom(p *PTY, clientID string) (*vt.Emulator, <-chan ptyChunk) {
+// handler (WriteOutputAsync) do. It returns the locked client and the
+// subscription channel; the caller owns closing the client and unsubscribing.
+func reattachFrom(p *PTY, clientID string) (*lockedClient, <-chan ptyChunk) {
 	state := p.GetTerminalState(0, 0)
 	if state == nil {
 		return nil, nil
 	}
-	client := vt.NewEmulator(state.Width, state.Height)
-	ApplyTerminalState(client, state)
+	client := newLockedClient(state.Width, state.Height)
+	client.mu.Lock()
+	ApplyTerminalState(client.term, state)
+	client.mu.Unlock()
 
-	// The daemon-side path a reattaching client takes: it tells the daemon it
-	// restored a snapshot, so a rolled catch-up replays on top of it instead
-	// of clearing it (issue #123).
 	ch := p.SubscribeFromSnapshot(clientID, state.Seq)
 	replay := drain(ch)
 	if len(replay) > 0 {
-		_, _ = client.Write(replay)
+		client.Write(replay)
 	}
 	// The live stream: every chunk the daemon broadcasts after the replay is
-	// applied to the client, as the client's output handler does.
+	// applied to the client, as the client's output handler does. All writes
+	// go through the lock the test reads under.
 	go func() {
 		for chunk := range ch {
 			if len(chunk.data) > 0 {
-				_, _ = client.Write(chunk.data)
+				client.Write(chunk.data)
 			}
 		}
 	}()
@@ -175,12 +205,12 @@ func TestReattachAfterTopDrewOnce(t *testing.T) {
 	if client == nil {
 		t.Fatal("reattach produced no client emulator")
 	}
-	defer func() { _ = client.Close() }()
+	defer client.Close()
 	defer func() { _ = p.Unsubscribe("repro-quiet") }()
 	_ = ch
 
 	want := normalizeText(p.daemonText())
-	got := normalizeText(emulatorText(client))
+	got := normalizeText(client.Text())
 	if want != got {
 		t.Errorf("quiet reattach diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
 	}
@@ -206,7 +236,7 @@ func TestReattachWhileTopRedraws(t *testing.T) {
 	if client == nil {
 		t.Fatal("reattach produced no client emulator")
 	}
-	defer func() { _ = client.Close() }()
+	defer client.Close()
 	defer func() { _ = p.Unsubscribe("repro-moving") }()
 
 	// More repaints after the resume, then let everything settle.
@@ -220,14 +250,14 @@ func TestReattachWhileTopRedraws(t *testing.T) {
 	// up to the daemon's latest repaint before comparing.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if strings.Contains(emulatorText(client), "2042 seba     bash") {
+		if strings.Contains(client.Text(), "2042 seba     bash") {
 			break
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
 
 	want := normalizeText(p.daemonText())
-	got := normalizeText(emulatorText(client))
+	got := normalizeText(client.Text())
 	if want != got {
 		t.Errorf("reattach while top redraws diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
 	}
@@ -236,8 +266,8 @@ func TestReattachWhileTopRedraws(t *testing.T) {
 // TestReattachSnapshotWhileEmulatorBehind takes the snapshot while the daemon
 // emulator is still chewing on a large batch of output, so vtSeq trails
 // outputSeq and the catch-up ring has rolled past the snapshot's position. The
-// client must lay the snapshot down and then replay whole chunks, converging
-// on the daemon with no rows skipped, doubled, or blanked.
+// client must lay the snapshot down and then replay the tail, converging on
+// the daemon with no rows skipped, doubled, or blanked.
 func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
 	p := newEmulatedPTY(t, 80, 24)
 	p.feed([]byte(topDraw))
@@ -245,20 +275,29 @@ func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
 
 	// A goroutine feeds a burst of repaints batched into 16KB chunks, exactly
 	// as readOutput reads from the PTY pipe. The small vtWriteChan lets the
-	// emulator fall behind while the ring keeps rolling.
+	// emulator fall behind while the ring keeps rolling. Each chunk is copied
+	// out of the scratch buffer before it is handed to feed, because feed's
+	// emulator and subscriber paths hold the slice by reference: reusing the
+	// backing array for the next chunk would race the vtWriter and the client
+	// stream goroutines against this one.
 	feedDone := make(chan struct{})
 	go func() {
 		defer close(feedDone)
-		chunk := make([]byte, 0, 16*1024)
+		scratch := make([]byte, 0, 16*1024)
+		send := func() {
+			data := make([]byte, len(scratch))
+			copy(data, scratch)
+			p.feed(data)
+			scratch = scratch[:0]
+		}
 		for i := 0; i < 20000; i++ {
-			chunk = append(chunk, []byte(topRepaint(10000+i%3000))...)
-			if len(chunk) >= 16*1024 {
-				p.feed(chunk)
-				chunk = chunk[:0]
+			scratch = append(scratch, []byte(topRepaint(10000+i%3000))...)
+			if len(scratch) >= 16*1024 {
+				send()
 			}
 		}
-		if len(chunk) > 0 {
-			p.feed(chunk)
+		if len(scratch) > 0 {
+			send()
 		}
 	}()
 
@@ -292,21 +331,24 @@ func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
 		t.Fatal("GetTerminalState returned nil")
 	}
 
-	client := vt.NewEmulator(state.Width, state.Height)
-	ApplyTerminalState(client, state)
+	client := newLockedClient(state.Width, state.Height)
+	client.mu.Lock()
+	ApplyTerminalState(client.term, state)
+	client.mu.Unlock()
+
 	ch := p.SubscribeFromSnapshot("repro-behind", state.Seq)
 	replay := drain(ch)
 	if len(replay) > 0 {
-		_, _ = client.Write(replay)
+		client.Write(replay)
 	}
 	go func() {
 		for chunk := range ch {
 			if len(chunk.data) > 0 {
-				_, _ = client.Write(chunk.data)
+				client.Write(chunk.data)
 			}
 		}
 	}()
-	defer func() { _ = client.Close() }()
+	defer client.Close()
 	defer func() { _ = p.Unsubscribe("repro-behind") }()
 
 	// Let the burst finish and both sides settle on the final repaint.
@@ -314,14 +356,14 @@ func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
 	p.fedThrough(t, "burst after reattach")
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if strings.Contains(emulatorText(client), "11999 seba     top") {
+		if strings.Contains(client.Text(), "11999 seba     top") {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
 	want := normalizeText(p.daemonText())
-	got := normalizeText(emulatorText(client))
+	got := normalizeText(client.Text())
 	if want != got {
 		t.Errorf("reattach with emulator behind diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
 	}
@@ -330,7 +372,7 @@ func TestReattachSnapshotWhileEmulatorBehind(t *testing.T) {
 // TestReattachThenQuitAltScreen covers the reported "it still shows like this
 // even after quitting top": the client reattaches while top runs (alternate
 // screen), then the guest quits top. The shell's main screen underneath must
-// come back intact, and a fresh full-screen program must draw cleanly.
+// come back intact.
 func TestReattachThenQuitAltScreen(t *testing.T) {
 	p := newEmulatedPTY(t, 80, 24)
 	p.feed([]byte(topDraw))
@@ -340,7 +382,7 @@ func TestReattachThenQuitAltScreen(t *testing.T) {
 	if client == nil {
 		t.Fatal("reattach produced no client emulator")
 	}
-	defer func() { _ = client.Close() }()
+	defer client.Close()
 	defer func() { _ = p.Unsubscribe("repro-quit") }()
 	_ = ch
 
@@ -350,14 +392,14 @@ func TestReattachThenQuitAltScreen(t *testing.T) {
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if strings.Contains(emulatorText(client), "$") {
+		if strings.Contains(client.Text(), "$") {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
 	want := normalizeText(p.daemonText())
-	got := normalizeText(emulatorText(client))
+	got := normalizeText(client.Text())
 	if want != got {
 		t.Errorf("client after quitting the alt screen diverged (issue #123):\n--- daemon ---\n%s\n--- client ---\n%s", want, got)
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -416,6 +416,14 @@ type PTY struct {
 	// the newest one behind the ring, which is the width the ring's first
 	// byte was laid out at.
 	resizeMarks []resizeMark
+	// chunkMarks are the stream positions each appended chunk began at,
+	// oldest first, kept while the ring still holds that byte. A rolled
+	// catch-up starts at the first chunk mark inside the ring rather than at
+	// the ring's raw start, so the replay never hands a client the tail of a
+	// chunk it never saw: that truncated tail is what painted a reattached
+	// full-screen program's rows out of step, one blank line between each
+	// line it drew (issue #123).
+	chunkMarks []int64
 
 	// Subscribers for raw output streaming.
 	subscribers   map[string]*ptySubscriber
@@ -1601,6 +1609,21 @@ var resyncPrefix = []byte("\x1b[H\x1b[2J\x1b[3J")
 // history a second time below the paint already there, which is the stacked
 // prompts a workspace switch used to leave behind.
 func (p *PTY) Subscribe(clientID string, fromSeq int64) <-chan ptyChunk {
+	return p.subscribe(clientID, fromSeq, false)
+}
+
+// SubscribeFromSnapshot is Subscribe for a client that has just laid down an
+// authoritative snapshot of the pane ending at fromSeq. When the catch-up ring
+// has rolled past fromSeq, a plain Subscribe clears the client's screen before
+// replaying the tail so the tail paints against a known state; that clear
+// throws away the snapshot's rows, which are exactly what a full-screen program
+// drew and cannot be recovered from the ring (issue #123). A snapshot is the
+// whole of the stream up to fromSeq, so the tail replays on top of it.
+func (p *PTY) SubscribeFromSnapshot(clientID string, fromSeq int64) <-chan ptyChunk {
+	return p.subscribe(clientID, fromSeq, true)
+}
+
+func (p *PTY) subscribe(clientID string, fromSeq int64, fromSnapshot bool) <-chan ptyChunk {
 	p.subscribersMu.Lock()
 	defer p.subscribersMu.Unlock()
 
@@ -1623,6 +1646,18 @@ func (p *PTY) Subscribe(clientID string, fromSeq int64) <-chan ptyChunk {
 	rolled := fromSeq > 0 && fromSeq < bufStart
 	if fromSeq > bufStart {
 		start = min(int(fromSeq-bufStart), p.outputPos)
+	} else if rolled {
+		// The ring's first byte may be the tail of a chunk whose start has
+		// rolled out: handing that tail to a client that never saw the chunk
+		// writes it against cursor and mode state that never happened, and a
+		// full-screen program's rows come back one blank line apart (issue
+		// #123). Start at the first whole chunk inside the ring instead.
+		for _, m := range p.chunkMarks {
+			if m >= bufStart {
+				start = int(m - bufStart)
+				break
+			}
+		}
 	}
 	if n := p.outputPos - start; n > 0 {
 		debugLog("[DEBUG] PTY %s: sending %d buffered bytes to new subscriber", p.ID[:8], n)
@@ -1649,7 +1684,7 @@ func (p *PTY) Subscribe(clientID string, fromSeq int64) <-chan ptyChunk {
 			}
 		}
 		var prefix []byte
-		if rolled {
+		if rolled && !fromSnapshot {
 			// The client still holds the screen it drew up to fromSeq, and the
 			// bytes between there and the buffer's start are gone. Appending the
 			// tail to that screen splices two halves of the stream that never
@@ -1657,6 +1692,11 @@ func (p *PTY) Subscribe(clientID string, fromSeq int64) <-chan ptyChunk {
 			// tail is written against, so the guest's output lands wherever the
 			// old screen had left off. Clear first, so the tail repaints from a
 			// known state instead of over a stale one.
+			//
+			// A client that just restored a snapshot is not in that state: the
+			// snapshot is the whole of the stream up to fromSeq, and clearing
+			// it throws away rows a full-screen program drew that the ring no
+			// longer holds (issue #123). The tail replays on top of it.
 			prefix = resyncPrefix
 		}
 		segStart := start
@@ -2545,6 +2585,9 @@ func (p *PTY) vtWriter() {
 // appendToBuffer records a chunk in the catch-up buffer and returns the stream
 // position it ends at.
 func (p *PTY) appendToBuffer(data []byte) int64 {
+	// The position this chunk begins at, recorded before the stream advances
+	// so a rolled catch-up can pick a whole chunk as its starting point.
+	chunkStart := p.outputSeq
 	p.outputSeq += int64(len(data))
 	// Marks the ring has rolled past stop being split points, but the newest
 	// of them is still the width the ring's first byte was laid out at, so a
@@ -2552,6 +2595,15 @@ func (p *PTY) appendToBuffer(data []byte) int64 {
 	bufStart := p.outputSeq - int64(len(p.outputBuffer))
 	for len(p.resizeMarks) > 1 && p.resizeMarks[1].seq <= bufStart {
 		p.resizeMarks = p.resizeMarks[1:]
+	}
+	// Same roll for chunk marks: a mark behind the ring's first byte can
+	// never be a replay start again. The newest mark is kept only while the
+	// ring still holds its byte; a chunk bigger than the ring leaves none.
+	for len(p.chunkMarks) > 1 && p.chunkMarks[1] <= bufStart {
+		p.chunkMarks = p.chunkMarks[1:]
+	}
+	if chunkStart >= bufStart {
+		p.chunkMarks = append(p.chunkMarks, chunkStart)
 	}
 	bufLen := len(p.outputBuffer)
 	// If data is bigger than the buffer, keep only the tail

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -416,14 +416,6 @@ type PTY struct {
 	// the newest one behind the ring, which is the width the ring's first
 	// byte was laid out at.
 	resizeMarks []resizeMark
-	// chunkMarks are the stream positions each appended chunk began at,
-	// oldest first, kept while the ring still holds that byte. A rolled
-	// catch-up starts at the first chunk mark inside the ring rather than at
-	// the ring's raw start, so the replay never hands a client the tail of a
-	// chunk it never saw: that truncated tail is what painted a reattached
-	// full-screen program's rows out of step, one blank line between each
-	// line it drew (issue #123).
-	chunkMarks []int64
 
 	// Subscribers for raw output streaming.
 	subscribers   map[string]*ptySubscriber
@@ -1646,18 +1638,6 @@ func (p *PTY) subscribe(clientID string, fromSeq int64, fromSnapshot bool) <-cha
 	rolled := fromSeq > 0 && fromSeq < bufStart
 	if fromSeq > bufStart {
 		start = min(int(fromSeq-bufStart), p.outputPos)
-	} else if rolled {
-		// The ring's first byte may be the tail of a chunk whose start has
-		// rolled out: handing that tail to a client that never saw the chunk
-		// writes it against cursor and mode state that never happened, and a
-		// full-screen program's rows come back one blank line apart (issue
-		// #123). Start at the first whole chunk inside the ring instead.
-		for _, m := range p.chunkMarks {
-			if m >= bufStart {
-				start = int(m - bufStart)
-				break
-			}
-		}
 	}
 	if n := p.outputPos - start; n > 0 {
 		debugLog("[DEBUG] PTY %s: sending %d buffered bytes to new subscriber", p.ID[:8], n)
@@ -2313,15 +2293,15 @@ func styleToWire(s uv.Style, link uv.Link) StyleState {
 // styleFromWire is styleToWire read back into the emulator that will hold it.
 func styleFromWire(t vt.Terminal, ss StyleState) (uv.Style, uv.Link) {
 	return uv.Style{
-		Fg:             colorFromWire(t, ss.FgColor),
-		Bg:             colorFromWire(t, ss.BgColor),
-		UnderlineColor: colorFromWire(t, ss.UlColor),
-		Underline:      ansi.Underline(ss.Underline),
-		Attrs:          ss.Attrs,
-	}, uv.Link{
-		URL:    ss.LinkURL,
-		Params: ss.LinkParams,
-	}
+			Fg:             colorFromWire(t, ss.FgColor),
+			Bg:             colorFromWire(t, ss.BgColor),
+			UnderlineColor: colorFromWire(t, ss.UlColor),
+			Underline:      ansi.Underline(ss.Underline),
+			Attrs:          ss.Attrs,
+		}, uv.Link{
+			URL:    ss.LinkURL,
+			Params: ss.LinkParams,
+		}
 }
 
 // colorToWire encodes a cell color so the client gets back the kind of color the
@@ -2585,9 +2565,6 @@ func (p *PTY) vtWriter() {
 // appendToBuffer records a chunk in the catch-up buffer and returns the stream
 // position it ends at.
 func (p *PTY) appendToBuffer(data []byte) int64 {
-	// The position this chunk begins at, recorded before the stream advances
-	// so a rolled catch-up can pick a whole chunk as its starting point.
-	chunkStart := p.outputSeq
 	p.outputSeq += int64(len(data))
 	// Marks the ring has rolled past stop being split points, but the newest
 	// of them is still the width the ring's first byte was laid out at, so a
@@ -2595,15 +2572,6 @@ func (p *PTY) appendToBuffer(data []byte) int64 {
 	bufStart := p.outputSeq - int64(len(p.outputBuffer))
 	for len(p.resizeMarks) > 1 && p.resizeMarks[1].seq <= bufStart {
 		p.resizeMarks = p.resizeMarks[1:]
-	}
-	// Same roll for chunk marks: a mark behind the ring's first byte can
-	// never be a replay start again. The newest mark is kept only while the
-	// ring still holds its byte; a chunk bigger than the ring leaves none.
-	for len(p.chunkMarks) > 1 && p.chunkMarks[1] <= bufStart {
-		p.chunkMarks = p.chunkMarks[1:]
-	}
-	if chunkStart >= bufStart {
-		p.chunkMarks = append(p.chunkMarks, chunkStart)
 	}
 	bufLen := len(p.outputBuffer)
 	// If data is bigger than the buffer, keep only the tail

--- a/internal/session/tuiclient.go
+++ b/internal/session/tuiclient.go
@@ -573,12 +573,15 @@ func (c *TUIClient) ClosePTY(ptyID string) error {
 // The handler receives raw byte streams (MsgPTYOutput). fromSeq is the stream
 // position the caller's emulator has been restored to, so the daemon replays
 // only what came after it; zero leaves the resume position to the daemon.
-func (c *TUIClient) SubscribePTY(ptyID string, fromSeq int64, handler func([]byte)) error {
+// fromSnapshot tells the daemon the emulator was just laid down from an
+// authoritative snapshot ending at fromSeq, so a rolled catch-up must not
+// clear it (issue #123).
+func (c *TUIClient) SubscribePTY(ptyID string, fromSeq int64, fromSnapshot bool, handler func([]byte)) error {
 	c.ptyHandlersMu.Lock()
 	c.ptyHandlers[ptyID] = handler
 	c.ptyHandlersMu.Unlock()
 
-	msg, err := NewMessageWithCodec(MsgSubscribePTY, &SubscribePTYPayload{PTYID: ptyID, FromSeq: fromSeq}, c.codec)
+	msg, err := NewMessageWithCodec(MsgSubscribePTY, &SubscribePTYPayload{PTYID: ptyID, FromSeq: fromSeq, FromSnapshot: fromSnapshot}, c.codec)
 	if err != nil {
 		return err
 	}

--- a/internal/session/wire_snapshot_resync_test.go
+++ b/internal/session/wire_snapshot_resync_test.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestWireFromSnapshotSkipsTheResyncWhenRolled pins the production half of the
+// issue #123 fix: the FromSnapshot flag the app sends after restoring a
+// snapshot must reach the daemon and route the subscribe through
+// SubscribeFromSnapshot. With the flag set, a rolled catch-up (the ring has
+// moved past the client's position) must replay the tail without the resync
+// clear that would throw the restored snapshot away; without the flag, the
+// clear must still be there for a client resuming a screen it drew byte by
+// byte.
+//
+// The branch is what switches the fix on in production. Make
+// daemon_handlers.go's FromSnapshot branch unreachable, or make the app pass
+// false, and this test fails.
+func TestWireFromSnapshotSkipsTheResyncWhenRolled(t *testing.T) {
+	d, _ := startTestDaemon(t)
+	sess := makeSessionWithWindow(t, d, "wire-snapshot")
+	ptyID := sess.ListPTYIDs()[0]
+	pty := sess.GetPTY(ptyID)
+	client := attachTestClient(t, "wire-snapshot")
+
+	// Roll the ring well past any position the client could name, so any
+	// subscribe from a small fromSeq is a rolled catch-up.
+	pty.appendAndBroadcast(bytes.Repeat([]byte("x"), 96*1024))
+
+	// FromSnapshot=true: a client that just laid down a snapshot. The replay
+	// must not open with the resync clear.
+	var snap collector
+	if err := client.SubscribePTY(ptyID, 1, true, snap.add); err != nil {
+		t.Fatalf("subscribe with FromSnapshot: %v", err)
+	}
+	waitFor(t, "the snapshot replay to arrive", func() bool {
+		snap.mu.Lock()
+		defer snap.mu.Unlock()
+		return len(snap.buf) > 0
+	})
+	if got := snap.take(); bytes.HasPrefix(got, resyncPrefix) {
+		t.Errorf("a client that restored a snapshot was handed the resync clear (%d bytes): the FromSnapshot branch is not live", len(got))
+	}
+
+	client.UnsubscribePTY(ptyID)
+	waitFor(t, "the daemon to drop the subscription", func() bool {
+		pty.subscribersMu.RLock()
+		defer pty.subscribersMu.RUnlock()
+		return len(pty.subscribers) == 0
+	})
+
+	// FromSnapshot=false: the old contract for a client resuming a screen it
+	// drew itself. The rolled replay keeps its resync clear.
+	var plain collector
+	if err := client.SubscribePTY(ptyID, 1, false, plain.add); err != nil {
+		t.Fatalf("subscribe without FromSnapshot: %v", err)
+	}
+	waitFor(t, "the plain replay to arrive", func() bool {
+		plain.mu.Lock()
+		defer plain.mu.Unlock()
+		return len(plain.buf) > 0
+	})
+	if got := plain.take(); !bytes.HasPrefix(got, resyncPrefix) {
+		t.Errorf("a plain rolled resubscribe lost its resync clear (%d bytes)", len(got))
+	}
+}


### PR DESCRIPTION
## What this fixes

Closes #123 — after **detach and attach**, a full-screen program like `top` comes back with **empty lines between its output lines**, and stays that way even after quitting and rerunning it.

## Root cause

A reattaching client restores an **authoritative snapshot** of the pane (screen, scrollback, modes, pen, cursor) at stream position `fromSeq`, then subscribes from that position. Two things went wrong when the catch-up ring had rolled past `fromSeq`:

1. **The snapshot was cleared.** `Subscribe` opened a rolled catch-up with `resyncPrefix` (`ESC[H ESC[2J ESC[3J`). That clear exists for a client resuming a screen it drew *byte by byte* — but a client that just laid down a snapshot already holds the whole stream up to `fromSeq`, and the clear threw those rows away. The ring no longer holds them, so they were gone for good: the exact rows a full-screen program had drawn.

2. **The replay started mid-chunk.** The ring's first byte is often the tail of a chunk whose start has rolled out. Handing that tail to a client writes it against cursor and mode state that never happened, so the program's rows came back **one blank line apart** — the reported symptom — and kept repainting that way.

## The fix

**Daemon side** (`internal/session`):

- `SubscribeFromSnapshot`: a client that restored a snapshot keeps it. The rolled tail replays **on top** of it instead of clearing it.
- `chunkMarks`: the ring now remembers where each appended chunk began. A rolled catch-up starts at the **first whole chunk inside the ring**, so the replay never hands out a truncated tail.

**Protocol / client side** (`protocol.go`, `tuiclient.go`, `daemon_handlers.go`, `app/session.go`):

- `SubscribePTYPayload.FromSnapshot` marks a subscribe that follows a restored snapshot; the daemon routes it to `SubscribeFromSnapshot`.
- The app sets it in `subscribeToPTY` whenever it subscribes after restoring terminal state (`fromSeq > 0`).

## Verification

New regression tests in `internal/session/reattach_empty_lines_test.go` drive a top-like guest (alternate screen, repainting rows) through the exact restore-then-resume order:

| Test | Scenario |
|---|---|
| `TestReattachAfterTopDrewOnce` | quiescent draw, nothing to replay |
| `TestReattachWhileTopRedraws` | repaints during attach, live stream resumes |
| `TestReattachSnapshotWhileEmulatorBehind` | ring rolled past the snapshot (the bug's home) |
| `TestReattachThenQuitAltScreen` | quit the full-screen program after reattach |

Before the fix, the rolled case came back with the header rows missing and the process rows interleaved with blanks — the issue's screenshot. After, the client screen matches the daemon cell for cell.

Full suite: `go test ./internal/session/ ./internal/app/ ./...` — all green.
