### PR TITLE
docs(dock): put clock back in the printed default dock list

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,7 +21,7 @@ component:
 [dock]
 left   = ["mode", "workspaces", "trail", "tape"]
 center = ["windows"]
-right  = ["notifications", "copy-help", "cpu", "ram", "session-controls"]
+right  = ["notifications", "copy-help", "cpu", "ram", "clock", "session-controls"]
 
 [dock.clock]
 format = "15:04"

--- a/e2e/tui/dock_components_test.go
+++ b/e2e/tui/dock_components_test.go
@@ -44,7 +44,7 @@ func TestDockDefaultListsDrawTheSameBar(t *testing.T) {
 [dock]
 left   = ["mode", "workspaces", "trail", "tape"]
 center = ["windows"]
-right  = ["notifications", "copy-help", "cpu", "ram", "session-controls"]
+right  = ["notifications", "copy-help", "cpu", "ram", "clock", "session-controls"]
 `)
 	listed := startIn(t, base, startOpts{})
 	waitBoot(t, listed)

--- a/examples/dock/README.md
+++ b/examples/dock/README.md
@@ -26,7 +26,7 @@ refresh = "event:after-focus-change"
 [dock]
 left   = ["mode", "workspaces", "trail", "tape"]
 center = ["windows"]
-right  = ["notifications", "copy-help", "cpu", "ram", "session-controls"]
+right  = ["notifications", "copy-help", "cpu", "ram", "clock", "session-controls"]
 ```
 
 That is the default. Omit the whole `[dock]` table and you get exactly this;

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -114,7 +114,7 @@ func configFileHeader(configPath string) string {
 	sb.WriteString("#   [dock]\n")
 	sb.WriteString("#   left   = [\"mode\", \"workspaces\", \"trail\", \"tape\"]\n")
 	sb.WriteString("#   center = [\"windows\"]\n")
-	sb.WriteString("#   right  = [\"notifications\", \"copy-help\", \"cpu\", \"ram\", \"session-controls\"]\n")
+	sb.WriteString("#   right  = [\"notifications\", \"copy-help\", \"cpu\", \"ram\", \"clock\", \"session-controls\"]\n")
 	sb.WriteString("#\n")
 	sb.WriteString("# A cell of your own is a command whose first line of stdout is the text:\n")
 	sb.WriteString("#\n")


### PR DESCRIPTION
## What does this pull request do?

- Resolves: no issue, I didn't open one
- Description: puts `"clock"` back into the four places that print the default `[dock]` right-hand list, so they match `defaultDockRight`

---

## Motivation / Context

Bug fix, though a very small one. `ea4baab6` added `clock` to the default right list so `show_clock` had somewhere to draw it. The four places that print that list as a copyable starting point never got the extra name, so they all still show five names.

That matters a bit more than a docs typo normally would, beacuse `examples/dock/README.md` says "Omit the whole `[dock]` table and you get exactly this" and `docs/CONFIGURATION.md` says the same thing. Paste it, turn `show_clock` on, and no clock turns up anywhere. Membership is a gate and not jus an order, so there's no cell for the switch to act on. The copy in the generated `config.toml` header is the worst of the four, since thats the file someone is already sat in when they start moving components around.

---

## What has been changed

`"clock"` goes between `"ram"` and `"session-controls"` in `docs/CONFIGURATION.md`, `examples/dock/README.md`, the config header in `internal/config/save.go`, and the inline config in `TestDockDefaultListsDrawTheSameBar`.

That last one is in here because the test compares an explicitly written default plan against an omitted `[dock]` table, and the plan it wrote wasn't the default any more.

---

## How to verify this change

1. `go build -o tuios ./cmd/tuios`
2. `./tuios --show-clock` with no `[dock]` table in the config: clock sits between the RAM meter and the power button.
3. Same again with the documented list pasted into `~/.config/tuios/config.toml`: no clock, and nothing says why.

I did it through the e2e harness rather than by hand. With `--show-clock`, no table gives a dock row ending `1:1 ... 00:36:50 ` and the documented list gives `1:1 ... ` with the gap where the time was.

---

## Notes on compatibility / installation method

- Platform(s) tested: Linux x86_64, pure Go backend
- Installation method tested: `go build ./cmd/tuios` from source
- Version/commit used: `3e50e79`
- Any limitations or blockers: none I know of. It's text, there's no behaviour change in it.

---

## Negative controls

No test added, so there's nothing here to break. The fixture edit doesn't move what the test asserts in either direction: `show_clock` is off by default, so neither of its two runs draws a clock, and `TestDockDefaultListsDrawTheSameBar` passes the same before and after. `go test ./internal/config/` is green too.

- Wiring cut: n/a
- Test that failed: n/a

---

## Checklist

- [x] Code changes compile and tests pass
- [x] Added/Updated relevant documentation
- [ ] Tested across supported platforms and install methods (Linux x86_64 only)
- [ ] Added or updated tests (a fixture, not a test)
- [x] PR title follows format (e.g. `[BUG]`, `[FEATURE]`, etc.)

---

## Additional Context (optional)

One other thing from `ea4baab6` that I've left alone. `examples/dock/README.md` still says the clock format "drives the status badge that `show_clock` turns on", and since that commit `show_clock` is the dock cell, with the badge back to the recording and prefix light. The format does still feed both of them, so its only the second half of that sentence thats gone stale. I wasn't sure what you'd want it to read instead so I havent touched it.
