### PR TITLE
feat(input): appearance.right_click_opens_menu, a plain right-click opens the pane menu

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -391,6 +391,7 @@ func (m *OS) settingsCategories() []settingsCategory {
 			opt("appearance.click_to_type"),
 			opt("appearance.auto_enter_terminal_on_focus"),
 			opt("appearance.alt_drag"),
+			opt("appearance.right_click_opens_menu"),
 			opt("appearance.niri_reverse_scroll"),
 			custom("appearance.max_fps", m.maxFPSItem()),
 			opt("appearance.preferred_shell"),

--- a/internal/app/settings_registry.go
+++ b/internal/app/settings_registry.go
@@ -65,6 +65,7 @@ var settingLabels = map[string]string{
 	"appearance.confirm_quit":           "Confirm quit",
 	"appearance.session_colors":         "Session colors",
 	"appearance.links":                  "Links",
+	"appearance.right_click_opens_menu": "Right-click menu",
 	"appearance.dock_pill_caps":         "Pill caps",
 	"appearance.dock_workspace_tabs":    "Workspace tabs",
 	"appearance.dock_workspace_tooltip": "Workspace name on hover",

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -142,6 +142,11 @@ var optionSpecs = []Option{
 		Default:     "true",
 	},
 	{
+		Path: "appearance.right_click_opens_menu", Type: OptionBool, Section: "appearance",
+		Description: "A plain right-click on a pane in terminal mode opens the pane menu, for pasting without selecting first",
+		Default:     "false",
+	},
+	{
 		Path: "appearance.click_to_type", Type: OptionString, Section: "appearance",
 		Description: "What a click on a pane's content does in window-management mode",
 		Accepted:    ClickToTypeModes, Default: ClickToTypeSingle,

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -298,6 +298,18 @@ type Settings struct {
 	// Set via appearance.click_to_type config.
 	ClickToType string
 
+	// RightClickOpensMenu makes a plain right-click on a pane's content open the
+	// pane menu while the keyboard is typing in it, instead of reserving the
+	// unmodified right button.
+	//
+	// Off by default: a pointer reaches the menu with ctrl or shift held and a
+	// plain right-click is consumed, so the button stays with the pane. A touch
+	// client has no modifier and opens the menu with a long press regardless.
+	// Turning this on is how someone makes the menu's Paste row one plain click
+	// away, without selecting anything first.
+	// Set via appearance.right_click_opens_menu config.
+	RightClickOpensMenu bool
+
 	// WordCharacters lists the punctuation that counts as part of a word when a
 	// double-click selects one, on top of letters and digits, which always do.
 	//
@@ -435,6 +447,7 @@ func DefaultSettings() Settings {
 		FocusFollowsMouse:           false,
 		AltDrag:                     true,
 		ClickToType:                 ClickToTypeSingle,
+		RightClickOpensMenu:         false,
 		AutoEnterTerminalOnFocus:    AutoEnterTerminalOff,
 		WordCharacters:              `@-./_~?&=%+#`,
 		NiriReverseScroll:           false,

--- a/internal/config/userconfig.go
+++ b/internal/config/userconfig.go
@@ -171,6 +171,7 @@ type AppearanceConfig struct {
 	CopyOnSelect             *bool                   `toml:"copy_on_select"`               // Copy a mouse selection to the clipboard on release (default: true)
 	FocusFollowsMouse        *bool                   `toml:"focus_follows_mouse"`          // Focus the pane under the cursor as the mouse moves (default: false)
 	AltDrag                  *bool                   `toml:"alt_drag"`                     // Alt + left-drag moves a pane (default: true)
+	RightClickOpensMenu      *bool                   `toml:"right_click_opens_menu"`       // A plain right-click on a pane in terminal mode opens the pane menu (default: false)
 	AutoEnterTerminalOnFocus AutoEnterTerminalPolicy `toml:"auto_enter_terminal_on_focus"` // When a keyboard focus command should start typing in that pane: off, targeted, all (default: off)
 	ClickToType              string                  `toml:"click_to_type"`                // What a click on a pane's content does in window-management mode: single, double, off (default: single)
 	WordCharacters           *string                 `toml:"word_characters"`              // Punctuation that counts as part of a word for double-click selection (default: "@-./_~?&=%+#")
@@ -1475,6 +1476,12 @@ func ApplyAppearanceConfig(cfg *UserConfig, s *Settings) {
 	// survives the default being on.
 	if cfg.Appearance.AltDrag != nil {
 		s.AltDrag = *cfg.Appearance.AltDrag
+	}
+
+	// RightClickOpensMenu defaults to false. A pointer so an explicit true in
+	// the config is what turns the plain right-click into the pane menu.
+	if cfg.Appearance.RightClickOpensMenu != nil {
+		s.RightClickOpensMenu = *cfg.Appearance.RightClickOpensMenu
 	}
 
 	// AutoEnterTerminalOnFocus only takes one of its three values, so a typo

--- a/internal/input/contextmenu_test.go
+++ b/internal/input/contextmenu_test.go
@@ -194,6 +194,28 @@ func TestRightClickGesture(t *testing.T) {
 		}
 	})
 
+	t.Run("terminal mode plain right-click opens the menu when the option is on", func(t *testing.T) {
+		o := ctxOS(t)
+		o.Mode = app.TerminalMode
+		o.Settings.RightClickOpensMenu = true
+		o, _ = handleMouseClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseRight}, o)
+		if !o.ContextMenuActive() {
+			t.Fatal("a plain right-click in terminal mode did not open the pane menu")
+		}
+		if o.ContextMenu.Target != app.CtxTargetPane {
+			t.Errorf("menu target = %v, want the pane menu", o.ContextMenu.Target)
+		}
+		for _, it := range o.ContextMenu.Items {
+			if it.Action == "paste_clipboard" {
+				if it.Dim {
+					t.Error("paste is dimmed on the pane menu opened from terminal mode")
+				}
+				return
+			}
+		}
+		t.Error("the pane menu opened from terminal mode has no paste row")
+	})
+
 	t.Run("mouse-mode pane keeps the modifier requirement", func(t *testing.T) {
 		o := ctxOS(t)
 		em := vt.NewEmulator(58, 28)

--- a/internal/input/mouse_click.go
+++ b/internal/input/mouse_click.go
@@ -299,17 +299,20 @@ func handleMouseClick(msg tea.MouseClickMsg, o *app.OS) (*app.OS, tea.Cmd) {
 		}
 	}
 	// Terminal mode, plain right-click that was neither a selection menu nor
-	// forwarded to a mouse-mode app: consumed, so it cannot fall through and
-	// start a window resize underneath the user's shell.
+	// forwarded to a mouse-mode app.
+	//
+	// By default the unmodified right button belongs to the pane and this is
+	// consumed: a pointer reaches the menu with ctrl or shift held. A touch
+	// client has no such modifier, so a long press opens the menu there
+	// regardless. appearance.right_click_opens_menu turns the plain click into
+	// the menu for a pointer too, which is how someone puts the menu's Paste row
+	// one click away without selecting anything first. A pane whose app tracks
+	// the mouse never gets here (the forwarding above returns first), so that
+	// app keeps the right button either way. Consumed either way as well, so it
+	// cannot fall through and start a window resize underneath the user's shell.
 	if clickedWindowIndex != -1 && o.Mode == app.TerminalMode &&
 		msg.Button == tea.MouseRight && msg.Mod == 0 {
-		// A finger has no ctrl and no shift, so a long press is the only right
-		// click a phone can make, and dropping it here left the pane menu
-		// unreachable from the mode a user spends their time in. The menu is
-		// also the only finger-sized way to close, zoom or split a pane, since
-		// the title bar's own buttons are one row tall. A pointer keeps the old
-		// contract: it reaches the same menu with ctrl or shift held.
-		if o.TouchClient {
+		if o.TouchClient || o.Settings.RightClickOpensMenu {
 			o.OpenContextMenu(X, Y)
 		}
 		return o, nil

--- a/skills/tuios/SKILL.md
+++ b/skills/tuios/SKILL.md
@@ -1328,7 +1328,7 @@ like "make it look like X" usually means some of each:
 | **Spacing** | ground between panes, padding inside overlay panels | `appearance.gap`, `appearance.panel_padding` |
 | **Composition** | what a window title, a workspace tab and the clock carry | `window_title_format`, `dock_workspace_tab_format`, `clock_format` |
 
-The 128 options above are scalars, and spacing and composition are set with them
+The 129 options above are scalars, and spacing and composition are set with them
 like any other. Colour and shape are not: each is a name from an open set
 standing for a document kept in a directory rather than a value in the config
 file, which is why both have a verb of their own rather than a row in


### PR DESCRIPTION
In terminal mode a plain right-click (no modifier) is consumed for a pointer: the pane menu is reached with ctrl or shift held, and only a touch client opens it with a long press. That leaves a plain right-click doing nothing in the mode a user spends their time in -- and the menu's Paste row is the one thing a right-click is usually asked for.

This adds `appearance.right_click_opens_menu` (bool, default false). When on, a plain right-click on a pane in terminal mode opens the pane menu for a pointer too, putting its Paste row one click away without selecting first.

A pane whose app tracks the mouse is unaffected: the forwarding returns first, so that app keeps the right button (and the menu still needs ctrl/shift there). The click is consumed either way, so it cannot fall through and start a window resize underneath the shell.

- config: `appearance.right_click_opens_menu` (bool, default false)
- `settings.go`: `RightClickOpensMenu`, mapped from `AppearanceConfig`
- `mouse_click.go`: gate on the setting alongside `TouchClient`
- tests: a terminal-mode pointer opens the menu when the option is on

Default off, so the existing contract and its tests stand. `go build ./...`, `go vet`, and the config/input suites are green.