### PR TITLE
fix(vt): a scrollback line is decoded under its own lock

### DIFF
--- a/internal/vt/scrollback.go
+++ b/internal/vt/scrollback.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"image/color"
 	"reflect"
+	"sync"
 	"unicode/utf8"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -69,6 +70,11 @@ type Scrollback struct {
 	// mutation bumps gen, which empties it on the next read. It is capped at
 	// cacheCap entries so a walk of the whole ring cannot pin a decoded copy
 	// of it.
+	// cacheMu guards the cache map below. Line() is reachable from capture
+	// paths that hold only terminalMu's read lock, so two captures can decode
+	// and cache at once; without its own lock the map is written by both and
+	// the runtime aborts the whole daemon on the concurrent map access.
+	cacheMu  sync.Mutex
 	cache    map[int]uv.Line
 	cacheGen uint64
 	gen      uint64
@@ -422,6 +428,8 @@ func (sb *Scrollback) Line(index int) uv.Line {
 	if index < 0 || index >= sb.Len() {
 		return nil
 	}
+	sb.cacheMu.Lock()
+	defer sb.cacheMu.Unlock()
 	if sb.cacheGen != sb.gen || len(sb.cache) >= cacheCap {
 		clear(sb.cache)
 		sb.cacheGen = sb.gen

--- a/internal/vt/scrollback_concurrent_test.go
+++ b/internal/vt/scrollback_concurrent_test.go
@@ -1,0 +1,32 @@
+package vt
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestScrollbackConcurrentLine reproduce el race que tumbaba al daemon:
+// dos (o más) capturadores llamando Line() a la vez — como hacen dos
+// `wait-for window-output` solapados. Line() decodifica y cachea en el mapa
+// sb.cache; sin lock, dos lectores lo escriben a la vez y el runtime de Go
+// aborta el proceso con "concurrent map writes".
+//
+// Con el fix (cacheMu) corre limpio bajo -race.
+func TestScrollbackConcurrentLine(t *testing.T) {
+	sb := NewScrollback(10000)
+	for i := 0; i < 3000; i++ {
+		sb.PushBlankLine(80)
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < sb.Len(); i++ {
+				_ = sb.Line(i)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
A `wait-for window-output` capture reads a pane's scrollback. Two of them at once killed the daemon twice in three minutes, both stacks ending at `internal/vt/scrollback.go:429`.

## The crash

```
fatal error: concurrent map writes
  github.com/Gaurav-Gosain/tuios/internal/session.(*PTY).captureContent(...)   internal/session/session.go:2424
  github.com/Gaurav-Gosain/tuios/internal/session.(*PTY).CaptureContent(...)   internal/session/session.go:2389
  github.com/Gaurav-Gosain/tuios/internal/session.(*Daemon).waitWindowOutput.func1(...)   internal/session/verb_subscribe.go:473
  github.com/Gaurav-Gosain/tuios/internal/vt.(*Scrollback).Line(...)   internal/vt/scrollback.go:429
```

`captureContent` runs under `terminalMu`'s **read** lock, so two captures decode and cache at the same time. `Scrollback.Line` writes its decode cache (`sb.cache`) on every miss, so the map is written from both — and Go aborts the process on a concurrent map write. That is the whole daemon, every session on it.

The feeder (`vtWriter`) takes the write lock, so the race is **reader-vs-reader**, not with the feeder: no lock the capture path already holds can prevent it. The cache only needed its own.

## The fix

Give the cache its own `sync.Mutex`, held across the read-or-decode in `Line`.

## Testing

`internal/vt/scrollback_concurrent_test.go` drives eight goroutines through `Line` over a ring of 3000 lines.

- On the old code the race detector reports `WARNING: DATA RACE` at `Scrollback.Line` + `runtime.mapassign_fast64` — the same concurrent map access the daemon died on.
- On this commit it passes, and so do `go build ./...`, `go vet ./internal/vt/`, and the `internal/vt` suite.
