### PR TITLE
test(layout): the popup guard on percent resize can now fail

### DIFF
--- a/internal/app/popup_test.go
+++ b/internal/app/popup_test.go
@@ -211,3 +211,32 @@ func TestAPopupRecentresWhenTheClientResizes(t *testing.T) {
 		t.Errorf("the popup runs off the narrowed screen: [%d,%d) of 60", popup.X, popup.X+popup.Width)
 	}
 }
+
+// TestAPopupIsNotSizedByPercent is the follow-up from the #140 merge: the
+// popup guard in the percentage setters (SetFocusedWindowWidthPercent and
+// SetFocusedWindowHeightPercent) had no test of its own, so removing w.IsPopup
+// from either setter left the whole suite green. A popup carries its own
+// percentage model (PopupWidth/PopupHeight) and applyPopupRects re-centres it
+// on the next tile, so a percent resize must leave the focused popup's box
+// exactly where it is.
+//
+// Negative control, confirmed red: drop the || w.IsPopup term from either
+// setter and the popup's box moves to the tiled percentage.
+func TestAPopupIsNotSizedByPercent(t *testing.T) {
+	m, popup := popupOS(t, "50%", "40%")
+	// The percentage setters drive the tiling resize path; the popup helpers
+	// leave the layout maps nil because their tests never resize.
+	m.AutoTiling = true
+	m.WorkspaceHasCustom = map[int]bool{}
+	m.WorkspaceLayouts = map[int][]WindowLayout{}
+	m.WorkspaceMasterRatio = map[int]float64{}
+	before := struct{ x, y, w, h int }{popup.X, popup.Y, popup.Width, popup.Height}
+
+	m.SetFocusedWindowWidthPercent(80)
+	m.SetFocusedWindowHeightPercent(80)
+
+	if popup.X != before.x || popup.Y != before.y || popup.Width != before.w || popup.Height != before.h {
+		t.Fatalf("percent resize moved the focused popup: box (%d,%d %dx%d) -> (%d,%d %dx%d)",
+			before.x, before.y, before.w, before.h, popup.X, popup.Y, popup.Width, popup.Height)
+	}
+}


### PR DESCRIPTION
Follow-up to the #140 merge ([304700dc](https://github.com/Gaurav-Gosain/tuios/commit/304700dc)): you noted there that removing `w.IsPopup` from the percentage setters left the whole suite green — the fix the review asked for was the one part nothing defended.

`TestAPopupIsNotSizedByPercent` (in `internal/app/popup_test.go`, the shape you pointed at) drives both `SetFocusedWindowWidthPercent` and `SetFocusedWindowHeightPercent` with the popup focused and asserts its box is untouched — popups carry their own percentage model (`PopupWidth`/`PopupHeight`) and `applyPopupRects` re-centres them on the next tile anyway.

**Negative control, confirmed red**: dropping the `|| w.IsPopup` term from either setter moves the popup's box from `(0,0 80x24)` to `(0,0 96x30)` and the test fails as an assertion (no panic).

Verified: `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean, full `internal/app` suite passes (212s).