### PR TITLE
fix(clipboard): native fallback for loopback SSH and VTE hosts

### DIFF
--- a/internal/app/clipboard_copy.go
+++ b/internal/app/clipboard_copy.go
@@ -38,7 +38,7 @@ func (m *OS) CopyToClipboard(text string) tea.Cmd {
 	}
 	m.CancelPendingCopy()
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(text)
+	return m.clipboardWriteCmd(text)
 }
 
 // DeferCopyToClipboard holds text back until delay has passed with no further
@@ -79,9 +79,43 @@ func (m *OS) HandlePendingCopy(seq uint64) tea.Cmd {
 	text := m.pendingCopy
 	m.pendingCopy = ""
 	m.ShowNotification(fmt.Sprintf("Copied %d chars", len(text)), "success", m.Settings.NotificationDuration)
-	return tea.SetClipboard(text)
+	return m.clipboardWriteCmd(text)
 }
 
 // PendingCopyText reports the text a deferred write is holding, for tests and
 // for anything that needs to know a gesture has not settled yet.
 func (m *OS) PendingCopyText() string { return m.pendingCopy }
+
+// nativeClipboardAllowed reports whether this client may touch the machine's
+// own clipboard. A plain local TUI and a loopback SSH session are the same
+// person at this box; a remote SSH peer or a browser tab are not, and their
+// clipboard lives elsewhere (OSC 52 is how it is reached). See
+// clipboard_local.go.
+func (m *OS) nativeClipboardAllowed() bool {
+	// RemoteClient is the canonical "the human is not at this machine" flag in
+	// the ClientKind model. A loopback SSH session is the exception: it is the
+	// same person on the same box, so the native clipboard is still theirs.
+	if m.RemoteClient && !m.SSHIsLoopback {
+		return false
+	}
+	return ShouldUseNativeClipboard(m.SSHIsLoopback)
+}
+
+// clipboardWriteCmd writes text with the native tool when one applies, and
+// still returns the OSC 52 write. The double write is idempotent (same text):
+// OSC 52 is harmless where the native write already happened and is the only
+// path where the terminal carries it. VTE terminals (GNOME Terminal, Ptyxis)
+// never answer OSC 52, so the native write is what makes copy work there.
+func (m *OS) clipboardWriteCmd(text string) tea.Cmd {
+	set := tea.SetClipboard(text) // the Cmd that yields the OSC 52 write
+	return func() tea.Msg {
+		if m.nativeClipboardAllowed() {
+			if tool := DetectClipboardTool(); tool != nil {
+				// Best-effort: a failed native write still leaves the OSC 52
+				// message below as the safety net.
+				_ = tool.Write(text)
+			}
+		}
+		return set()
+	}
+}

--- a/internal/app/clipboard_local.go
+++ b/internal/app/clipboard_local.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Native system clipboard fallback.
+//
+// TUIOS normally reaches the clipboard through OSC 52, which asks the user's
+// terminal to carry the text. Terminals built on VTE (GNOME Terminal, Ptyxis)
+// never implement it, so copy and paste silently fail there. When this process
+// can reach a native clipboard tool (wl-clipboard on Wayland, xclip or xsel on
+// X11, pbcopy/pbpaste on macOS), tuios talks to the system clipboard directly
+// instead, and OSC 52 stays the path for a client whose clipboard lives
+// somewhere else.
+//
+// Where the clipboard lives decides who may touch it. A plain local TUI is the
+// person at this box. A loopback SSH session is the same person on the same
+// box, so the server's native clipboard is still theirs. A remote SSH peer or
+// a browser tab is someone else, whose clipboard this process must not reach;
+// OSC 52 is how their terminal carries it.
+
+type clipboardTool struct {
+	name     string
+	copyCmd  []string
+	pasteCmd []string
+}
+
+// detectClipboardToolEnv is the environment a clipboard decision is made from.
+// Both fields are injectable so the whole decision table becomes a plain test
+// with no compositor and no host environment leaking in.
+type detectClipboardToolEnv struct {
+	getenv   func(string) string
+	lookPath func(string) bool
+}
+
+// DetectClipboardTool finds a native clipboard tool for this session, or nil
+// when none is reachable (a headless box, or no helper installed). Detection
+// order is Wayland, then X11, then macOS.
+func DetectClipboardTool() *clipboardTool {
+	return detectClipboardTool(detectClipboardToolEnv{
+		getenv:   os.Getenv,
+		lookPath: hasExecutable,
+	})
+}
+
+func hasExecutable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func detectClipboardTool(env detectClipboardToolEnv) *clipboardTool {
+	getenv, lp := env.getenv, env.lookPath
+	// Wayland: the runtime dir and the display socket both have to be named
+	// for the tool to reach the compositor, so a tool on PATH with neither is
+	// not a usable route.
+	if getenv("XDG_RUNTIME_DIR") != "" && getenv("WAYLAND_DISPLAY") != "" {
+		if lp("wl-copy") && lp("wl-paste") {
+			return &clipboardTool{
+				name:     "wl-clipboard",
+				copyCmd:  []string{"wl-copy"},
+				pasteCmd: []string{"wl-paste", "-n"},
+			}
+		}
+	}
+	if getenv("DISPLAY") != "" {
+		if lp("xclip") {
+			return &clipboardTool{
+				name:     "xclip",
+				copyCmd:  []string{"xclip", "-selection", "clipboard"},
+				pasteCmd: []string{"xclip", "-selection", "clipboard", "-o"},
+			}
+		}
+		if lp("xsel") {
+			return &clipboardTool{
+				name:     "xsel",
+				copyCmd:  []string{"xsel", "--clipboard", "--input"},
+				pasteCmd: []string{"xsel", "--clipboard", "--output"},
+			}
+		}
+	}
+	if lp("pbcopy") && lp("pbpaste") {
+		return &clipboardTool{
+			name:     "pbcopy/pbpaste",
+			copyCmd:  []string{"pbcopy"},
+			pasteCmd: []string{"pbpaste"},
+		}
+	}
+	return nil
+}
+
+// Write sends text to the native clipboard. The tool owns the data: wl-copy
+// forks a keeper that holds the selection until it is replaced, which is the
+// semantics wanted, so the write is started and reaped in the background
+// rather than waited on (waiting would block until the selection changes).
+func (t *clipboardTool) Write(text string) error {
+	cmd := exec.Command(t.copyCmd[0], t.copyCmd[1:]...)
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait() // reap the keeper so it does not linger as a zombie
+	return nil
+}
+
+// nativePasteTimeout bounds a native clipboard read. A hung xclip (the X
+// server gone, a stalled selection) would otherwise leave the paste pending
+// forever; on timeout the read fails and the caller reports that nothing came
+// back rather than pretending an empty paste succeeded.
+const nativePasteTimeout = 2 * time.Second
+
+// Read returns the current native clipboard contents.
+func (t *clipboardTool) Read() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), nativePasteTimeout)
+	defer cancel()
+	// wl-paste -n suppresses the trailing newline it otherwise adds; xclip -o
+	// and pbpaste do not add one, so a selection that genuinely ends in a
+	// newline keeps it.
+	out, err := exec.CommandContext(ctx, t.pasteCmd[0], t.pasteCmd[1:]...).Output()
+	return string(out), err
+}
+
+// hostTerminalIsVTE reports whether the outer terminal is VTE-based. VTE is the
+// family that never answers OSC 52, so it is where the native route earns its
+// keep; on a terminal that does answer, OSC 52 already works and spawning a
+// helper would only add a duplicate clipboard-manager entry per selection.
+func hostTerminalIsVTE() bool {
+	return os.Getenv("VTE_VERSION") != ""
+}
+
+// ShouldUseNativeClipboard is the single decision point for the fallback. It is
+// true only when a native tool is reachable AND the human is either at a VTE
+// terminal on this box or on a loopback SSH session, which is the same person
+// whose clipboard is this machine's.
+func ShouldUseNativeClipboard(loopback bool) bool {
+	return shouldUseNativeClipboard(detectClipboardToolEnv{
+		getenv:   os.Getenv,
+		lookPath: hasExecutable,
+	}, hostTerminalIsVTE(), loopback)
+}
+
+func shouldUseNativeClipboard(env detectClipboardToolEnv, hostIsVTE, loopback bool) bool {
+	// A loopback SSH session is the same human on the same box: the server
+	// process cannot see the client's VTE_VERSION, but the native clipboard is
+	// still theirs, so a loopback session is treated as VTE-hosted here.
+	if !hostIsVTE && !loopback {
+		return false
+	}
+	return detectClipboardTool(env) != nil
+}

--- a/internal/app/clipboard_local_test.go
+++ b/internal/app/clipboard_local_test.go
@@ -1,0 +1,78 @@
+package app
+
+import "testing"
+
+// detectEnv builds an injectable environment: getenv answers from vars, and a
+// tool is "installed" when its name is in tools.
+func detectEnv(vars map[string]string, tools ...string) detectClipboardToolEnv {
+	have := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		have[t] = true
+	}
+	return detectClipboardToolEnv{
+		getenv:   func(k string) string { return vars[k] },
+		lookPath: func(name string) bool { return have[name] },
+	}
+}
+
+func TestDetectClipboardTool(t *testing.T) {
+	wayland := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
+	x11 := map[string]string{"DISPLAY": ":0"}
+
+	cases := []struct {
+		name string
+		env  detectClipboardToolEnv
+		want string // "" means no tool
+	}{
+		{"wayland names wl-clipboard", detectEnv(wayland, "wl-copy", "wl-paste"), "wl-clipboard"},
+		{"wayland needs both wl tools", detectEnv(wayland, "wl-copy"), ""},
+		{"wayland without a runtime dir is not a route", detectEnv(map[string]string{"WAYLAND_DISPLAY": "wayland-0"}, "wl-copy", "wl-paste"), ""},
+		{"wayland with no helper falls through to x11", detectEnv(map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0", "DISPLAY": ":0"}, "xclip"), "xclip"},
+		{"x11 names xclip", detectEnv(x11, "xclip"), "xclip"},
+		{"x11 names xsel when xclip is absent", detectEnv(x11, "xsel"), "xsel"},
+		{"xclip wins over xsel", detectEnv(x11, "xclip", "xsel"), "xclip"},
+		{"macos names pbcopy", detectEnv(map[string]string{}, "pbcopy", "pbpaste"), "pbcopy/pbpaste"},
+		{"pbpaste without pbcopy is not a route", detectEnv(map[string]string{}, "pbpaste"), ""},
+		{"nothing reachable", detectEnv(map[string]string{}), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectClipboardTool(tc.env)
+			gotName := ""
+			if got != nil {
+				gotName = got.name
+			}
+			if gotName != tc.want {
+				t.Fatalf("detectClipboardTool = %q, want %q", gotName, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldUseNativeClipboard(t *testing.T) {
+	wayland := map[string]string{"XDG_RUNTIME_DIR": "/run/user/1000", "WAYLAND_DISPLAY": "wayland-0"}
+
+	cases := []struct {
+		name     string
+		env      detectClipboardToolEnv
+		hostVTE  bool
+		loopback bool
+		want     bool
+	}{
+		{"a VTE host on a box with a tool uses the native path", detectEnv(wayland, "wl-copy", "wl-paste"), true, false, true},
+		{"a loopback SSH session counts even without VTE detection", detectEnv(wayland, "wl-copy", "wl-paste"), false, true, true},
+		{"a plain local non-VTE terminal keeps OSC 52", detectEnv(wayland, "wl-copy", "wl-paste"), false, false, false},
+		{"VTE but no tool falls back to OSC 52", detectEnv(wayland), true, false, false},
+		{"loopback but no tool falls back to OSC 52", detectEnv(wayland), false, true, false},
+		{"neither VTE nor loopback, even with a tool, is refused", detectEnv(wayland, "wl-copy", "wl-paste"), false, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldUseNativeClipboard(tc.env, tc.hostVTE, tc.loopback); got != tc.want {
+				t.Fatalf("shouldUseNativeClipboard(vte=%v, loopback=%v) = %v, want %v", tc.hostVTE, tc.loopback, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/clipboard_paste.go
+++ b/internal/app/clipboard_paste.go
@@ -49,6 +49,26 @@ func (m *OS) RequestHostPaste() tea.Cmd {
 	m.pasteSeq++
 	m.pastePending = true
 	seq := m.pasteSeq
+
+	// A terminal that never answers the OSC 52 read is asked natively instead,
+	// when the human is at this machine (a local VTE terminal, or a loopback
+	// SSH session). The reply is a tea.ClipboardMsg, so it lands in the same
+	// handler the OSC 52 answer does. See clipboard_local.go.
+	if m.nativeClipboardAllowed() {
+		if tool := DetectClipboardTool(); tool != nil {
+			return tea.Batch(
+				func() tea.Msg {
+					text, err := tool.Read()
+					if err != nil {
+						return PasteTimeoutMsg{Seq: seq}
+					}
+					return tea.ClipboardMsg{Content: text, Selection: 'c'}
+				},
+				tea.Tick(hostPasteTimeout, func(time.Time) tea.Msg { return PasteTimeoutMsg{Seq: seq} }),
+			)
+		}
+	}
+
 	return tea.Batch(
 		tea.ReadClipboard,
 		tea.Tick(hostPasteTimeout, func(time.Time) tea.Msg { return PasteTimeoutMsg{Seq: seq} }),

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -69,6 +69,11 @@ type OSOptions struct {
 	// IsSSHMode indicates this is an SSH session.
 	IsSSHMode bool
 
+	// SSHIsLoopback marks an SSH session that arrived over loopback (the
+	// same machine), so its native clipboard is the operator's. See
+	// OS.SSHIsLoopback.
+	SSHIsLoopback bool
+
 	// SSHSession is the SSH session reference (nil in local mode).
 	SSHSession ssh.Session
 
@@ -177,6 +182,7 @@ func NewOS(opts OSOptions) *OS {
 		IsDaemonSession: opts.IsDaemonSession,
 		IsSSHMode:       opts.IsSSHMode,
 		SSHSession:      opts.SSHSession,
+		SSHIsLoopback:   opts.SSHIsLoopback,
 		TouchClient:     opts.TouchClient,
 		RemoteClient:    opts.RemoteClient,
 		Caps:            caps,

--- a/internal/app/os.go
+++ b/internal/app/os.go
@@ -458,6 +458,10 @@ type OS struct {
 	// code reads and what the tests set. See ClientKind.
 	Client    ClientKind
 	IsSSHMode bool // True when running over SSH
+	// SSHIsLoopback is true when an SSH session arrived over loopback (the
+	// same machine). The human is at this box, so the native clipboard is
+	// theirs and the local fallback is safe; a remote SSH peer is not.
+	SSHIsLoopback bool
 	// Daemon mode fields
 	IsDaemonSession bool               // True when running as part of a persistent daemon session
 	DaemonClient    *session.TUIClient // Client for daemon communication (nil in local mode)

--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -432,6 +432,7 @@ func createEphemeralTUIOSInstance(sshSession ssh.Session, graphicsOut io.Writer,
 		Width:           width,
 		Height:          height,
 		SSHSession:      sshSession,
+		SSHIsLoopback:   isLoopbackAddr(sshSession.RemoteAddr()),
 		// Route kitty/sixel APC sequences to the SSH session so they reach the
 		// client's terminal, via the serialized writer shared with the
 		// bubbletea renderer so graphics and text writes never interleave on
@@ -512,6 +513,7 @@ func createDaemonTUIOSInstance(sshSession ssh.Session, graphicsOut io.Writer, se
 		Width:           width,
 		Height:          height,
 		SSHSession:      sshSession,
+		SSHIsLoopback:   isLoopbackAddr(sshSession.RemoteAddr()),
 		IsDaemonSession: true,
 		DaemonClient:    client,
 		SessionName:     sessionName,
@@ -533,3 +535,21 @@ func createDaemonTUIOSInstance(sshSession ssh.Session, graphicsOut io.Writer, se
 
 // Window is an alias for terminal.Window for use in this package
 type Window = terminal.Window
+
+// isLoopbackAddr reports whether an SSH connection arrived from the same
+// machine (127.0.0.1, ::1, or a unix socket with no port). The native clipboard
+// fallback is only safe for such sessions: the operator's clipboard IS the
+// server's. A remote SSH peer's clipboard lives elsewhere, so it keeps the
+// OSC 52 path.
+func isLoopbackAddr(addr net.Addr) bool {
+	if addr == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		// No host:port to split means a unix socket, which is always local.
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/server/ssh_loopback_test.go
+++ b/internal/server/ssh_loopback_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net"
+	"testing"
+)
+
+// The native clipboard fallback is only safe for a session that arrived from
+// this machine, so this predicate is what keeps a remote peer's clipboard out
+// of reach. See isLoopbackAddr.
+func TestIsLoopbackAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{"v4 loopback", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 41234}, true},
+		{"v6 loopback", &net.TCPAddr{IP: net.ParseIP("::1"), Port: 41234}, true},
+		{"a remote peer", &net.TCPAddr{IP: net.ParseIP("10.0.0.5"), Port: 41234}, false},
+		{"a link-local peer is not loopback", &net.TCPAddr{IP: net.ParseIP("169.254.1.1"), Port: 41234}, false},
+		{"nil is not loopback", nil, false},
+		{"a unix socket has no port to split, so it is local", &net.UnixAddr{Name: "/run/user/1000/tuios.sock", Net: "unix"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLoopbackAddr(tc.addr); got != tc.want {
+				t.Fatalf("isLoopbackAddr(%v) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Text copy/paste goes through OSC 52, which VTE-based terminals (GNOME Terminal, Ptyxis) never answer, so copy and paste silently fail there. When this process can reach a native clipboard tool (wl-clipboard on Wayland, xclip/xsel on X11, pbcopy/pbpaste on macOS), this talks to the system clipboard directly and keeps OSC 52 as the path for a client whose clipboard lives elsewhere.

Where the clipboard lives decides who may touch it. A loopback SSH session is the same person on the same box, so the server's native clipboard is theirs; a remote SSH peer or a browser tab keeps OSC 52, whose clipboard is somewhere else.

Ported onto the ClientKind model (the canonical `RemoteClient` flag):

- `clipboard_local.go`: tool detection + a testable decision table
- `clipboard_copy.go`: native write plus the OSC 52 write as the safety net
- `clipboard_paste.go`: native read delivered as a `tea.ClipboardMsg`
- `os.go` / `factory.go` / `ssh.go`: `SSHIsLoopback`, set from `RemoteAddr()`

Tests: a decision-table test for tool detection and for the native-fallback decision, plus an `isLoopbackAddr` test. `go build ./...`, `go vet`, and the app/config/input/server suites are green.